### PR TITLE
Feature/mesh generate circle

### DIFF
--- a/Examples/StereoKitTest/Demos/DemoGeo.cs
+++ b/Examples/StereoKitTest/Demos/DemoGeo.cs
@@ -1,4 +1,4 @@
-﻿using StereoKit;
+using StereoKit;
 
 class DemoGeo : ITest
 {
@@ -15,6 +15,8 @@ class DemoGeo : ITest
 	Model demoCylinderModel = null;
 	Mesh  demoPlaneMesh  = null;
 	Model demoPlaneModel = null;
+	Mesh  demoCircleMesh = null;
+	Model demoCircleModel = null;
 
 	Mesh  demoProcMesh = null;
 
@@ -89,6 +91,20 @@ class DemoGeo : ITest
 		demoPlaneMesh  = planeMesh;
 		demoPlaneModel = planeModel;
 
+		/// :CodeSample: Mesh.GenerateCircle
+		/// ### Generating a Mesh and Model
+		/// 
+		/// ![Procedural Geometry Demo]({{site.url}}/img/screenshots/ProceduralGeometry.jpg)
+		/// 
+		/// Here's a quick example of generating a mesh! You can store it in just a
+		/// Mesh, or you can attach it to a Model for easier rendering later on.
+		// Do this in your initialization
+		Mesh  circleMesh  = Mesh.GenerateCircle(0.4f);
+		Model circleModel = Model.FromMesh(circleMesh, Default.Material);
+		/// :End:
+		demoCircleMesh  = circleMesh;
+		demoCircleModel = circleModel;
+
 		/// :CodeSample: Mesh.SetVerts Mesh.SetInds Mesh.SetData
 		/// ### Procedurally generating a wavy grid
 		/// 
@@ -156,8 +172,24 @@ class DemoGeo : ITest
 	{
 		Hierarchy.Push(Matrix.TRS(V.XYZ(0.5f, -0.25f, -0.5f), Quat.LookDir(-1,0,1), 0.2f));
 
-		Tests.Screenshot("ProceduralGeometry.jpg", 600, 600, V.XYZ(0.3f, -0.25f, -0.3f), V.XYZ(0.5f, -0.25f, -0.5f));
+		Tests.Screenshot("ProceduralGeometry.jpg", 600, 600, V.XYZ(0.29f, -0.29f, -0.29f), V.XYZ(0.5f, -0.29f, -0.5f));
 		Tests.Screenshot("ProceduralGrid.jpg",     600, 600, Hierarchy.ToWorld(V.X0Z(-2, -0.7f)), Hierarchy.ToWorld(V.X0Z(-2, 0)));
+
+		// Circle!
+		Mesh  circleMesh = demoCircleMesh;
+		Model circleModel = demoCircleModel;
+
+		/// :CodeSample: Mesh.GenerateCircle
+		/// Drawing both a Mesh and a Model generated this way is reasonably simple, 
+		/// here's a short example! For the Mesh, you'll need to create your own material, 
+		/// we just loaded up the default Material here.
+		Matrix circleTransform = Matrix.T(-.5f, -1.5f, 0);
+		circleMesh.Draw(Default.Material, circleTransform);
+
+		circleTransform = Matrix.T(.5f, -1.5f, 0);
+		circleModel.Draw(circleTransform);
+		/// :End:
+
 
 		// Plane!
 		Mesh  planeMesh  = demoPlaneMesh;

--- a/Examples/StereoKitTest/Tests/TestProceduralGeo.cs
+++ b/Examples/StereoKitTest/Tests/TestProceduralGeo.cs
@@ -7,6 +7,7 @@ class TestProceduralGeo : ITest
 	Mesh meshSphere      = null;
 	Mesh meshCylinder    = null;
 	Mesh meshPlane       = null;
+	Mesh meshCircle      = null;
 
 	Material material;
 	Material materialWire;
@@ -33,29 +34,36 @@ class TestProceduralGeo : ITest
 		/// ### UV and Face layout
 		/// Here's a test image that illustrates how this mesh's geometry is
 		/// laid out.
-		/// ![Procedural Cube Mesh]({{site.screen_url}}/ProcGeoRoundedCube.jpg)
+		/// ![Procedural Rounded Cube Mesh]({{site.screen_url}}/ProcGeoRoundedCube.jpg)
 		meshRoundedCube = Mesh.GenerateRoundedCube(Vec3.One, 0.05f);
 		/// :End:
 		/// :CodeSample: Mesh.GenerateSphere
 		/// ### UV and Face layout
 		/// Here's a test image that illustrates how this mesh's geometry is
 		/// laid out.
-		/// ![Procedural Cube Mesh]({{site.screen_url}}/ProcGeoSphere.jpg)
+		/// ![Procedural Sphere Mesh]({{site.screen_url}}/ProcGeoSphere.jpg)
 		meshSphere = Mesh.GenerateSphere(1);
 		/// :End:
 		/// :CodeSample: Mesh.GenerateCylinder
 		/// ### UV and Face layout
 		/// Here's a test image that illustrates how this mesh's geometry is
 		/// laid out.
-		/// ![Procedural Cube Mesh]({{site.screen_url}}/ProcGeoCylinder.jpg)
+		/// ![Procedural Cylinder Mesh]({{site.screen_url}}/ProcGeoCylinder.jpg)
 		meshCylinder = Mesh.GenerateCylinder(1, 1, Vec3.Up);
 		/// :End:
 		/// :CodeSample: Mesh.GeneratePlane
 		/// ### UV and Face layout
 		/// Here's a test image that illustrates how this mesh's geometry is
 		/// laid out.
-		/// ![Procedural Cube Mesh]({{site.screen_url}}/ProcGeoPlane.jpg)
+		/// ![Procedural Plane Mesh]({{site.screen_url}}/ProcGeoPlane.jpg)
 		meshPlane = Mesh.GeneratePlane(Vec2.One);
+		/// :End:
+		/// /// :CodeSample: Mesh.GenerateCircle
+		/// ### UV and Face layout
+		/// Here's a test image that illustrates how this mesh's geometry is
+		/// laid out.
+		/// ![Procedural Circle Mesh]({{site.screen_url}}/ProcGeoCircle.jpg)
+		meshCircle = Mesh.GenerateCircle(1);
 		/// :End:
 	}
 
@@ -89,5 +97,10 @@ class TestProceduralGeo : ITest
 		meshPlane.Draw(material, Matrix.T(at));
 		meshPlane.Draw(materialWire, Matrix.T(at));
 		Tests.Screenshot("ProcGeoPlane.jpg", 600, 600, at + from, at);
+
+		at += Vec3.Right * 100;
+		meshCircle.Draw(material, Matrix.T(at));
+		meshCircle.Draw(materialWire, Matrix.T(at));
+		Tests.Screenshot("ProcGeoCircle.jpg", 600, 600, at + from, at);
 	}
 }

