### PR TITLE
Adds a synchronous memory load for textures.

### DIFF
--- a/StereoKit/Assets/Tex.cs
+++ b/StereoKit/Assets/Tex.cs
@@ -263,25 +263,25 @@ namespace StereoKit
 			NativeAPI.tex_set_colors(_inst, width, height, data);
 		}
 
-        /// <summary>Loads an image file stored in memory directly into
-        /// the created texture! Supported formats are: jpg, png, tga,
-        /// bmp, psd, gif, hdr, pic. This method introduces a blocking 
-        /// boolean parameter, which allows you to specify whether this
-        /// method blocks until the image fully loads! The default case
-        /// is to have it as part of the asynchronous asset pipeline, in
-        /// which the Asset Id will be the same as the filename.</summary>
-        /// <param name="imageFileData">The binary data of an image file,
-        /// this is NOT a raw RGB color array!</param>
-        /// <param name="sRGBData">Is this image color data in sRGB format,
-        /// or is it normal/metal/rough/data that's not for direct display?
-        /// sRGB colors get converted to linear color space on the graphics
-        /// card, so getting this right can have a big impact on visuals.
-        /// </param>
-        /// <param name="blocking">Will this method wait for the image 
-        /// to load. By default, we try to load it asynchronously.</param>
-        /// <param name="priority">The priority sort order for this asset in
-        /// the async loading system. Lower values mean loading sooner.</param>
-        public void SetMemory(in byte[] imageFileData, bool sRGBData = true, bool blocking = false, int priority = 10)
+		/// <summary>Loads an image file stored in memory directly into
+		/// the created texture! Supported formats are: jpg, png, tga,
+		/// bmp, psd, gif, hdr, pic. This method introduces a blocking 
+		/// boolean parameter, which allows you to specify whether this
+		/// method blocks until the image fully loads! The default case
+		/// is to have it as part of the asynchronous asset pipeline, in
+		/// which the Asset Id will be the same as the filename.</summary>
+		/// <param name="imageFileData">The binary data of an image file,
+		/// this is NOT a raw RGB color array!</param>
+		/// <param name="sRGBData">Is this image color data in sRGB format,
+		/// or is it normal/metal/rough/data that's not for direct display?
+		/// sRGB colors get converted to linear color space on the graphics
+		/// card, so getting this right can have a big impact on visuals.
+		/// </param>
+		/// <param name="blocking">Will this method wait for the image 
+		/// to load. By default, we try to load it asynchronously.</param>
+		/// <param name="priority">The priority sort order for this asset in
+		/// the async loading system. Lower values mean loading sooner.</param>
+		public void SetMemory(in byte[] imageFileData, bool sRGBData = true, bool blocking = false, int priority = 10)
 		{
 			NativeAPI.tex_set_mem(_inst, imageFileData, (UIntPtr)imageFileData.Length, sRGBData?1:0, blocking, priority);
 		}

--- a/StereoKit/Assets/Tex.cs
+++ b/StereoKit/Assets/Tex.cs
@@ -263,54 +263,54 @@ namespace StereoKit
 			NativeAPI.tex_set_colors(_inst, width, height, data);
 		}
 
-        /// <summary>Loads an image file stored in memory directly into a
-        /// texture synchronously! Supported formats are: jpg, png, tga,
+		/// <summary>Loads an image file stored in memory directly into a
+		/// texture synchronously! Supported formats are: jpg, png, tga,
 		/// bmp, psd, gif, hdr, pic. Asset Id will be the same as the
 		/// filename.</summary>
-        /// <param name="imageFileData">The binary data of an image file,
-        /// this is NOT a raw RGB color array!</param>
-        /// <param name="sRGBData">Is this image color data in sRGB format,
-        /// or is it normal/metal/rough/data that's not for direct display?
-        /// sRGB colors get converted to linear color space on the graphics
-        /// card, so getting this right can have a big impact on visuals.
-        /// </param>
-        public void SetMemory(in byte[] imageFileData, bool sRGBData = true)
-        {
-            NativeAPI.tex_set_mem(_inst, imageFileData, (UIntPtr)imageFileData.Length, sRGBData?1:0);
-        }
+		/// <param name="imageFileData">The binary data of an image file,
+		/// this is NOT a raw RGB color array!</param>
+		/// <param name="sRGBData">Is this image color data in sRGB format,
+		/// or is it normal/metal/rough/data that's not for direct display?
+		/// sRGB colors get converted to linear color space on the graphics
+		/// card, so getting this right can have a big impact on visuals.
+		/// </param>
+		public void SetMemory(in byte[] imageFileData, bool sRGBData = true)
+		{
+			NativeAPI.tex_set_mem(_inst, imageFileData, (UIntPtr)imageFileData.Length, sRGBData?1:0);
+		}
 
