### PR TITLE
Fix mistake in docs

### DIFF
--- a/StereoKit/Systems/Hierarchy.cs
+++ b/StereoKit/Systems/Hierarchy.cs
@@ -65,7 +65,7 @@
 		/// <summary>Converts a world pose relative to the current 
 		/// hierarchy stack into local space!</summary>
 		/// <param name="worldPose">A pose in world space.</param>
-		/// <returns>The provided pose now in world space!</returns>
+		/// <returns>The provided pose now in local hierarchy space!</returns>
 		public static Pose ToLocal(Pose worldPose)
 			=> NativeAPI.hierarchy_to_local_pose(worldPose);
 


### PR DESCRIPTION
Fixes a minor mistake in the docs where the result type should be in local space, but the docs say World Space