### PR TITLE
Fix for EGL crashing in XR mode on Linux

### DIFF
--- a/StereoKit/Native/NativeTypes.cs
+++ b/StereoKit/Native/NativeTypes.cs
@@ -66,6 +66,12 @@ namespace StereoKit
 		/// You don't want this, you can disable it with this setting!</summary>
 		public  bool disableFlatscreenMRSim { get { return _disableFlatscreenMRSim > 0; } set { _disableFlatscreenMRSim = value ? 1 : 0; } }
 		private int _disableFlatscreenMRSim;
+		/// <summary>By default, StereoKit will open a desktop window for
+		/// keyboard input due to lack of XR-native keyboard APIs on many
+		/// platforms. If you don't want this, you can disable it with
+		/// this setting!</summary>
+		public  bool disableDesktopInputWindow { get { return _disableFlatscreenMRSim > 0; } set { _disableFlatscreenMRSim = value ? 1 : 0; } }
+		private int _disableDesktopInputWindow;
 		/// <summary>By default, StereoKit will slow down when the
 		/// application is out of focus. This is useful for saving processing
 		/// power while the app is out-of-focus, but may not always be

--- a/StereoKit/Native/NativeTypes.cs
+++ b/StereoKit/Native/NativeTypes.cs
@@ -70,7 +70,7 @@ namespace StereoKit
 		/// keyboard input due to lack of XR-native keyboard APIs on many
 		/// platforms. If you don't want this, you can disable it with
 		/// this setting!</summary>
-		public  bool disableDesktopInputWindow { get { return _disableFlatscreenMRSim > 0; } set { _disableFlatscreenMRSim = value ? 1 : 0; } }
+		public  bool disableDesktopInputWindow { get { return _disableDesktopInputWindow > 0; } set { _disableDesktopInputWindow = value ? 1 : 0; } }
 		private int _disableDesktopInputWindow;
 		/// <summary>By default, StereoKit will slow down when the
 		/// application is out of focus. This is useful for saving processing

--- a/StereoKitC/platforms/linux.cpp
+++ b/StereoKitC/platforms/linux.cpp
@@ -425,7 +425,7 @@ bool linux_start_pre_xr() {
 
 bool linux_start_post_xr() {
 	#if defined(SKG_LINUX_EGL)
-	if (!sk_settings.disable_xr_window && !setup_x_window())
+	if (!sk_settings.disable_desktop_input_window && !setup_x_window())
 		return false;
 	#endif
 
@@ -510,7 +510,7 @@ void linux_shutdown() {
 
 void linux_step_begin_xr() {
   #if defined(SKG_LINUX_EGL)
-	if(!sk_settings.disable_xr_window)
+	if(!sk_settings.disable_desktop_input_window)
   #endif
 		linux_events();
 }

--- a/StereoKitC/platforms/linux.cpp
+++ b/StereoKitC/platforms/linux.cpp
@@ -518,7 +518,9 @@ void linux_shutdown() {
 ///////////////////////////////////////////
 
 void linux_step_begin_xr() {
+  #if !defined(SKG_LINUX_EGL)
 	linux_events();
+  #endif
 }
 
 ///////////////////////////////////////////

--- a/StereoKitC/platforms/linux.cpp
+++ b/StereoKitC/platforms/linux.cpp
@@ -386,16 +386,6 @@ bool setup_x_window() {
 
 ///////////////////////////////////////////
 
-#if defined(SKG_LINUX_EGL)
-
-bool setup_egl_flat() {
-	return true;
-}
-
-#endif
-
-///////////////////////////////////////////
-
 bool check_wayland() {
 	char* sess_type = getenv("XDG_SESSION_TYPE");
 	if (sess_type == NULL) {
@@ -417,11 +407,9 @@ bool linux_init() {
 
 	xwayland = check_wayland();
 
-	#if !defined(SKG_LINUX_EGL)
-
+	#if defined(SKG_LINUX_GLX)
 	if (!setup_x_window())
 		return false;
-
 	#endif
 
 	return true;
@@ -436,6 +424,11 @@ bool linux_start_pre_xr() {
 ///////////////////////////////////////////
 
 bool linux_start_post_xr() {
+	#if defined(SKG_LINUX_EGL)
+	if (!sk_settings.disable_xr_window && !setup_x_window())
+		return false;
+	#endif
+
 	return true;
 }
 
@@ -444,8 +437,6 @@ bool linux_start_post_xr() {
 bool linux_start_flat() {
 	#if defined(SKG_LINUX_EGL)
 	if (!setup_x_window())
-		return false;
-	if (!setup_egl_flat())
 		return false;
 	#endif
 	
@@ -518,9 +509,10 @@ void linux_shutdown() {
 ///////////////////////////////////////////
 
 void linux_step_begin_xr() {
-  #if !defined(SKG_LINUX_EGL)
-	linux_events();
+  #if defined(SKG_LINUX_EGL)
+	if(!sk_settings.disable_xr_window)
   #endif
+		linux_events();
 }
 
 ///////////////////////////////////////////

--- a/StereoKitC/platforms/linux.cpp
+++ b/StereoKitC/platforms/linux.cpp
@@ -510,9 +510,12 @@ void linux_shutdown() {
 
 void linux_step_begin_xr() {
   #if defined(SKG_LINUX_EGL)
-	if(!sk_settings.disable_desktop_input_window)
-  #endif
+	if(!sk_settings.disable_desktop_input_window) {
 		linux_events();
+	}
+  #else
+	linux_events();
+  #endif
 }
 
 ///////////////////////////////////////////

--- a/StereoKitC/stereokit.h
+++ b/StereoKitC/stereokit.h
@@ -291,6 +291,7 @@ typedef struct sk_settings_t {
 	int32_t        flatscreen_width;
 	int32_t        flatscreen_height;
 	bool32_t       disable_flatscreen_mr_sim;
+	bool32_t       disable_xr_window;
 	bool32_t       disable_unfocused_sleep;
 
 	void          *android_java_vm;  // JavaVM*

--- a/StereoKitC/stereokit.h
+++ b/StereoKitC/stereokit.h
@@ -291,7 +291,7 @@ typedef struct sk_settings_t {
 	int32_t        flatscreen_width;
 	int32_t        flatscreen_height;
 	bool32_t       disable_flatscreen_mr_sim;
-	bool32_t       disable_xr_window;
+	bool32_t       disable_desktop_input_window;
 	bool32_t       disable_unfocused_sleep;
 
 	void          *android_java_vm;  // JavaVM*


### PR DESCRIPTION
just don't start the x window in XR mode, EGL is useful because you don't need to make a window so standalone headsets can run XR apps