-        /// <summary>This function is dependent on the graphics backend! It
-        /// will take a texture resource for the current graphics backend (D3D
-        /// or GL) and wrap it in a StereoKit texture for use within StereoKit.
-        /// This is a bit of an advanced feature.</summary>
-        /// <param name="nativeTexture">For D3D, this should be an
-        /// ID3D11Texture2D*, and for GL, this should be a uint32_t from a
-        /// glGenTexture call, coerced into the IntPtr.</param>
-        /// <param name="type">The image flags that tell SK how to treat the
-        /// texture, this should match up with the settings the texture was
-        /// originally created with. If SK can figure the appropriate settings,
-        /// it _may_ override the value provided here.</param>
-        /// <param name="native_fmt">The texture's format using the graphics
-        /// backend's value, not SK's. This should match up with the settings
-        /// the texture was originally created with. If SK can figure the
-        /// appropriate settings, it _may_ override the value provided here.
-        /// </param>
-        /// <param name="width">Width of the texture. This should match up with
-        /// the settings the texture was originally created with. If SK can
-        /// figure the appropriate settings, it _may_ override the value
-        /// provided here.</param>
-        /// <param name="height">Height of the texture. This should match up
-        /// with the settings the texture was originally created with. If SK
-        /// can figure the appropriate settings, it _may_ override the value
-        /// provided here.</param>
-        /// <param name="surface_count">Texture array surface count. This
-        /// should match up with the settings the texture was originally
-        /// created with. If SK can figure the appropriate settings, it _may_
-        /// override the value provided here.</param>
-        /// <param name="owned">Should ownership of this texture resource be
-        /// passed on to StereoKit? If so, StereoKit may delete it when it's
-        /// finished with it. If this is not desired, pass in false.</param>
-        public void SetNativeSurface(IntPtr nativeTexture, TexType type=TexType.Image, long native_fmt=0, int width=0, int height=0, int surface_count=1, bool owned=true)
+		/// <summary>This function is dependent on the graphics backend! It
+		/// will take a texture resource for the current graphics backend (D3D
+		/// or GL) and wrap it in a StereoKit texture for use within StereoKit.
+		/// This is a bit of an advanced feature.</summary>
+		/// <param name="nativeTexture">For D3D, this should be an
+		/// ID3D11Texture2D*, and for GL, this should be a uint32_t from a
+		/// glGenTexture call, coerced into the IntPtr.</param>
+		/// <param name="type">The image flags that tell SK how to treat the
+		/// texture, this should match up with the settings the texture was
+		/// originally created with. If SK can figure the appropriate settings,
+		/// it _may_ override the value provided here.</param>
+		/// <param name="native_fmt">The texture's format using the graphics
+		/// backend's value, not SK's. This should match up with the settings
+		/// the texture was originally created with. If SK can figure the
+		/// appropriate settings, it _may_ override the value provided here.
+		/// </param>
+		/// <param name="width">Width of the texture. This should match up with
+		/// the settings the texture was originally created with. If SK can
+		/// figure the appropriate settings, it _may_ override the value
+		/// provided here.</param>
+		/// <param name="height">Height of the texture. This should match up
+		/// with the settings the texture was originally created with. If SK
+		/// can figure the appropriate settings, it _may_ override the value
+		/// provided here.</param>
+		/// <param name="surface_count">Texture array surface count. This
+		/// should match up with the settings the texture was originally
+		/// created with. If SK can figure the appropriate settings, it _may_
+		/// override the value provided here.</param>
+		/// <param name="owned">Should ownership of this texture resource be
+		/// passed on to StereoKit? If so, StereoKit may delete it when it's
+		/// finished with it. If this is not desired, pass in false.</param>
+		public void SetNativeSurface(IntPtr nativeTexture, TexType type=TexType.Image, long native_fmt=0, int width=0, int height=0, int surface_count=1, bool owned=true)
 			=> NativeAPI.tex_set_surface(_inst, nativeTexture, type, native_fmt, width, height, surface_count, owned?1:0);
 
 		/// <summary>This will return the texture's native resource for use

