### PR TITLE
Multimaterial skinned meshes

### DIFF
--- a/StereoKitC/asset_types/model_gltf.cpp
+++ b/StereoKitC/asset_types/model_gltf.cpp
@@ -880,6 +880,7 @@ bool modelfmt_gltf(model_t model, const char *filename, void *file_data, size_t 
 	for (size_t i = 0; i < data->nodes_count; i++) {
 		if (data->nodes[i].skin == nullptr) continue;
 		cgltf_skin *skin = data->nodes[i].skin;
+    cgltf_node *node = &data->nodes[i];
 
     // Each GLTF skin node has an sk_mesh node for each of its primitives.
     for (cgltf_size p = 0; node->mesh && p < node->mesh->primitives_count; p++) {


### PR DESCRIPTION
In multimaterial skinned meshes, the GLTF skin node has multiple primitives.

This solution feels kinda hack-y, maybe the `node_map` should be replaced with a `hashmap_t<cgltf_node*, hashmap_t<cgltf_size, model_node_id>>`, since GLTF nodes with multiple primitives correspond to multiple `sk_mesh` nodes? (Not sure how to free that nicely, though). 

If a GLTF skin node has a mesh primitive that fails to parse, this code will fail since the offset will be wrong (although I think the code would fail before too, if a skin's mesh failed to parse)

I can refactor or this can just serve as reference!