### PR TITLE
Add libjsoncpp-dev to linux build instructions on BUILDING.md

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -44,7 +44,7 @@ bash <(curl -fsSL https://xmake.io/shget.text)
 
 # here's a few other pre-reqs, mostly pulled from OpenXR's build list:
 sudo apt-get update
-sudo apt-get install build-essential cmake unzip libfontconfig1-dev libgl1-mesa-dev libvulkan-dev libx11-xcb-dev libxcb-dri2-0-dev libxcb-glx0-dev libxcb-icccm4-dev libxcb-keysyms1-dev libxcb-randr0-dev libxrandr-dev libxxf86vm-dev mesa-common-dev
+sudo apt-get install build-essential cmake unzip libfontconfig1-dev libgl1-mesa-dev libvulkan-dev libx11-xcb-dev libxcb-dri2-0-dev libxcb-glx0-dev libxcb-icccm4-dev libxcb-keysyms1-dev libxcb-randr0-dev libxrandr-dev libxxf86vm-dev mesa-common-dev libjsoncpp-dev
 
 ### From StereoKit's root directory ###
 


### PR DESCRIPTION
In the Linux instructions contained in BUILDING.md it is not listed the **libjsoncpp-dev** dependency.  In this Pull Request I'm adding this dependency to the instructions on how to build StereoKit on Linux.