--- a/StereoKit/Assets/Tex.cs
+++ b/StereoKit/Assets/Tex.cs
@@ -263,38 +263,54 @@ namespace StereoKit
 			NativeAPI.tex_set_colors(_inst, width, height, data);
 		}
 
-		/// <summary>This function is dependent on the graphics backend! It
-		/// will take a texture resource for the current graphics backend (D3D
-		/// or GL) and wrap it in a StereoKit texture for use within StereoKit.
-		/// This is a bit of an advanced feature.</summary>
-		/// <param name="nativeTexture">For D3D, this should be an
-		/// ID3D11Texture2D*, and for GL, this should be a uint32_t from a
-		/// glGenTexture call, coerced into the IntPtr.</param>
-		/// <param name="type">The image flags that tell SK how to treat the
-		/// texture, this should match up with the settings the texture was
-		/// originally created with. If SK can figure the appropriate settings,
-		/// it _may_ override the value provided here.</param>
-		/// <param name="native_fmt">The texture's format using the graphics
-		/// backend's value, not SK's. This should match up with the settings
-		/// the texture was originally created with. If SK can figure the
-		/// appropriate settings, it _may_ override the value provided here.
-		/// </param>
-		/// <param name="width">Width of the texture. This should match up with
-		/// the settings the texture was originally created with. If SK can
-		/// figure the appropriate settings, it _may_ override the value
-		/// provided here.</param>
-		/// <param name="height">Height of the texture. This should match up
-		/// with the settings the texture was originally created with. If SK
-		/// can figure the appropriate settings, it _may_ override the value
-		/// provided here.</param>
-		/// <param name="surface_count">Texture array surface count. This
-		/// should match up with the settings the texture was originally
-		/// created with. If SK can figure the appropriate settings, it _may_
-		/// override the value provided here.</param>
-		/// <param name="owned">Should ownership of this texture resource be
-		/// passed on to StereoKit? If so, StereoKit may delete it when it's
-		/// finished with it. If this is not desired, pass in false.</param>
-		public void SetNativeSurface(IntPtr nativeTexture, TexType type=TexType.Image, long native_fmt=0, int width=0, int height=0, int surface_count=1, bool owned=true)
+        /// <summary>Loads an image file stored in memory directly into a
+        /// texture synchronously! Supported formats are: jpg, png, tga,
+		/// bmp, psd, gif, hdr, pic. Asset Id will be the same as the
+		/// filename.</summary>
+        /// <param name="imageFileData">The binary data of an image file,
+        /// this is NOT a raw RGB color array!</param>
+        /// <param name="sRGBData">Is this image color data in sRGB format,
+        /// or is it normal/metal/rough/data that's not for direct display?
+        /// sRGB colors get converted to linear color space on the graphics
+        /// card, so getting this right can have a big impact on visuals.
+        /// </param>
+        public void SetMemory(in byte[] imageFileData, bool sRGBData = true)
+        {
+            NativeAPI.tex_set_mem(_inst, imageFileData, (UIntPtr)imageFileData.Length, sRGBData?1:0);
+        }
+
+        /// <summary>This function is dependent on the graphics backend! It
+        /// will take a texture resource for the current graphics backend (D3D
+        /// or GL) and wrap it in a StereoKit texture for use within StereoKit.
+        /// This is a bit of an advanced feature.</summary>
+        /// <param name="nativeTexture">For D3D, this should be an
+        /// ID3D11Texture2D*, and for GL, this should be a uint32_t from a
+        /// glGenTexture call, coerced into the IntPtr.</param>
+        /// <param name="type">The image flags that tell SK how to treat the
+        /// texture, this should match up with the settings the texture was
+        /// originally created with. If SK can figure the appropriate settings,
+        /// it _may_ override the value provided here.</param>
+        /// <param name="native_fmt">The texture's format using the graphics
+        /// backend's value, not SK's. This should match up with the settings
+        /// the texture was originally created with. If SK can figure the
+        /// appropriate settings, it _may_ override the value provided here.
+        /// </param>
+        /// <param name="width">Width of the texture. This should match up with
+        /// the settings the texture was originally created with. If SK can
+        /// figure the appropriate settings, it _may_ override the value
+        /// provided here.</param>
+        /// <param name="height">Height of the texture. This should match up
+        /// with the settings the texture was originally created with. If SK
+        /// can figure the appropriate settings, it _may_ override the value
+        /// provided here.</param>
+        /// <param name="surface_count">Texture array surface count. This
+        /// should match up with the settings the texture was originally
+        /// created with. If SK can figure the appropriate settings, it _may_
+        /// override the value provided here.</param>
+        /// <param name="owned">Should ownership of this texture resource be
+        /// passed on to StereoKit? If so, StereoKit may delete it when it's
+        /// finished with it. If this is not desired, pass in false.</param>
+        public void SetNativeSurface(IntPtr nativeTexture, TexType type=TexType.Image, long native_fmt=0, int width=0, int height=0, int surface_count=1, bool owned=true)
 			=> NativeAPI.tex_set_surface(_inst, nativeTexture, type, native_fmt, width, height, surface_count, owned?1:0);
 
 		/// <summary>This will return the texture's native resource for use

