### PR TITLE
Relative and Delta Quaternion Math

### DIFF
--- a/Examples/StereoKitTest/Docs/DocQuat.cs
+++ b/Examples/StereoKitTest/Docs/DocQuat.cs
@@ -2,7 +2,21 @@
 
 class DocQuat : ITest
 {
-	public void Initialize() { }
+	Pose spherePose;
+	Quat sphereDelta;
+	Vec3 oldPalmPos;
+
+	Material matDev;
+
+	public void Initialize() 
+	{
+		spherePose = new Pose(-1,0,1, Quat.Identity);
+		sphereDelta = Quat.Identity;
+
+		matDev = Material.Default.Copy();
+		matDev.SetTexture("diffuse", Tex.DevTex);
+	}
+
 	public void Shutdown() { }
 
 	public void Update()
@@ -23,6 +37,21 @@ class DocQuat : ITest
 		Pose winPose = new Pose(0,0,-0.5f, Quat.LookDir(0,0,1));
 		UI.WindowBegin("Posed Window", ref winPose);
 		UI.WindowEnd();
+
+		/// :End:
+
+
+		/// :CodeSample: Quat.Delta
+		
+		// Draw a sphere that you can spin around with your right hand!
+		Vec3 palmPos = Input.Hand(1).palm.position - spherePose.position;
+		if (palmPos.Length < 0.3f)
+		{
+			sphereDelta = Quat.Delta(oldPalmPos.Normalized, palmPos.Normalized);
+		}
+		spherePose.orientation = sphereDelta * spherePose.orientation;
+		oldPalmPos = palmPos;
+		Mesh.Sphere.Draw(matDev, spherePose.ToMatrix(0.5f));
 
 		/// :End:
 	}

--- a/StereoKit/Math/Quat.cs
+++ b/StereoKit/Math/Quat.cs
@@ -167,32 +167,28 @@ namespace StereoKit
 		public static Quat Difference(Quat a, Quat b) 
 			=> NativeAPI.quat_difference(a, b);
 
-		/// <summary>Creates a quaternion that goes to one rotation from 
-		/// another. Just like when you are working with vectors: 
-		/// delta = to - from</summary>
-		/// <param name="to">The target rotation.</param>
-		/// <param name="from">And the origin rotation!</param>
-		/// <returns>Quaternion that goes to one rotation from another.
-		/// </returns>
+		/// <summary>Creates a quaternion that goes from one rotation to
+		/// another.</summary>
+		/// <param name="from">The origin rotation.</param>
+		/// <param name="to">And the target rotation!</param>
+		/// <returns>The quaternion between from and to.</returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static Quat Delta(Quat from, Quat to) 
 			=> NativeAPI.quat_difference(from, to);
 
-		/// <summary>Creates a rotation that goes to one direction from 
-		/// another. Just like when you are working with 
-		/// vectors: delta = to - from. Super handy when converting a 
-		/// relative position delta into a quaternion!</summary>
-		/// <param name="to">The target direction.</param>
-		/// <param name="from">And the origin direction!</param>
-		/// <returns>Quaternion that goes to one direction from another.
-		/// </returns>
+		/// <summary>Creates a rotation that goes from one direction to
+		/// another. Which is comes in handy when trying to roll
+		/// something around with position data.</summary> 
+		/// <param name="from">The origin direction.</param>
+		/// <param name="to">And the target direction!</param>
+		/// <returns>The quaternion between from and to.</returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static Quat Delta(Vec3 from, Vec3 to) {
 			Vec3 vec = Vec3.Cross(from, to);
 			return new Quat(vec.x, vec.y, vec.z, 1 + Vec3.Dot(from, to)).Normalized;
 		}
 
-		/// <summary>Rotates a quaternion making it relative to another 
+		/// <summary>Rotates a quaternion making it relative to another
 		/// rotation while preserving it's "Length"!</summary>
 		/// <param name="to">The relative quaternion.</param>
 		/// <returns>This quaternion made relative to another rotation.

--- a/StereoKit/Math/Quat.cs
+++ b/StereoKit/Math/Quat.cs
@@ -167,6 +167,39 @@ namespace StereoKit
 		public static Quat Difference(Quat a, Quat b) 
 			=> NativeAPI.quat_difference(a, b);
 
+		/// <summary>Creates a quaternion that goes to one rotation from 
+		/// another. Just like when you are working with vectors: 
+		/// delta = to - from</summary>
+		/// <param name="to">The target rotation.</param>
+		/// <param name="from">And the origin rotation!</param>
+		/// <returns>Quaternion that goes to one rotation from another.
+		/// </returns>
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static Quat Delta(Quat to, Quat from) 
+			=> NativeAPI.quat_difference(from, to);
+
+		/// <summary>Creates a rotation that goes to one direction from 
+		/// another. Just like when you are working with 
+		/// vectors: delta = to - from. Super handy when converting a 
+		/// relative position delta into a quaternion!</summary>
+		/// <param name="to">The target direction.</param>
+		/// <param name="from">And the origin direction!</param>
+		/// <returns>Quaternion that goes to one direction from another.
+		/// </returns>
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static Quat Delta(Vec3 to, Vec3 from) {
+			Vec3 vec = Vec3.Cross(to, from);
+			return new Quat(vec.x, vec.y, vec.z, 1 + Vec3.Dot(to, from)).Normalized;
+		}
+
+		/// <summary>Rotates a quaternion making it relative to another 
+		/// rotation while preserving it's "Length"!</summary>
+		/// <param name="to">The relative quaternion.</param>
+		/// <returns>This quaternion made relative to another rotation.
+		/// </returns>
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public Quat Relative(Quat to) => to * q * Quaternion.Inverse(to);
+
 		/// <summary>Creates a Roll/Pitch/Yaw rotation (applied in that
 		/// order) from the provided angles in degrees!</summary>
 		/// <param name="pitchXDeg">Pitch is rotation around the x axis,

--- a/StereoKit/Math/Quat.cs
+++ b/StereoKit/Math/Quat.cs
@@ -175,7 +175,7 @@ namespace StereoKit
 		/// <returns>Quaternion that goes to one rotation from another.
 		/// </returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Quat Delta(Quat to, Quat from) 
+		public static Quat Delta(Quat from, Quat to) 
 			=> NativeAPI.quat_difference(from, to);
 
 		/// <summary>Creates a rotation that goes to one direction from 
@@ -187,9 +187,9 @@ namespace StereoKit
 		/// <returns>Quaternion that goes to one direction from another.
 		/// </returns>
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public static Quat Delta(Vec3 to, Vec3 from) {
-			Vec3 vec = Vec3.Cross(to, from);
-			return new Quat(vec.x, vec.y, vec.z, 1 + Vec3.Dot(to, from)).Normalized;
+		public static Quat Delta(Vec3 from, Vec3 to) {
+			Vec3 vec = Vec3.Cross(from, to);
+			return new Quat(vec.x, vec.y, vec.z, 1 + Vec3.Dot(from, to)).Normalized;
 		}
 
 		/// <summary>Rotates a quaternion making it relative to another 


### PR DESCRIPTION
Quaternion methods and conventions I've found invaluable and would like to showcase as StereoKit functionality in my upcoming FOSSXR talk!

I would also like to Deprecate: Quat.Difference(a, b)
as it doesn't clearly communicate the "direction" of the resulting delta through its operator names and obfuscates the underlying math of (delta = to - from)