--- a/StereoKit/Assets/Mesh.cs
+++ b/StereoKit/Assets/Mesh.cs
@@ -322,28 +322,30 @@ namespace StereoKit
 		public static Mesh GeneratePlane(Vec2 dimensions, Vec3 planeNormal, Vec3 planeTopDirection, int subdivisions = 0)
 			=> new Mesh(NativeAPI.mesh_gen_plane(dimensions, planeNormal, planeTopDirection, subdivisions));
 
-		/// <summary>Generates a circle on the XZ axis facing up that is
-		/// optionally subdivided, pre-sized to the given diameter. UV
-		/// coordinates corespond to a unit circle centered at 0.5, 0.5! That is, 
-		/// the right-most point on the circle has UV coordinates 1, 0.5 and the
-		/// top-most point has UV coordinates 0.5, 1.
+		/// <summary>Generates a circle on the XZ axis facing up that is 
+		/// pre-sized to the given diameter. UV coordinates corespond to a unit 
+		/// circle centered at 0.5, 0.5! That is, the right-most point on the 
+		/// circle has UV coordinates 1, 0.5 and the top-most point has UV 
+		/// coordinates 0.5, 1.
 		/// 
 		/// NOTE: This generates a completely new Mesh asset on the GPU, and
 		/// is best done during 'initialization' of your app/scene.</summary>
 		/// <param name="diameter">The diameter of the circle in meters, or 
 		/// 2*radius. This is the full length from one side to the other.
 		/// </param>
