### PR TITLE
Fix compilation failure for ARM64

### DIFF
--- a/StereoKitC/systems/render_sort.cpp
+++ b/StereoKitC/systems/render_sort.cpp
@@ -87,7 +87,7 @@ void radix_sort7(render_item_t *a, size_t count)
 			size_t index = (value.sort_id >> shift) & RADIX_MASK;
 			*queue_ptrs[index]++ = value;
 #ifdef _WIN32
-#ifdef _M_ARM
+#if defined(_M_ARM) || defined(_M_ARM64)
 			__prefetch (queue_ptrs[index] + 1);
 #elif !defined(WINDOWS_UWP)
 			_m_prefetch(queue_ptrs[index] + 1);


### PR DESCRIPTION
Hello, this is my first commit here. Apologies if it's been already resolved somewhere else.

I'm using latest Visual Studio 2019 (16.11.3) , targeting ARM64. Compilation of `render_sort.cpp` fails.

The fix is to check for both macros `_M_ARM` and `_M_ARM64`. After that everything compiles successfully.

Thank you.