--- a/StereoKit/Assets/Tex.cs
+++ b/StereoKit/Assets/Tex.cs
@@ -263,20 +263,27 @@ namespace StereoKit
 			NativeAPI.tex_set_colors(_inst, width, height, data);
 		}
 
-		/// <summary>Loads an image file stored in memory directly into a
-		/// texture synchronously! Supported formats are: jpg, png, tga,
-		/// bmp, psd, gif, hdr, pic. Asset Id will be the same as the
-		/// filename.</summary>
-		/// <param name="imageFileData">The binary data of an image file,
-		/// this is NOT a raw RGB color array!</param>
-		/// <param name="sRGBData">Is this image color data in sRGB format,
-		/// or is it normal/metal/rough/data that's not for direct display?
-		/// sRGB colors get converted to linear color space on the graphics
-		/// card, so getting this right can have a big impact on visuals.
-		/// </param>
-		public void SetMemory(in byte[] imageFileData, bool sRGBData = true)
+        /// <summary>Loads an image file stored in memory directly into
+        /// the created texture! Supported formats are: jpg, png, tga,
+        /// bmp, psd, gif, hdr, pic. This method introduces a blocking 
+        /// boolean parameter, which allows you to specify whether this
+        /// method blocks until the image fully loads! The default case
+        /// is to have it as part of the asynchronous asset pipeline, in
+        /// which the Asset Id will be the same as the filename.</summary>
+        /// <param name="imageFileData">The binary data of an image file,
+        /// this is NOT a raw RGB color array!</param>
+        /// <param name="sRGBData">Is this image color data in sRGB format,
+        /// or is it normal/metal/rough/data that's not for direct display?
+        /// sRGB colors get converted to linear color space on the graphics
+        /// card, so getting this right can have a big impact on visuals.
+        /// </param>
+        /// <param name="blocking">Will this method wait for the image 
+        /// to load. By default, we try to load it asynchronously.</param>
+        /// <param name="priority">The priority sort order for this asset in
+        /// the async loading system. Lower values mean loading sooner.</param>
+        public void SetMemory(in byte[] imageFileData, bool sRGBData = true, bool blocking = false, int priority = 10)
 		{
-			NativeAPI.tex_set_mem(_inst, imageFileData, (UIntPtr)imageFileData.Length, sRGBData?1:0);
+			NativeAPI.tex_set_mem(_inst, imageFileData, (UIntPtr)imageFileData.Length, sRGBData?1:0, blocking, priority);
 		}
 
 		/// <summary>This function is dependent on the graphics backend! It

--- a/StereoKit/Native/NativeAPI.cs
+++ b/StereoKit/Native/NativeAPI.cs
@@ -169,6 +169,7 @@ namespace StereoKit
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   tex_set_colors          (IntPtr texture, int width, int height, [In] byte[] data);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   tex_set_colors          (IntPtr texture, int width, int height, [In] ushort[] data);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   tex_set_colors          (IntPtr texture, int width, int height, [In] float[] data);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   tex_set_mem             (IntPtr texture, [In] byte[] data, UIntPtr data_size, int srgb_data);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   tex_set_surface         (IntPtr texture, IntPtr native_surface, TexType type, long native_fmt, int width, int height, int surface_count, int owned);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr tex_get_surface         (IntPtr texture);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr tex_add_zbuffer         (IntPtr texture, TexFormat format = TexFormat.DepthStencil);