-		/// <param name="subdivisions">How many additional triangles compose
-		/// the circle? More is smoother, but less performant.</param>
+		/// <param name="spokes">How many vertices compose the circumference of 
+		/// the circle? Clamps to a minimum of 3. More is smoother, but less 
+		/// performant.</param>
+		/// <param name="doubleSided">Should both sides of the circle be 
+		/// rendered?</param>
 		/// <returns>A circle mesh, pre-sized to the given dimensions.</returns>
-		public static Mesh GenerateCircle(float diameter, int subdivisions = 16)
-			=> new Mesh(NativeAPI.mesh_gen_circle(diameter, Vec3.Up, Vec3.Forward, subdivisions));
+		public static Mesh GenerateCircle(float diameter, int spokes = 16, bool doubleSided = false)
+			=> new Mesh(NativeAPI.mesh_gen_circle(diameter, Vec3.Up, Vec3.Forward, spokes, doubleSided));
 
 		/// <summary>Generates a circle with an arbitrary orientation that is
-		/// optionally subdivided, pre-sized to the given diameter. UV 
-		/// coordinates start at the top left indicated with 
-		/// 'planeTopDirection' and corespond to a unit circle centered at 
-		/// 0.5, 0.5.
+		/// pre-sized to the given diameter. UV coordinates start at the top 
+		/// left indicated with 'planeTopDirection' and corespond to a unit 
+		/// circle centered at 0.5, 0.5.
 		/// 
 		/// NOTE: This generates a completely new Mesh asset on the GPU, and
 		/// is best done during 'initialization' of your app/scene.</summary>
@@ -358,11 +360,14 @@ namespace StereoKit
 		/// doesn't need to be exact. This function takes the planeNormal as
 		/// law, and uses this vector to find the right and up vectors via
 		/// cross-products.</param>
-		/// <param name="subdivisions">How many additional triangles compose
-		/// the circle? More is smoother, but less performant.</param>
+		/// <param name="spokes">How many vertices compose the circumference of 
+		/// the circle? Clamps to a minimum of 3. More is smoother, but less 
+		/// performant.</param>
+		/// <param name="doubleSided">Should both sides of the circle be 
+		/// rendered?</param>
 		/// <returns>A circle mesh, pre-sized to the given dimensions.</returns>
-		public static Mesh GenerateCircle(float diameter, Vec3 planeNormal, Vec3 planeTopDirection, int subdivisions = 16)
-			=> new Mesh(NativeAPI.mesh_gen_circle(diameter, planeNormal, planeTopDirection, subdivisions));
+		public static Mesh GenerateCircle(float diameter, Vec3 planeNormal, Vec3 planeTopDirection, int spokes = 16, bool doubleSided = false)
+			=> new Mesh(NativeAPI.mesh_gen_circle(diameter, planeNormal, planeTopDirection, spokes, doubleSided));
 
 		/// <summary>Generates a flat-shaded cube mesh, pre-sized to the
 		/// given dimensions. UV coordinates are projected flat on each face,

--- a/StereoKit/Assets/Mesh.cs
+++ b/StereoKit/Assets/Mesh.cs
@@ -292,9 +292,11 @@ namespace StereoKit
 		/// <param name="subdivisions">Use this to add extra slices of 
 		/// vertices across the plane. This can be useful for some types of
 		/// vertex-based effects!</param>
+		/// <param name="doubleSided">Should both sides of the plane be 
+		/// rendered?</param>
 		/// <returns>A plane mesh, pre-sized to the given dimensions.</returns>
-		public static Mesh GeneratePlane(Vec2 dimensions, int subdivisions = 0)
-			=> new Mesh(NativeAPI.mesh_gen_plane(dimensions, Vec3.Up, Vec3.Forward, subdivisions));
+		public static Mesh GeneratePlane(Vec2 dimensions, int subdivisions = 0, bool doubleSided = false)
+			=> new Mesh(NativeAPI.mesh_gen_plane(dimensions, Vec3.Up, Vec3.Forward, subdivisions, doubleSided));
 
 		/// <summary>Generates a plane with an arbitrary orientation that is
 		/// optionally subdivided, pre-sized to the given dimensions. UV 
