### PR TITLE
Use calloc

### DIFF
--- a/StereoKitC/asset_types/texture.cpp
+++ b/StereoKitC/asset_types/texture.cpp
@@ -73,8 +73,8 @@ bool32_t tex_load_arr_files(asset_task_t *task, asset_header_t *asset, void *job
 	tex_load_t *data = (tex_load_t *)job_data;
 	tex_t       tex  = (tex_t)asset;
 
-	data->file_data  = sk_malloc_zero_t(void *, data->file_count);
-	data->file_sizes = sk_malloc_zero_t(size_t, data->file_count);
+	data->file_data  = sk_calloc_t(void *, data->file_count);
+	data->file_sizes = sk_calloc_t(size_t, data->file_count);
 
 	// Load all files
 	int32_t     width  = 0;
@@ -160,8 +160,8 @@ bool32_t tex_load_equirect_file(asset_task_t *task, asset_header_t *asset, void 
 	tex_load_t *data = (tex_load_t *)job_data;
 	tex_t       tex  = (tex_t)asset;
 
-	data->file_data  = sk_malloc_zero_t(void *, data->file_count);
-	data->file_sizes = sk_malloc_zero_t(size_t, data->file_count);
+	data->file_data  = sk_calloc_t(void *, data->file_count);
+	data->file_sizes = sk_calloc_t(size_t, data->file_count);
 
 	if (!platform_read_file(assets_file(data->file_names[0]), &data->file_data[0], &data->file_sizes[0])) {
 		log_warnf(tex_msg_load_failed, data->file_names[0]);
@@ -381,7 +381,7 @@ tex_t tex_create_file_type(const char *file, tex_type_ type, bool32_t srgb_data,
 	tex_set_id(result, file);
 	result->header.state = asset_state_loading;
 
-	tex_load_t *load_data = sk_malloc_zero_t(tex_load_t, 1);
+	tex_load_t *load_data = sk_calloc_t(tex_load_t, 1);
 	load_data->is_srgb       = srgb_data;
 	load_data->file_count    = 1;
 	load_data->file_names    = sk_malloc_t(char *, 1);
@@ -413,7 +413,7 @@ tex_t tex_create_file(const char *file, bool32_t srgb_data, int32_t priority) {
 tex_t tex_create_mem_type(tex_type_ type, void *data, size_t data_size, bool32_t srgb_data, int32_t priority) {
 	tex_t result = tex_create(type);
 
-	tex_load_t *load_data = sk_malloc_zero_t(tex_load_t, 1);
+	tex_load_t *load_data = sk_calloc_t(tex_load_t, 1);
 	load_data->is_srgb       = srgb_data;
 	load_data->file_count    = 1;
 	load_data->file_names    = sk_malloc_t(char *, 1);
@@ -516,7 +516,7 @@ tex_t _tex_create_file_arr(tex_type_ type, const char **files, int32_t file_coun
 	tex_set_id(result, file_id);
 	result->header.state = asset_state_loading;
 
-	tex_load_t *load_data = sk_malloc_zero_t(tex_load_t, 1);
+	tex_load_t *load_data = sk_calloc_t(tex_load_t, 1);
 	load_data->is_srgb    = srgb_data;
 	load_data->file_count = file_count;
 	load_data->file_names = sk_malloc_t(char *, file_count);
@@ -566,7 +566,7 @@ tex_t tex_create_cubemap_file(const char *equirectangular_file, bool32_t srgb_da
 	tex_set_id(result, equirect_id);
 	result->header.state = asset_state_loading;
 
-	tex_load_t *load_data = sk_malloc_zero_t(tex_load_t, 1);
+	tex_load_t *load_data = sk_calloc_t(tex_load_t, 1);
 	load_data->is_srgb       = srgb_data;
 	load_data->file_count    = 1;
 	load_data->file_names    = sk_malloc_t(char *, 1);

--- a/StereoKitC/sk_memory.cpp
+++ b/StereoKitC/sk_memory.cpp
@@ -18,13 +18,12 @@ void *sk_malloc(size_t bytes) {
 
 ///////////////////////////////////////////
 
-void *sk_malloc_zero(size_t bytes) {
-	void *result = malloc(bytes);
+void *sk_calloc(size_t bytes) {
+	void *result = calloc(bytes, 1);
 	if (result == nullptr && bytes > 0) {
 		fprintf(stderr, "Memory alloc failed!");
 		abort();
 	}
-	memset(result, 0, bytes);
 	return result;
 }
 

--- a/StereoKitC/sk_memory.h
+++ b/StereoKitC/sk_memory.h
@@ -6,11 +6,11 @@ namespace sk {
 
 // Safer memory allocation functions, will kill the app on failure.
 void *sk_malloc     (              size_t bytes);
-void *sk_malloc_zero(              size_t bytes);
+void *sk_calloc(              size_t bytes);
 void *sk_realloc    (void *memory, size_t bytes);
 
 #define sk_malloc_t(T, count) ((T*)sk_malloc ((count) * sizeof(T)))
-#define sk_malloc_zero_t(T, count) ((T*)sk_malloc_zero((count) * sizeof(T)))
+#define sk_calloc_t(T, count) ((T*)sk_calloc((count) * sizeof(T)))
 #define sk_realloc_t(T, memory, count) ((T*)sk_realloc(memory, (count) * sizeof(T)))
 
 } // namespace sk


### PR DESCRIPTION
Almost no actual changes, feel free to discard and do something yourself.

Also check out the macros [here](https://gitlab.freedesktop.org/monado/monado/-/blob/main/src/xrt/auxiliary/util/u_misc.h) to see macros to magically malloc/calloc something (or an array of something) with the right type.