### PR TITLE
Bytedance Pico OpenXR Loader, Controller Profiles and Handtracking

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -31,6 +31,11 @@ In addition to the Windows steps, to build for Android, StereoKit uses [xmake](h
 
 I may update this guide eventually, but if you can track what steps you take while doing this and submit a PR, that would be really incredible!
 
+General Setup steps:
+1. Install xmake
+2. Install the Android NDK. Grab the latest version from [here](https://developer.android.com/ndk/downloads) and unzip into a folder, a path without spaces will make life easier (C:\tools\Android\android-sdk)
+3. Set the NDK path into xmake. This command sets the global config: `xmake g --ndk="C:\tools\Android\android-sdk\android-ndk-rXYZ"`
+
 ## I want to modify code (Linux)
 
 StereoKit official Linux builds currently use xmake running on Windows Subsystems for Linux, however, it's also possible to use cmake, and do either from a normal Linux machine.

--- a/Examples/StereoKitTest/StereoKitTest_Maui/Platforms/Android/AndroidManifest.xml
+++ b/Examples/StereoKitTest/StereoKitTest_Maui/Platforms/Android/AndroidManifest.xml
@@ -3,9 +3,12 @@
 	<uses-sdk android:minSdkVersion="29" android:targetSdkVersion="29" />
 
 	<application android:allowBackup="true" android:icon="@mipmap/appicon" android:roundIcon="@mipmap/appicon_round" android:supportsRtl="true">
+		<!-- Oculus -->
 		<meta-data android:name="com.oculus.supportedDevices" android:value="quest|quest2|questpro"/>
 		<meta-data android:name="com.oculus.handtracking.version" android:value="V2.0"/>
-		<meta-data android:name="pvr.app.type" android:value="vr" /> <!-- Pico -->
+		<!-- Pico -->
+		<meta-data android:name="pvr.app.type" android:value="vr" />
+		<meta-data android:name="handtracking" android:value="1" />
 	</application>
 
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />

--- a/StereoKitC/hands/hand_oxr_articulated.cpp
+++ b/StereoKitC/hands/hand_oxr_articulated.cpp
@@ -190,9 +190,9 @@ void hand_oxra_update_joints() {
 		xr_extensions.xrLocateHandJointsEXT(oxra_hand_tracker[h], &locate_info, &locations);
 
 		// Update the tracking state of the hand, join definations here: https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#_conventions_of_hand_joints
-		// joint 0 is the palm center. joint 1 is the wrist.
+		// joint 10 is index finger tip
 		// joint 0, 6, 11, 16, 21 don't appear to be tracked on Pico 4
-		bool valid_joints = (locations.jointLocations[1].locationFlags & XR_SPACE_LOCATION_POSITION_VALID_BIT) > 0;
+		bool valid_joints = (locations.jointLocations[10].locationFlags & XR_SPACE_LOCATION_POSITION_VALID_BIT) > 0;
 		hand_t *inp_hand     = (hand_t*)input_hand((handed_)h);
 		inp_hand->tracked_state = button_make_state(inp_hand->tracked_state & button_state_active, valid_joints);
 		pointer->tracked = inp_hand->tracked_state;

--- a/StereoKitC/hands/hand_oxr_articulated.cpp
+++ b/StereoKitC/hands/hand_oxr_articulated.cpp
@@ -149,6 +149,7 @@ void hand_oxra_shutdown() {
 }
 
 ///////////////////////////////////////////
+
 void hand_oxra_update_joints() {
 	// Generate some shoulder data used for generating hand pointers
 

--- a/StereoKitC/hands/hand_oxr_articulated.cpp
+++ b/StereoKitC/hands/hand_oxr_articulated.cpp
@@ -149,7 +149,6 @@ void hand_oxra_shutdown() {
 }
 
 ///////////////////////////////////////////
-
 void hand_oxra_update_joints() {
 	// Generate some shoulder data used for generating hand pointers
 
@@ -189,8 +188,10 @@ void hand_oxra_update_joints() {
 		locations.jointLocations = joint_locations;
 		xr_extensions.xrLocateHandJointsEXT(oxra_hand_tracker[h], &locate_info, &locations);
 
-		// Update the tracking state of the hand
-		bool    valid_joints = (locations.jointLocations[0].locationFlags & XR_SPACE_LOCATION_POSITION_VALID_BIT) > 0;
+		// Update the tracking state of the hand, join definations here: https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#_conventions_of_hand_joints
+		// joint 0 is the palm center. joint 1 is the wrist.
+		// joint 0, 6, 11, 16, 21 don't appear to be tracked on Pico 4
+		bool valid_joints = (locations.jointLocations[1].locationFlags & XR_SPACE_LOCATION_POSITION_VALID_BIT) > 0;
 		hand_t *inp_hand     = (hand_t*)input_hand((handed_)h);
 		inp_hand->tracked_state = button_make_state(inp_hand->tracked_state & button_state_active, valid_joints);
 		pointer->tracked = inp_hand->tracked_state;

--- a/StereoKitC/xr_backends/openxr_input.cpp
+++ b/StereoKitC/xr_backends/openxr_input.cpp
@@ -436,14 +436,14 @@ bool oxri_init() {
 		suggested_binds.suggestedBindings = binding_arr.data;
 		suggested_binds.countSuggestedBindings = binding_arr.count;
 		if (XR_SUCCEEDED(xrSuggestInteractionProfileBindings(xr_instance, &suggested_binds))) {
-			// Orientation fix for PICO Neo3 controllers (untested)
+			// Orientation fix for PICO Neo3 controllers (untested, assume same as pico 4)
 			xrc_profile_info_t info;
 			info.profile = profile_path;
 			info.name = "bytedance/pico_neo3_controller";
-			info.offset_rot[handed_left] = quat_identity;
-			info.offset_rot[handed_right] = quat_identity;
-			info.offset_pos[handed_left] = vec3_zero;
-			info.offset_pos[handed_right] = vec3_zero;
+			info.offset_rot[handed_left] = quat_from_angles(-80, 0, 0);
+			info.offset_rot[handed_right] = quat_from_angles(-80, 0, 0);
+			info.offset_pos[handed_left] = { -0.03f, 0.01f, 0.00f };
+			info.offset_pos[handed_right] = { 0.03f, 0.01f, 0.00f };
 			xrc_profile_offsets.add(info);
 		}
 		binding_arr.clear();
@@ -451,6 +451,8 @@ bool oxri_init() {
 
 	// Bytedance Pico 4
 	// https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#XR_BD_controller_interaction
+	// Note that on the pico 4 OS 5.5 OpenXR SDK 2.2, the xrGetCurrentInteractionProfile will return '/interaction_profiles/bytedance/pico_neo3_controller'
+	// instead of the expected '/interaction_profiles/bytedance/pico4_controller'
 	{
 		xrStringToPath(xr_instance, "/user/hand/left/input/x/click", &path_x1[0]);
 		xrStringToPath(xr_instance, "/user/hand/right/input/a/click", &path_x1[1]);
@@ -486,10 +488,10 @@ bool oxri_init() {
 			xrc_profile_info_t info;
 			info.profile = profile_path;
 			info.name = "bytedance/pico4_controller";
-			info.offset_rot[handed_left] = quat_identity;
-			info.offset_rot[handed_right] = quat_identity;
-			info.offset_pos[handed_left] = vec3_zero;
-			info.offset_pos[handed_right] = vec3_zero;
+			info.offset_rot[handed_left] = quat_from_angles(-80, 0, 0);
+			info.offset_rot[handed_right] = quat_from_angles(-80, 0, 0);
+			info.offset_pos[handed_left] = { -0.03f, 0.01f, 0.00f };
+			info.offset_pos[handed_right] = { 0.03f, 0.01f, 0.00f };
 			xrc_profile_offsets.add(info);
 		}
 		binding_arr.clear();
@@ -714,7 +716,7 @@ bool oxri_init() {
 		return false;
 	}
 
-	oxri_set_profile(handed_left,  xrc_active_profile[handed_left ]);
+	oxri_set_profile(handed_left, xrc_active_profile[handed_left ]);
 	oxri_set_profile(handed_right, xrc_active_profile[handed_right]);
 	return true;
 }
@@ -942,7 +944,6 @@ void oxri_update_interaction_profile() {
 	XrPath path[2];
 	xrStringToPath(xr_instance, "/user/hand/left",  &path[handed_left]);
 	xrStringToPath(xr_instance, "/user/hand/right", &path[handed_right]);
-
 	XrInteractionProfileState active_profile = { XR_TYPE_INTERACTION_PROFILE_STATE };
 	for (int32_t h = 0; h < handed_max; h++) {
 		if (XR_FAILED(xrGetCurrentInteractionProfile(xr_session, path[h], &active_profile)))

--- a/StereoKitC/xr_backends/openxr_input.cpp
+++ b/StereoKitC/xr_backends/openxr_input.cpp
@@ -716,7 +716,7 @@ bool oxri_init() {
 		return false;
 	}
 
-	oxri_set_profile(handed_left, xrc_active_profile[handed_left ]);
+	oxri_set_profile(handed_left,  xrc_active_profile[handed_left ]);
 	oxri_set_profile(handed_right, xrc_active_profile[handed_right]);
 	return true;
 }
@@ -944,6 +944,7 @@ void oxri_update_interaction_profile() {
 	XrPath path[2];
 	xrStringToPath(xr_instance, "/user/hand/left",  &path[handed_left]);
 	xrStringToPath(xr_instance, "/user/hand/right", &path[handed_right]);
+
 	XrInteractionProfileState active_profile = { XR_TYPE_INTERACTION_PROFILE_STATE };
 	for (int32_t h = 0; h < handed_max; h++) {
 		if (XR_FAILED(xrGetCurrentInteractionProfile(xr_session, path[h], &active_profile)))

--- a/StereoKitC/xr_backends/openxr_input.cpp
+++ b/StereoKitC/xr_backends/openxr_input.cpp
@@ -403,6 +403,98 @@ bool oxri_init() {
 		binding_arr.clear();
 	}
 
+	// Bytedance PICO Neo3
+	// https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#XR_BD_controller_interaction
+	{
+		xrStringToPath(xr_instance, "/user/hand/left/input/x/click", &path_x1[0]);
+		xrStringToPath(xr_instance, "/user/hand/right/input/a/click", &path_x1[1]);
+		xrStringToPath(xr_instance, "/user/hand/left/input/y/click", &path_x2[0]);
+		xrStringToPath(xr_instance, "/user/hand/right/input/b/click", &path_x2[1]);
+
+		xrStringToPath(xr_instance, "/user/hand/left/input/trigger/value", &path_trigger[0]);
+		xrStringToPath(xr_instance, "/user/hand/right/input/trigger/value", &path_trigger[1]);
+		XrActionSuggestedBinding bindings[] = {
+			{ xrc_action_pose_grip,  path_pose_grip[0] }, { xrc_action_pose_grip,   path_pose_grip[1] },
+			{ xrc_action_pose_aim,   path_pose_aim[0] }, { xrc_action_pose_aim,    path_pose_aim[1] },
+			{ xrc_action_trigger,    path_trigger[0] }, { xrc_action_trigger,     path_trigger[1] },
+			{ xrc_action_grip,       path_grip[0] }, { xrc_action_grip,        path_grip[1] },
+			{ xrc_action_stick_x,    path_stick_x[0] }, { xrc_action_stick_x,     path_stick_x[1] },
+			{ xrc_action_stick_y,    path_stick_y[0] }, { xrc_action_stick_y,     path_stick_y[1] },
+			{ xrc_action_stick_click,path_stick_click[0] }, { xrc_action_stick_click, path_stick_click[1] },
+			{ xrc_action_menu,       path_menu[0] }, { xrc_action_menu,        path_menu[1] },
+			{ xrc_action_x1,         path_x1[0] }, { xrc_action_x1,          path_x1[1] },
+			{ xrc_action_x2,         path_x2[0] }, { xrc_action_x2,          path_x2[1] },
+		};
+		binding_arr.add_range(bindings, _countof(bindings));
+		if (xr_ext_available.EXT_palm_pose) {
+			binding_arr.add({ xrc_action_pose_palm, path_pose_palm[0] });
+			binding_arr.add({ xrc_action_pose_palm, path_pose_palm[1] });
+		}
+
+		xrStringToPath(xr_instance, "/interaction_profiles/bytedance/pico_neo3_controller", &profile_path);
+		suggested_binds.interactionProfile = profile_path;
+		suggested_binds.suggestedBindings = binding_arr.data;
+		suggested_binds.countSuggestedBindings = binding_arr.count;
+		if (XR_SUCCEEDED(xrSuggestInteractionProfileBindings(xr_instance, &suggested_binds))) {
+			// Orientation fix for PICO Neo3 controllers (untested)
+			xrc_profile_info_t info;
+			info.profile = profile_path;
+			info.name = "bytedance/pico_neo3_controller";
+			info.offset_rot[handed_left] = quat_identity;
+			info.offset_rot[handed_right] = quat_identity;
+			info.offset_pos[handed_left] = vec3_zero;
+			info.offset_pos[handed_right] = vec3_zero;
+			xrc_profile_offsets.add(info);
+		}
+		binding_arr.clear();
+	}
+
+	// Bytedance Pico 4
+	// https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#XR_BD_controller_interaction
+	{
+		xrStringToPath(xr_instance, "/user/hand/left/input/x/click", &path_x1[0]);
+		xrStringToPath(xr_instance, "/user/hand/right/input/a/click", &path_x1[1]);
+		xrStringToPath(xr_instance, "/user/hand/left/input/y/click", &path_x2[0]);
+		xrStringToPath(xr_instance, "/user/hand/right/input/b/click", &path_x2[1]);
+
+		xrStringToPath(xr_instance, "/user/hand/left/input/trigger/value", &path_trigger[0]);
+		xrStringToPath(xr_instance, "/user/hand/right/input/trigger/value", &path_trigger[1]);
+		XrActionSuggestedBinding bindings[] = {
+			{ xrc_action_pose_grip,  path_pose_grip[0] }, { xrc_action_pose_grip,   path_pose_grip[1] },
+			{ xrc_action_pose_aim,   path_pose_aim[0] }, { xrc_action_pose_aim,    path_pose_aim[1] },
+			{ xrc_action_trigger,    path_trigger[0] }, { xrc_action_trigger,     path_trigger[1] },
+			{ xrc_action_grip,       path_grip[0] }, { xrc_action_grip,        path_grip[1] },
+			{ xrc_action_stick_x,    path_stick_x[0] }, { xrc_action_stick_x,     path_stick_x[1] },
+			{ xrc_action_stick_y,    path_stick_y[0] }, { xrc_action_stick_y,     path_stick_y[1] },
+			{ xrc_action_stick_click,path_stick_click[0] }, { xrc_action_stick_click, path_stick_click[1] },
+			{ xrc_action_menu,       path_menu[0] },
+			{ xrc_action_x1,         path_x1[0] }, { xrc_action_x1,          path_x1[1] },
+			{ xrc_action_x2,         path_x2[0] }, { xrc_action_x2,          path_x2[1] },
+		};
+		binding_arr.add_range(bindings, _countof(bindings));
+		if (xr_ext_available.EXT_palm_pose) {
+			binding_arr.add({ xrc_action_pose_palm, path_pose_palm[0] });
+			binding_arr.add({ xrc_action_pose_palm, path_pose_palm[1] });
+		}
+
+		xrStringToPath(xr_instance, "/interaction_profiles/bytedance/pico4_controller", &profile_path);
+		suggested_binds.interactionProfile = profile_path;
+		suggested_binds.suggestedBindings = binding_arr.data;
+		suggested_binds.countSuggestedBindings = binding_arr.count;
+		if (XR_SUCCEEDED(xrSuggestInteractionProfileBindings(xr_instance, &suggested_binds))) {
+			// Orientation fix for pico 4 controllers
+			xrc_profile_info_t info;
+			info.profile = profile_path;
+			info.name = "bytedance/pico4_controller";
+			info.offset_rot[handed_left] = quat_identity;
+			info.offset_rot[handed_right] = quat_identity;
+			info.offset_pos[handed_left] = vec3_zero;
+			info.offset_pos[handed_right] = vec3_zero;
+			xrc_profile_offsets.add(info);
+		}
+		binding_arr.clear();
+	}
+
 	// htc/vive_controller
 	// https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#_htc_vive_controller_profile
 	{

--- a/Templates/SKTemplate_Maui/Platforms/Android/AndroidManifest.xml
+++ b/Templates/SKTemplate_Maui/Platforms/Android/AndroidManifest.xml
@@ -3,9 +3,12 @@
 	<uses-sdk android:minSdkVersion="29" android:targetSdkVersion="29" />
 
 	<application android:allowBackup="true" android:icon="@mipmap/appicon" android:roundIcon="@mipmap/appicon_round" android:supportsRtl="true">
+		<!-- Oculus -->
 		<meta-data android:name="com.oculus.supportedDevices" android:value="quest|quest2|questpro"/>
 		<meta-data android:name="com.oculus.handtracking.version" android:value="V2.0"/>
-		<meta-data android:name="pvr.app.type" android:value="vr" /> <!-- Pico -->
+		<!-- Pico -->
+		<meta-data android:name="pvr.app.type" android:value="vr" />
+		<meta-data android:name="handtracking" android:value="1" />
 	</application>
 
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />


### PR DESCRIPTION
Changes have been made to support the Pico 4 headset.

The standard/Oculus libopenxr_loader.so does not work on the Pico, its behaviour is to launch into a black display with the loading indicator.  Instead, Pico provide their own loader. The changes are to include it into the Nuget package and allow a developer to set `<SKOpenXRLoader>Pico</SKOpenXRLoader>` in the csproj file and have the Pico specific loader bundled in the app. The Oculus loader is still used during the xmake build, there's an assumption here that api surface is the same between the Pico and Oculus loader.

I have not been able to get the whole project to build in order to test the nuget packing works correctly. 

The controller profiles are added for the Pico 4 and Pico Neo 3.  Note that the xrGetCurrentInteractionProfile returns '/interaction_profiles/bytedance/pico_neo3_controller' instead of the expected '/interaction_profiles/bytedance/pico4_controller'. I don't think this is a StereoKit issue and the controllers appear to work OK.

Hand tracking was not working on the Pico due the joint at index 0 (palm center) being empty and so failing a valid check. The change to resolve this is to use the wrist joint (index 1). However, this change assumes that existing devices will always present a wrist joint. I can only confirm this is the case on the Pico 4 device.

Features confirmed working on the Pico 4 OS 5.5.0
- Pico's version of the loader.
- Pico 4 Controller with adjusted orientations.
- Hand tracking
- StereoKitTest UI demo tested
- Pass Through. Note that disabling pass through from within StereoKitTest causes a crash. Have yet to debug but suspect the crash is in the next FrameEnd cycle after the pass through is disabled.