@@ -318,9 +320,11 @@ namespace StereoKit
 		/// <param name="subdivisions">Use this to add extra slices of 
 		/// vertices across the plane. This can be useful for some types of
 		/// vertex-based effects!</param>
+		/// <param name="doubleSided">Should both sides of the plane be 
+		/// rendered?</param>
 		/// <returns>A plane mesh, pre-sized to the given dimensions.</returns>
-		public static Mesh GeneratePlane(Vec2 dimensions, Vec3 planeNormal, Vec3 planeTopDirection, int subdivisions = 0)
-			=> new Mesh(NativeAPI.mesh_gen_plane(dimensions, planeNormal, planeTopDirection, subdivisions));
+		public static Mesh GeneratePlane(Vec2 dimensions, Vec3 planeNormal, Vec3 planeTopDirection, int subdivisions = 0, bool doubleSided = false)
+			=> new Mesh(NativeAPI.mesh_gen_plane(dimensions, planeNormal, planeTopDirection, subdivisions, doubleSided));
 
 		/// <summary>Generates a circle on the XZ axis facing up that is 
 		/// pre-sized to the given diameter. UV coordinates corespond to a unit 

--- a/StereoKit/Assets/Mesh.cs
+++ b/StereoKit/Assets/Mesh.cs
@@ -280,7 +280,7 @@ namespace StereoKit
 
 		/// <summary>Generates a plane on the XZ axis facing up that is
 		/// optionally subdivided, pre-sized to the given dimensions. UV
-		/// coordinates start at 0,0 at the -X,-Z corer, and go to 1,1 at the
+		/// coordinates start at 0,0 at the -X,-Z corner, and go to 1,1 at the
 		/// +X,+Z corner!
 		/// 
 		/// NOTE: This generates a completely new Mesh asset on the GPU, and

--- a/StereoKit/Assets/Mesh.cs
+++ b/StereoKit/Assets/Mesh.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.InteropServices;
 
 namespace StereoKit
@@ -321,6 +321,48 @@ namespace StereoKit
 		/// <returns>A plane mesh, pre-sized to the given dimensions.</returns>
 		public static Mesh GeneratePlane(Vec2 dimensions, Vec3 planeNormal, Vec3 planeTopDirection, int subdivisions = 0)
 			=> new Mesh(NativeAPI.mesh_gen_plane(dimensions, planeNormal, planeTopDirection, subdivisions));
+
+		/// <summary>Generates a circle on the XZ axis facing up that is
+		/// optionally subdivided, pre-sized to the given diameter. UV
+		/// coordinates corespond to a unit circle centered at 0.5, 0.5! That is, 
+		/// the right-most point on the circle has UV coordinates 1, 0.5 and the
+		/// top-most point has UV coordinates 0.5, 1.
+		/// 
+		/// NOTE: This generates a completely new Mesh asset on the GPU, and
+		/// is best done during 'initialization' of your app/scene.</summary>
+		/// <param name="diameter">The diameter of the circle in meters, or 
+		/// 2*radius. This is the full length from one side to the other.
+		/// </param>
+		/// <param name="subdivisions">How many additional triangles compose
+		/// the circle? More is smoother, but less performant.</param>
+		/// <returns>A circle mesh, pre-sized to the given dimensions.</returns>
+		public static Mesh GenerateCircle(float diameter, int subdivisions = 16)
+			=> new Mesh(NativeAPI.mesh_gen_circle(diameter, Vec3.Up, Vec3.Forward, subdivisions));
+
+		/// <summary>Generates a circle with an arbitrary orientation that is
+		/// optionally subdivided, pre-sized to the given diameter. UV 
+		/// coordinates start at the top left indicated with 
+		/// 'planeTopDirection' and corespond to a unit circle centered at 
+		/// 0.5, 0.5.
+		/// 
+		/// NOTE: This generates a completely new Mesh asset on the GPU, and
+		/// is best done during 'initialization' of your app/scene.</summary>
+		/// <param name="diameter">The diameter of the circle in meters, or 
+		/// 2*radius. This is the full length from one side to the other.
+		/// </param>
+		/// <param name="planeNormal">What is the normal of the surface this
+		/// circle is generated on?</param>
+		/// <param name="planeTopDirection">A normal defines the plane, but 
+		/// this is technically a rectangle on the 
+		/// plane. So which direction is up? It's important for UVs, but 
+		/// doesn't need to be exact. This function takes the planeNormal as
+		/// law, and uses this vector to find the right and up vectors via
+		/// cross-products.</param>
+		/// <param name="subdivisions">How many additional triangles compose
+		/// the circle? More is smoother, but less performant.</param>
+		/// <returns>A circle mesh, pre-sized to the given dimensions.</returns>
+		public static Mesh GenerateCircle(float diameter, Vec3 planeNormal, Vec3 planeTopDirection, int subdivisions = 16)
+			=> new Mesh(NativeAPI.mesh_gen_circle(diameter, planeNormal, planeTopDirection, subdivisions));
 
 		/// <summary>Generates a flat-shaded cube mesh, pre-sized to the
 		/// given dimensions. UV coordinates are projected flat on each face,

