### PR TITLE
feat: implement an `Matrix.Perspective` overload for camera perspectives

### DIFF
--- a/StereoKit/Math/Matrix.cs
+++ b/StereoKit/Math/Matrix.cs
@@ -417,12 +417,12 @@ namespace StereoKit
 		/// <returns>The final perspective matrix.</returns>
 		public static Matrix Perspective(Vec2 imageResolution, Vec2 focalLength, float nearClip, float farClip)
 		{
-		    Vec2 aspectRatio = imageResolution / focalLength;
+		    Vec2 nearPlaneDimensions = imageResolution / focalLength;
 		    float deltaZ = nearClip - farClip;
 		    return new Matrix4x4()
 		    {
-			M11 = 2 / aspectRatio.x,
-			M22 = 2 / aspectRatio.y,
+			M11 = 2 / nearPlaneDimensions.x,
+			M22 = 2 / nearPlaneDimensions.y,
 			M33 = farClip / deltaZ,
 			M34 = -1,
 			M43 = nearClip * farClip / deltaZ,

--- a/StereoKit/Math/Matrix.cs
+++ b/StereoKit/Math/Matrix.cs
@@ -417,12 +417,12 @@ namespace StereoKit
 		/// <returns>The final perspective matrix.</returns>
 		public static Matrix Perspective(Vec2 imageResolution, Vec2 focalLength, float nearClip, float farClip)
 		{
-		    Vec2 aspectRatio = imageResolution / focalLength * nearClip;
+		    Vec2 aspectRatio = imageResolution / focalLength;
 		    float deltaZ = nearClip - farClip;
 		    return new Matrix4x4()
 		    {
-			M11 = 2 * nearClip / aspectRatio.x,
-			M22 = 2 * nearClip / aspectRatio.y,
+			M11 = 2 / aspectRatio.x,
+			M22 = 2 / aspectRatio.y,
 			M33 = farClip / deltaZ,
 			M34 = -1,
 			M43 = nearClip * farClip / deltaZ,

--- a/StereoKit/Math/Matrix.cs
+++ b/StereoKit/Math/Matrix.cs
@@ -414,14 +414,14 @@ namespace StereoKit
 		/// artifacts.</param>
 		/// <returns>The final perspective matrix.</returns>
 		public static Matrix Perspective(Vec2 focalLength, Vec2 principalPoint, float nearClip, float farClip)
-		    => new Matrix(new Matrix4x4()
+		    => new Matrix4x4()
 		    {
 			M11 = focalLength.x / principalPoint.x,
 			M22 = focalLength.y / principalPoint.y,
 			M33 = farClip / (nearClip - farClip),
 			M34 = -1,
 			M43 = nearClip * farClip / (nearClip - farClip),
-		    });
+		    };
 		
 		/// <summary>This creates a matrix used for projecting 3D geometry
 		/// onto a 2D surface for rasterization. Orthographic projection 

--- a/StereoKit/Math/Matrix.cs
+++ b/StereoKit/Math/Matrix.cs
@@ -417,16 +417,8 @@ namespace StereoKit
 		/// <returns>The final perspective matrix.</returns>
 		public static Matrix Perspective(Vec2 imageResolution, Vec2 focalLength, float nearClip, float farClip)
 		{
-		    Vec2 nearPlaneDimensions = imageResolution / focalLength;
-		    float deltaZ = nearClip - farClip;
-		    return new Matrix4x4()
-		    {
-			M11 = 2 / nearPlaneDimensions.x,
-			M22 = 2 / nearPlaneDimensions.y,
-			M33 = farClip / deltaZ,
-			M34 = -1,
-			M43 = nearClip * farClip / deltaZ,
-		    };
+			Vec2 nearPlaneDimensions = imageResolution / focalLength * nearClip;
+			return Matrix4x4.CreatePerspective(nearPlaneDimensions.x, nearPlaneDimensions.y, nearClip, farClip);
 		}
 		
 		/// <summary>This creates a matrix used for projecting 3D geometry

--- a/StereoKit/Math/Matrix.cs
+++ b/StereoKit/Math/Matrix.cs
@@ -403,8 +403,10 @@ namespace StereoKit
 		/// <summary>This creates a matrix used for projecting 3D geometry
 		/// onto a 2D surface for rasterization. With the known camera 
 		/// intrinsics, you can replicate its perspective!</summary>
-		/// <param name="focalLength">The focal length of a camera.</param>
-		/// <param name="principalPoint">The principal point of a camera.</param>
+		/// <param name="imageResolution">The resolution of the image. This
+		/// should be the image's width and height in pixels.</param>
+		/// <param name="focalLength">The focal length of camera in pixels,
+		/// with image coordinates +X (pointing right) and +Y (pointing up).</param>
 		/// <param name="nearClip">Anything closer than this distance (in
 		/// meters) will be discarded. Must not be zero, and if you make this
 		/// too small, you may experience glitching in your depth buffer.</param>
@@ -413,15 +415,19 @@ namespace StereoKit
 		/// should not be too far away, or you'll see bad z-fighting 
 		/// artifacts.</param>
 		/// <returns>The final perspective matrix.</returns>
-		public static Matrix Perspective(Vec2 focalLength, Vec2 principalPoint, float nearClip, float farClip)
-		    => new Matrix4x4()
+		public static Matrix Perspective(Vec2 imageResolution, Vec2 focalLength, float nearClip, float farClip)
+		{
+		    Vec2 aspectRatio = imageResolution / focalLength * nearClip;
+		    float deltaZ = nearClip - farClip;
+		    return new Matrix4x4()
 		    {
-			M11 = focalLength.x / principalPoint.x,
-			M22 = focalLength.y / principalPoint.y,
-			M33 = farClip / (nearClip - farClip),
+			M11 = 2 * nearClip / aspectRatio.x,
+			M22 = 2 * nearClip / aspectRatio.y,
+			M33 = farClip / deltaZ,
 			M34 = -1,
-			M43 = nearClip * farClip / (nearClip - farClip),
+			M43 = nearClip * farClip / deltaZ,
 		    };
+		}
 		
 		/// <summary>This creates a matrix used for projecting 3D geometry
 		/// onto a 2D surface for rasterization. Orthographic projection 

--- a/StereoKit/Math/Matrix.cs
+++ b/StereoKit/Math/Matrix.cs
@@ -401,6 +401,29 @@ namespace StereoKit
 			=> Matrix4x4.CreatePerspectiveFieldOfView(fovDegrees*Units.deg2rad, aspectRatio, nearClip, farClip);
 
 		/// <summary>This creates a matrix used for projecting 3D geometry
+		/// onto a 2D surface for rasterization. With the known camera 
+		/// intrinsics, you can replicate its perspective!</summary>
+		/// <param name="focalLength">The focal length of a camera.</param>
+		/// <param name="principalPoint">The principal point of a camera.</param>
+		/// <param name="nearClip">Anything closer than this distance (in
+		/// meters) will be discarded. Must not be zero, and if you make this
+		/// too small, you may experience glitching in your depth buffer.</param>
+		/// <param name="farClip">Anything further than this distance (in
+		/// meters) will be discarded. For low resolution depth buffers, this
+		/// should not be too far away, or you'll see bad z-fighting 
+		/// artifacts.</param>
+		/// <returns>The final perspective matrix.</returns>
+		public static Matrix Perspective(Vec2 focalLength, Vec2 principalPoint, float nearClip, float farClip)
+		    => new Matrix(new Matrix4x4()
+		    {
+			M11 = focalLength.x / principalPoint.x,
+			M22 = focalLength.y / principalPoint.y,
+			M33 = farClip / (nearClip - farClip),
+			M34 = -1,
+			M43 = nearClip * farClip / (nearClip - farClip),
+		    });
+		
+		/// <summary>This creates a matrix used for projecting 3D geometry
 		/// onto a 2D surface for rasterization. Orthographic projection 
 		/// matrices will preserve parallel lines. This is great for 2D 
 		/// scenes or content.</summary>


### PR DESCRIPTION
This uses the same calculation as `CreatePerspectiveFieldOfView` but takes advantage of the camera intrinsic information for its near plane dimensions (width + height).
I can prove that this works, if needed, but also here's a similar calculation by MSFT: https://learn.microsoft.com/en-us/previous-versions/windows/desktop/bb281732(v=vs.85)