### PR TITLE
Include EGL header in linux.cpp

### DIFF
--- a/StereoKitC/platforms/linux.cpp
+++ b/StereoKitC/platforms/linux.cpp
@@ -21,6 +21,8 @@
 
 #if defined(SKG_LINUX_EGL)
 
+#include <EGL/egl.h>
+
 extern EGLDisplay egl_display;
 extern EGLContext egl_context;
 extern EGLConfig  egl_config;

--- a/StereoKitC/platforms/linux.cpp
+++ b/StereoKitC/platforms/linux.cpp
@@ -19,16 +19,6 @@
 #include "../libraries/sokol_time.h"
 #include "../libraries/unicode.h"
 
-#if defined(SKG_LINUX_EGL)
-
-#include <EGL/egl.h>
-
-extern EGLDisplay egl_display;
-extern EGLContext egl_context;
-extern EGLConfig  egl_config;
-
-#endif
-
 namespace sk {
 
 ///////////////////////////////////////////


### PR DESCRIPTION
Fixes these issues:

```
/run/media/nova/MEDIA/xr/stardust/stereokit-sys/StereoKit/StereoKitC/platforms/linux.cpp:24:8: error: ‘EGLDisplay’ does not name a type; did you mean ‘Display’?
     24 | extern EGLDisplay egl_display;
        |        ^~~~~~~~~~
        |        Display
  /run/media/nova/MEDIA/xr/stardust/stereokit-sys/StereoKit/StereoKitC/platforms/linux.cpp:25:8: error: ‘EGLContext’ does not name a type; did you mean ‘GLXContext’?
     25 | extern EGLContext egl_context;
        |        ^~~~~~~~~~
        |        GLXContext
  /run/media/nova/MEDIA/xr/stardust/stereokit-sys/StereoKit/StereoKitC/platforms/linux.cpp:26:8: error: ‘EGLConfig’ does not name a type; did you mean ‘GLXFBConfig’?
     26 | extern EGLConfig  egl_config;
        |        ^~~~~~~~~
        |        GLXFBConfig**
```