--- a/StereoKit/Native/NativeAPI.cs
+++ b/StereoKit/Native/NativeAPI.cs
@@ -169,7 +169,7 @@ namespace StereoKit
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   tex_set_colors          (IntPtr texture, int width, int height, [In] byte[] data);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   tex_set_colors          (IntPtr texture, int width, int height, [In] ushort[] data);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   tex_set_colors          (IntPtr texture, int width, int height, [In] float[] data);
-		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   tex_set_mem             (IntPtr texture, [In] byte[] data, UIntPtr data_size, int srgb_data);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   tex_set_mem             (IntPtr texture, [In] byte[] data, UIntPtr data_size, int srgb_data, bool blocking, int priority);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   tex_set_surface         (IntPtr texture, IntPtr native_surface, TexType type, long native_fmt, int width, int height, int surface_count, int owned);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr tex_get_surface         (IntPtr texture);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr tex_add_zbuffer         (IntPtr texture, TexFormat format = TexFormat.DepthStencil);

--- a/StereoKitC/asset_types/texture.cpp
+++ b/StereoKitC/asset_types/texture.cpp
@@ -158,6 +158,39 @@ bool32_t tex_load_arr_parse(asset_task_t *, asset_header_t *asset, void *job_dat
 	tex->header.state = asset_state_loaded_meta;
 	return true;
 }
+bool32_t tex_set_arr_parse(tex_t tex, tex_load_t* data) {
+	data->color_data = sk_malloc_t(void*, data->file_count);
+
+	// Parse all files
+	for (int32_t i = 0; i < data->file_count; i++) {
+		int         width = 0;
+		int         height = 0;
+		tex_format_ format = tex_format_none;
+		data->color_data[i] = tex_load_image_data(data->file_data[i], data->file_sizes[i], data->is_srgb, &format, &width, &height);
+
+		if (data->color_data[i] == nullptr) {
+			log_warnf(tex_msg_invalid_fmt, data->file_names[i]);
+			tex->header.state = asset_state_error_unsupported;
+			return false;
+		}
+
+		// This shouldn't happen, tex_load_image_data and tex_load_image_info
+		// should always agree with eachother
+		if (tex->width != width ||
+			tex->height != height ||
+			tex->format != format) {
+			log_warnf("Texture data mismatch: %s", data->file_names[i]);
+			tex_set_fallback(tex, tex_error_texture);
+			tex->header.state = asset_state_error;
+			return false;
+		}
+
+		// Release file memory as soon as we're done with it
+		sk_free(data->file_data[i]);
+	}
+	tex->header.state = asset_state_loaded_meta;
+	return true;
+}
 
 ///////////////////////////////////////////
 
@@ -865,6 +898,36 @@ void tex_set_color_arr(tex_t texture, int32_t width, int32_t height, void **data
 #else
 	_tex_set_color_arr(job_data.texture, job_data.width, job_data.height, job_data.data, job_data.data_count, job_data.sh_lighting_info, job_data.multisample);
 #endif
+}
+
+///////////////////////////////////////////
+
+void tex_set_mem(tex_t texture, void* data, size_t data_size, bool32_t srgb_data) {
+	tex_load_t* load_data = sk_calloc_t(tex_load_t, 1);
+	load_data->is_srgb = srgb_data;
+	load_data->file_count = 1;
+	load_data->file_names = sk_malloc_t(char*, 1);
+	load_data->file_sizes = sk_malloc_t(size_t, 1);
+	load_data->file_data = sk_malloc_t(void*, 1);
+	load_data->file_names[0] = string_copy("(memory)");
+	load_data->file_sizes[0] = data_size;
+	load_data->file_data[0] = sk_malloc(sizeof(uint8_t) * data_size);
+	memcpy(load_data->file_data[0], data, data_size);
+
+	// Grab the file meta right away since we already have the file data, no
+	// point in delaying that until the task.
+	int32_t     width = 0;
+	int32_t     height = 0;
+	tex_format_ format = tex_format_none;
+	if (!tex_load_image_info(load_data->file_data[0], load_data->file_sizes[0], load_data->is_srgb, &width, &height, &format)) {
+		log_warnf(tex_msg_invalid_fmt, load_data->file_names[0]);
+		texture->header.state = asset_state_error_unsupported;
+		return;
+	}
+	tex_set_meta(texture, width, height, format);
+
+	tex_set_arr_parse(texture, load_data);
+	tex_set_color_arr(texture, texture->width, texture->height, load_data->color_data, load_data->file_count);
 }
 
 ///////////////////////////////////////////

