### PR TITLE
EGL without a display server on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,7 +79,7 @@ elseif (UNIX)
   # Add OpenGL, and account for the SK_LINUX_EGL option
   if(SK_LINUX_EGL)
     add_definitions("-DSKG_LINUX_EGL")
-    list(APPEND LINUX_LIBS EGL)
+    list(APPEND LINUX_LIBS EGL gbm)
   else()
     add_definitions("-DSKG_LINUX_GLX")
     find_package(X11 REQUIRED)

--- a/StereoKitC/libraries/sk_gpu.h
+++ b/StereoKitC/libraries/sk_gpu.h
@@ -541,7 +541,6 @@ typedef struct skg_platform_data_t {
 ///////////////////////////////////////////
 
 SKG_API void                skg_setup_xlib               (void *dpy, void *vi, void *fbconfig, void *drawable);
-SKG_API bool                skg_egl_dri                  ();
 SKG_API int32_t             skg_init                     (const char *app_name, void *adapter_id);
 SKG_API const char*         skg_adapter_name             ();
 SKG_API void                skg_shutdown                 ();
@@ -3276,16 +3275,6 @@ void skg_setup_xlib(void *dpy, void *vi, void *fbconfig, void *drawable) {
 	visualInfo  =  (XVisualInfo*) vi;
 	glxFBConfig = *(GLXFBConfig*) fbconfig;
 	glxDrawable = *(Drawable   *) drawable;
-#endif
-}
-
-///////////////////////////////////////////
-
-bool skg_egl_dri() {
-#ifdef _SKG_GL_LOAD_EGL
-	return egl_dri;
-#else
-	return false;
 #endif
 }
 

--- a/StereoKitC/platforms/linux.cpp
+++ b/StereoKitC/platforms/linux.cpp
@@ -424,10 +424,7 @@ bool linux_start_post_xr() {
 #if defined(SKG_LINUX_EGL)
 	if (sk_settings.disable_desktop_input_window)
 		return true;
-	if(skg_egl_dri())
-		return true;
-	if(!setup_x_window())
-		return false;
+	setup_x_window();
 #endif
 
 	return true;
@@ -437,10 +434,6 @@ bool linux_start_post_xr() {
 
 bool linux_start_flat() {
 	#if defined(SKG_LINUX_EGL)
-	if (skg_egl_dri()) {
-		log_fail_reason(90, log_error, "Cannot create a window with a direct rendering EGL context");
-		return false;
-	}
 	if (!setup_x_window())
 		return false;
 	#endif


### PR DESCRIPTION
Needed for Stardust, great for many other things! This basically tries to get a display and if that fails it tries DRI from the default card, if that fails the app fails to load.