--- a/StereoKit/Math/Pose.cs
+++ b/StereoKit/Math/Pose.cs
@@ -102,7 +102,7 @@ namespace StereoKit
 		public Matrix ToMatrix() 
 			=> Matrix.TR(position, orientation);
 
-		/// <summary>Interpolates between two poses! t is unclamped, so values outside of (0,1) will
+		/// <summary>Interpolates between two poses! It is unclamped, so values outside of (0,1) will
 		/// extrapolate their position.</summary>
 		/// <param name="a">Starting pose, or percent == 0</param>
 		/// <param name="b">Ending pose, or percent == 1</param>

--- a/StereoKit/Native/NativeAPI.cs
+++ b/StereoKit/Native/NativeAPI.cs
@@ -114,7 +114,7 @@ namespace StereoKit
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern int    mesh_ray_intersect   (IntPtr mesh, Ray model_space_ray, out Ray out_pt, out uint out_start_inds);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern int    mesh_get_triangle    (IntPtr mesh, uint triangle_index, out Vertex a, out Vertex b, out Vertex c);
 
-		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr mesh_gen_plane       (Vec2 dimensions, Vec3 plane_normal, Vec3 plane_top_direction, int subdivisions = 0);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr mesh_gen_plane       (Vec2 dimensions, Vec3 plane_normal, Vec3 plane_top_direction, int subdivisions, bool double_sided);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr mesh_gen_circle      (float diameter,  Vec3 plane_normal, Vec3 plane_top_direction, int spokes, bool double_sided);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr mesh_gen_cube        (Vec3 dimensions, int subdivisions = 0);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr mesh_gen_sphere      (float diameter, int subdivisions = 4);

--- a/StereoKit/Native/NativeAPI.cs
+++ b/StereoKit/Native/NativeAPI.cs
@@ -115,6 +115,7 @@ namespace StereoKit
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern int    mesh_get_triangle    (IntPtr mesh, uint triangle_index, out Vertex a, out Vertex b, out Vertex c);
 
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr mesh_gen_plane       (Vec2 dimensions, Vec3 plane_normal, Vec3 plane_top_direction, int subdivisions = 0);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr mesh_gen_circle      (float diameter,  Vec3 plane_normal, Vec3 plane_top_direction, int subdivisions);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr mesh_gen_cube        (Vec3 dimensions, int subdivisions = 0);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr mesh_gen_sphere      (float diameter, int subdivisions = 4);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr mesh_gen_rounded_cube(Vec3 dimensions, float edge_radius, int subdivisions);

