### PR TITLE
Add API to get systemName as reported by OpenXR

### DIFF
--- a/StereoKit/Native/NativeAPI.cs
+++ b/StereoKit/Native/NativeAPI.cs
@@ -19,6 +19,7 @@ namespace StereoKit
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void        sk_run([MarshalAs(UnmanagedType.FunctionPtr)] Action app_update, [MarshalAs(UnmanagedType.FunctionPtr)] Action app_shutdown);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern int         sk_is_stepping();
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern DisplayMode sk_active_display_mode();
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr      sk_system_name();
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern SystemInfo  sk_system_info();
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr      sk_version_name();
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern ulong       sk_version_id();

--- a/StereoKit/SK.cs
+++ b/StereoKit/SK.cs
@@ -34,6 +34,10 @@ namespace StereoKit
 		/// characteristics!</summary>
 		public static SystemInfo System => _system;
 
+		/// <summary>Human-readable system name embedded in the StereoKitC
+		/// DLL.</summary>
+		public static string SystemName => Marshal.PtrToStringAnsi(NativeAPI.sk_system_name());
+
 		/// <summary>Human-readable version name embedded in the StereoKitC
 		/// DLL.</summary>
 		public static string VersionName => Marshal.PtrToStringAnsi( NativeAPI.sk_version_name() );

--- a/StereoKitC/_stereokit.h
+++ b/StereoKitC/_stereokit.h
@@ -4,6 +4,7 @@
 
 namespace sk {
 
+extern char          sk_sys_name[256];
 extern const char   *sk_app_name;
 extern sk_settings_t sk_settings;
 extern system_info_t sk_info;

--- a/StereoKitC/stereokit.cpp
+++ b/StereoKitC/stereokit.cpp
@@ -29,6 +29,7 @@ namespace sk {
 
 ///////////////////////////////////////////
 
+char          sk_sys_name[256];
 const char   *sk_app_name;
 void        (*sk_app_update_func)(void);
 display_mode_ sk_display_mode           = display_mode_none;
@@ -61,6 +62,12 @@ system_t *app_system    = nullptr;
 
 sk_settings_t sk_get_settings() {
 	return sk_settings;
+}
+
+///////////////////////////////////////////
+
+const char* sk_system_name() {
+	return &sk_sys_name[0];
 }
 
 ///////////////////////////////////////////
@@ -125,6 +132,7 @@ void sk_app_update() {
 ///////////////////////////////////////////
 
 bool32_t sk_init(sk_settings_t settings) {
+	strcpy(sk_sys_name, "");
 	sk_settings               = settings;
 	sk_no_flatscreen_fallback = sk_settings.no_flatscreen_fallback;
 	sk_app_name               = sk_settings.app_name == nullptr ? "StereoKit App" : sk_settings.app_name;

--- a/StereoKitC/stereokit.h
+++ b/StereoKitC/stereokit.h
@@ -336,6 +336,7 @@ SK_API bool32_t      sk_is_stepping        ();
 SK_API display_mode_ sk_active_display_mode();
 SK_API sk_settings_t sk_get_settings       ();
 SK_API system_info_t sk_system_info        ();
+SK_API const char   *sk_system_name        ();
 SK_API const char   *sk_version_name       ();
 SK_API uint64_t      sk_version_id         ();
 SK_API app_focus_    sk_app_focus          ();

--- a/StereoKitC/xr_backends/openxr.cpp
+++ b/StereoKitC/xr_backends/openxr.cpp
@@ -340,6 +340,7 @@ bool openxr_init() {
 	xr_check(xrGetSystemProperties(xr_instance, xr_system_id, &properties),
 		"xrGetSystemProperties failed [%s]");
 	log_diagf("System name: <~grn>%s<~clr>", properties.systemName);
+	strncpy(sk_sys_name, properties.systemName, 256);
 	xr_has_single_pass                = true;
 	xr_has_articulated_hands          = xr_ext_available.EXT_hand_tracking        && properties_tracking.supportsHandTracking;
 	xr_has_hand_meshes                = xr_ext_available.MSFT_hand_tracking_mesh  && properties_handmesh.supportsHandTrackingMesh;


### PR DESCRIPTION
I ran into https://github.com/StereoKit/StereoKit/discussions/343 (floor height inconsistent between devices) again and would really like to be able to do a check at startup to handle different systems. I suspect OpenXR's systemName property isn't always useful, but in my case I can see "XR-3" being reported in the SK initialization, so I can definitely detect that and use it in those cases (probably other headsets as well).