--- a/StereoKitC/asset_types/texture.cpp
+++ b/StereoKitC/asset_types/texture.cpp
@@ -926,8 +926,11 @@ void tex_set_mem(tex_t texture, void* data, size_t data_size, bool32_t srgb_data
 	}
 	tex_set_meta(texture, width, height, format);
 
-	tex_set_arr_parse(texture, load_data);
-	tex_set_color_arr(texture, texture->width, texture->height, load_data->color_data, load_data->file_count);
+	bool32_t success = tex_set_arr_parse(texture, load_data);
+	if (!success)	tex_set_fallback(texture, tex_error_texture);
+	else		tex_set_color_arr(texture, texture->width, texture->height, load_data->color_data, load_data->file_count);
+
+	tex_load_free(nullptr, load_data);
 }
 
 ///////////////////////////////////////////

--- a/StereoKitC/stereokit.h
+++ b/StereoKitC/stereokit.h
@@ -937,7 +937,7 @@ SK_API void         tex_on_load             (tex_t texture, void (*asset_on_load
 SK_API void         tex_on_load_remove      (tex_t texture, void (*asset_on_load_callback)(tex_t texture, void *context));
 SK_API void         tex_set_colors          (tex_t texture, int32_t width, int32_t height, void *data);
 SK_API void         tex_set_color_arr       (tex_t texture, int32_t width, int32_t height, void** data, int32_t data_count, spherical_harmonics_t *out_sh_lighting_info sk_default(nullptr), int32_t multisample sk_default(1));
-SK_API void         tex_set_mem             (tex_t texture, void* data, size_t data_size, bool32_t srgb_data sk_default(true));
+SK_API void         tex_set_mem             (tex_t texture, void* data, size_t data_size, bool32_t srgb_data sk_default(true), bool32_t blocking sk_default(false), int32_t priority sk_default(10));
 // TODO: For v0.4, remove the return value here, since this needs to addref, and the texture may be ignored
 SK_API tex_t        tex_add_zbuffer         (tex_t texture, tex_format_ format sk_default(tex_format_depthstencil));
 // TODO: For v0.4, combine these two functions

--- a/StereoKitC/stereokit.h
+++ b/StereoKitC/stereokit.h
@@ -937,6 +937,7 @@ SK_API void         tex_on_load             (tex_t texture, void (*asset_on_load
 SK_API void         tex_on_load_remove      (tex_t texture, void (*asset_on_load_callback)(tex_t texture, void *context));
 SK_API void         tex_set_colors          (tex_t texture, int32_t width, int32_t height, void *data);
 SK_API void         tex_set_color_arr       (tex_t texture, int32_t width, int32_t height, void** data, int32_t data_count, spherical_harmonics_t *out_sh_lighting_info sk_default(nullptr), int32_t multisample sk_default(1));
+SK_API void         tex_set_mem             (tex_t texture, void* data, size_t data_size, bool32_t srgb_data sk_default(true));
 // TODO: For v0.4, remove the return value here, since this needs to addref, and the texture may be ignored
 SK_API tex_t        tex_add_zbuffer         (tex_t texture, tex_format_ format sk_default(tex_format_depthstencil));
 // TODO: For v0.4, combine these two functions


### PR DESCRIPTION
Hi nick, I have a stream of JPEG encoded images coming from another thread and found the asynchronous loading system difficult to get _just right_. I tried using the `OnLoaded` events to synchronize to the SK game thread as well as attempts at your suggestions here about checking the `AssetState`: https://github.com/StereoKit/StereoKit/issues/526#issuecomment-1314510572. At the end of the day, it was much simpler to have a `Tex.SetMemory` that performs synchronously, like `Tex.SetColors`. Here's it in practice with a JPEG-encoded MediaCapture stream on the HL2: 

https://user-images.githubusercontent.com/32556981/212746350-51c88027-bbd9-4473-8fcc-3c01077335dc.mp4

I created a new method for `tex_set_arr_parse` to separate itself from any asset loading. Curious about your thoughts on this! Would be happy to change anything, I'm just glad it's working now :)