--- a/StereoKit/Native/NativeAPI.cs
+++ b/StereoKit/Native/NativeAPI.cs
@@ -115,7 +115,7 @@ namespace StereoKit
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern int    mesh_get_triangle    (IntPtr mesh, uint triangle_index, out Vertex a, out Vertex b, out Vertex c);
 
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr mesh_gen_plane       (Vec2 dimensions, Vec3 plane_normal, Vec3 plane_top_direction, int subdivisions = 0);
-		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr mesh_gen_circle      (float diameter,  Vec3 plane_normal, Vec3 plane_top_direction, int subdivisions);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr mesh_gen_circle      (float diameter,  Vec3 plane_normal, Vec3 plane_top_direction, int spokes, bool double_sided);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr mesh_gen_cube        (Vec3 dimensions, int subdivisions = 0);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr mesh_gen_sphere      (float diameter, int subdivisions = 4);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr mesh_gen_rounded_cube(Vec3 dimensions, float edge_radius, int subdivisions);

--- a/StereoKitC/asset_types/mesh.cpp
+++ b/StereoKitC/asset_types/mesh.cpp
@@ -681,8 +681,8 @@ mesh_t mesh_gen_plane(vec2 dimensions, vec3 plane_normal, vec3 plane_top_directi
 
 ///////////////////////////////////////////
 
-mesh_t mesh_gen_circle(float diameter, vec3 plane_normal, vec3 plane_top_direction, int32_t divisions) {
-	vind_t spokes = maxi(0, (int32_t)divisions) + 3;
+mesh_t mesh_gen_circle(float diameter, vec3 plane_normal, vec3 plane_top_direction, int32_t subdivisions) {
+	vind_t spokes = maxi(0, (int32_t)subdivisions) + 3;
 	mesh_t result = mesh_create();
 
 	int vert_count = spokes;
@@ -704,7 +704,7 @@ mesh_t mesh_gen_circle(float diameter, vec3 plane_normal, vec3 plane_top_directi
 
 		pt->norm = plane_normal;
 		pt->pos  = radius * ((right * xp) + (up * yp));
-		pt->uv   = {xp,yp};
+		pt->uv   = {((xp+1)/2),((yp+1)/2)};
 		pt->col  = {255,255,255,255};
 	}
 

--- a/StereoKitC/stereokit.h
+++ b/StereoKitC/stereokit.h
@@ -703,7 +703,7 @@ SK_API bool32_t    mesh_ray_intersect_bvh(mesh_t mesh, ray_t model_space_ray, ra
 SK_API bool32_t    mesh_get_triangle    (mesh_t mesh, uint32_t triangle_index, vert_t* a, vert_t* b, vert_t* c);
 
 SK_API mesh_t      mesh_gen_plane       (vec2 dimensions, vec3 plane_normal, vec3 plane_top_direction, int32_t subdivisions sk_default(0));
-SK_API mesh_t      mesh_gen_circle      (float diameter, vec3 plane_normal, vec3 plane_top_direction, int32_t divisions sk_default(0));
+SK_API mesh_t      mesh_gen_circle      (float diameter,  vec3 plane_normal, vec3 plane_top_direction, int32_t subdivisions sk_default(16));
 SK_API mesh_t      mesh_gen_cube        (vec3 dimensions, int32_t subdivisions sk_default(0));
 SK_API mesh_t      mesh_gen_sphere      (float diameter,  int32_t subdivisions sk_default(4));
 SK_API mesh_t      mesh_gen_rounded_cube(vec3 dimensions, float edge_radius, int32_t subdivisions);

--- a/StereoKitC/stereokit.h
+++ b/StereoKitC/stereokit.h
@@ -702,7 +702,7 @@ SK_API bool32_t    mesh_ray_intersect   (mesh_t mesh, ray_t model_space_ray, ray
 SK_API bool32_t    mesh_ray_intersect_bvh(mesh_t mesh, ray_t model_space_ray, ray_t* out_pt, uint32_t* out_start_inds sk_default(nullptr), cull_ cull_mode sk_default(cull_back));
 SK_API bool32_t    mesh_get_triangle    (mesh_t mesh, uint32_t triangle_index, vert_t* a, vert_t* b, vert_t* c);
 
-SK_API mesh_t      mesh_gen_plane       (vec2 dimensions, vec3 plane_normal, vec3 plane_top_direction, int32_t subdivisions sk_default(0));
+SK_API mesh_t      mesh_gen_plane       (vec2 dimensions, vec3 plane_normal, vec3 plane_top_direction, int32_t subdivisions sk_default(0), bool32_t double_sided sk_default(false));
 SK_API mesh_t      mesh_gen_circle      (float diameter,  vec3 plane_normal, vec3 plane_top_direction, int32_t spokes sk_default(16), bool32_t double_sided sk_default(false));
 SK_API mesh_t      mesh_gen_cube        (vec3 dimensions, int32_t subdivisions sk_default(0));
 SK_API mesh_t      mesh_gen_sphere      (float diameter,  int32_t subdivisions sk_default(4));

--- a/StereoKitC/stereokit.h
+++ b/StereoKitC/stereokit.h
@@ -703,7 +703,7 @@ SK_API bool32_t    mesh_ray_intersect_bvh(mesh_t mesh, ray_t model_space_ray, ra
 SK_API bool32_t    mesh_get_triangle    (mesh_t mesh, uint32_t triangle_index, vert_t* a, vert_t* b, vert_t* c);
 
 SK_API mesh_t      mesh_gen_plane       (vec2 dimensions, vec3 plane_normal, vec3 plane_top_direction, int32_t subdivisions sk_default(0));
-SK_API mesh_t      mesh_gen_circle      (float diameter,  vec3 plane_normal, vec3 plane_top_direction, int32_t subdivisions sk_default(16));
+SK_API mesh_t      mesh_gen_circle      (float diameter,  vec3 plane_normal, vec3 plane_top_direction, int32_t spokes sk_default(16), bool32_t double_sided sk_default(false));
 SK_API mesh_t      mesh_gen_cube        (vec3 dimensions, int32_t subdivisions sk_default(0));
 SK_API mesh_t      mesh_gen_sphere      (float diameter,  int32_t subdivisions sk_default(4));
 SK_API mesh_t      mesh_gen_rounded_cube(vec3 dimensions, float edge_radius, int32_t subdivisions);

--- a/StereoKitC/stereokit.h
+++ b/StereoKitC/stereokit.h
@@ -703,6 +703,7 @@ SK_API bool32_t    mesh_ray_intersect_bvh(mesh_t mesh, ray_t model_space_ray, ra
 SK_API bool32_t    mesh_get_triangle    (mesh_t mesh, uint32_t triangle_index, vert_t* a, vert_t* b, vert_t* c);
 
 SK_API mesh_t      mesh_gen_plane       (vec2 dimensions, vec3 plane_normal, vec3 plane_top_direction, int32_t subdivisions sk_default(0));
+SK_API mesh_t      mesh_gen_circle      (float diameter, vec3 plane_normal, vec3 plane_top_direction, int32_t divisions sk_default(0));
 SK_API mesh_t      mesh_gen_cube        (vec3 dimensions, int32_t subdivisions sk_default(0));
 SK_API mesh_t      mesh_gen_sphere      (float diameter,  int32_t subdivisions sk_default(4));
 SK_API mesh_t      mesh_gen_rounded_cube(vec3 dimensions, float edge_radius, int32_t subdivisions);


### PR DESCRIPTION
Ok here's the code for the circle mesh generator! I also added an optional parameter to Mesh.GeneratePlane for generating a double sided mesh.

Here's a shot of one of the demo scenes from the underside, showing the double-sidedness:
![Untitled picture](https://user-images.githubusercontent.com/53974525/198799223-a88b3ba8-9188-4dfb-a156-03706c8f2259.png)


I also "moved" one of the test screenshot camera positions ("ProceduralGeometry.jpg") in order to squeeze the circle mesh into the frame:
![ProceduralGeometry](https://user-images.githubusercontent.com/53974525/198795720-f1bdfbd0-d0e9-4939-a2e9-f422cdaf7677.jpg)

And I added a test for the circle, similar to what was done for the plane. But not sure if I connected all the pieces to get this to show up in the docs. I tried generating the docs locally, but didn't see anything about the new Mesh.GenerateCircle method.
![ProcGeoCircle-](https://user-images.githubusercontent.com/53974525/198796610-e6ec8e9b-ab72-4a03-bfb7-e2da0645c2c9.jpg)

Let me know if you want any other changes or tweaks!
