### PR TITLE
Added model_recalculate_bounds_exact() 

### DIFF
--- a/StereoKit/Assets/Model.cs
+++ b/StereoKit/Assets/Model.cs
@@ -419,6 +419,13 @@ namespace StereoKit
 		public void RecalculateBounds()
 			=> NativeAPI.model_recalculate_bounds(_inst);
 
+		/// <summary>Examines the visuals as they currently are, and rebuilds
+		/// the bounds based on all the vertices in the model! This leads (in general)
+		/// to a tighter bound than the default bound based on bounding boxes.
+		/// However, computing the exact bound can take much longer!</summary>
+		public void RecalculateBoundsExact()
+			=> NativeAPI.model_recalculate_bounds_exact(_inst);
+
 		/// <inheritdoc cref="Model.Draw(Matrix)"/>
 		/// <param name="colorLinear">A per-instance linear space color value
 		/// to pass into the shader! Normally this gets used like a material

--- a/StereoKit/Native/NativeAPI.cs
+++ b/StereoKit/Native/NativeAPI.cs
@@ -307,6 +307,7 @@ namespace StereoKit
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern int    model_add_named_subset  (IntPtr model, string name, IntPtr mesh, IntPtr material, in Matrix transform);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern int    model_subset_count      (IntPtr model);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   model_recalculate_bounds(IntPtr model);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   model_recalculate_bounds_exact(IntPtr model);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   model_set_bounds        (IntPtr model, in Bounds bounds);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern Bounds model_get_bounds        (IntPtr model);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern int    model_ray_intersect     (IntPtr model, Ray model_space_ray, out Ray out_pt, Cull cull_mode);

--- a/StereoKitC/stereokit.h
+++ b/StereoKitC/stereokit.h
@@ -1259,6 +1259,7 @@ SK_API void          model_addref                  (model_t model);
 SK_API void          model_release                 (model_t model);
 SK_API void          model_draw                    (model_t model, matrix transform, color128 color_linear sk_default({1,1,1,1}), render_layer_ layer sk_default(render_layer_0));
 SK_API void          model_recalculate_bounds      (model_t model);
+SK_API void          model_recalculate_bounds_exact(model_t model);
 SK_API void          model_set_bounds              (model_t model, const sk_ref(bounds_t) bounds);
 SK_API bounds_t      model_get_bounds              (model_t model);
 SK_API bool32_t      model_ray_intersect           (model_t model, ray_t model_space_ray, ray_t* out_pt, cull_ cull_mode sk_default(cull_back));


### PR DESCRIPTION
This computes a model bound based on (transformed) vertices, instead of using per-mesh AABBs. Main reason for this is to have a much tighter bound, especially for interaction volumes, at the cost of a longer time needed to compute bounds for models with many vertices.

Note that I haven't tested this from the C# side, but the C code does compile on Linux :smile: 