### PR TITLE
Header define for FFI that can remove unnecessary functions

### DIFF
--- a/StereoKitC/stereokit.h
+++ b/StereoKitC/stereokit.h
@@ -43,13 +43,9 @@ inline enumType  operator~ (const enumType& a)              { return static_cast
 #define SK_DeclarePrivateType(name) struct _ ## name; typedef struct _ ## name *name;
 
 #include <stdint.h>
-#ifdef SK_FFI
-#include <stddef.h>
-typedef __uint_least16_t char16_t;
-typedef __uint_least32_t char32_t;
-#else
-#include <math.h>
 #include <uchar.h>
+#ifdef __cplusplus
+#include <math.h>
 #endif
 
 #ifdef __cplusplus

--- a/StereoKitC/stereokit.h
+++ b/StereoKitC/stereokit.h
@@ -44,11 +44,9 @@ inline enumType  operator~ (const enumType& a)              { return static_cast
 
 #include <stdint.h>
 #include <uchar.h>
-#ifdef __cplusplus
-#include <math.h>
-#endif
 
 #ifdef __cplusplus
+#include <math.h> // For C++ math operator overloading
 namespace sk {
 #endif
 

--- a/StereoKitC/stereokit.h
+++ b/StereoKitC/stereokit.h
@@ -43,8 +43,14 @@ inline enumType  operator~ (const enumType& a)              { return static_cast
 #define SK_DeclarePrivateType(name) struct _ ## name; typedef struct _ ## name *name;
 
 #include <stdint.h>
+#ifdef SK_FFI
+#include <stddef.h>
+typedef __uint_least16_t char16_t;
+typedef __uint_least32_t char32_t;
+#else
 #include <math.h>
 #include <uchar.h>
+#endif
 
 #ifdef __cplusplus
 namespace sk {


### PR DESCRIPTION
I noticed rust had a ton of warnings due to functions being included in the header that were very unnecessary for ffi so I just added an #ifdef for SK_FFI to not include some headers and define char types