### PR TITLE
fix: dlopen & dlopen2 arguments interpreted as absolute unless clearly specified as relative paths

### DIFF
--- a/StereoKit/Native/NativeLib.cs
+++ b/StereoKit/Native/NativeLib.cs
@@ -55,7 +55,7 @@ namespace StereoKit
 			const int RTLD_NOW = 2;
 			if (dlopen($"./runtimes/linux-{arch}/native/libStereoKitC.so", RTLD_NOW) != IntPtr.Zero) return true;
 			if (dlopen($"{AppDomain.CurrentDomain.BaseDirectory}/runtimes/linux-{arch}/native/libStereoKitC.so", RTLD_NOW) != IntPtr.Zero) return true;
-			if (dlopen("libStereoKitC.so", RTLD_NOW) != IntPtr.Zero) return true;
+			if (dlopen("./libStereoKitC.so", RTLD_NOW) != IntPtr.Zero) return true;
 			return false;
 		}
 
@@ -67,7 +67,7 @@ namespace StereoKit
 			const int RTLD_NOW = 2;
 			if (dlopen2($"./runtimes/linux-{arch}/native/libStereoKitC.so", RTLD_NOW) != IntPtr.Zero) return true;
 			if (dlopen2($"{AppDomain.CurrentDomain.BaseDirectory}/runtimes/linux-{arch}/native/libStereoKitC.so", RTLD_NOW) != IntPtr.Zero) return true;
-			if (dlopen2("libStereoKitC.so", RTLD_NOW) != IntPtr.Zero) return true;
+			if (dlopen2("./libStereoKitC.so", RTLD_NOW) != IntPtr.Zero) return true;
 			return false;
 		}
 	}


### PR DESCRIPTION
Here's a sample script to test with and without './'

```
using System;
using System.Runtime.InteropServices;

public class Program
{
    [DllImport("libdl.so")]
    public static extern IntPtr dlopen(string fileName, int flags);

    [DllImport("libdl.so")]
    public static extern IntPtr dlerror();

    public static void Main(string[] args)
    {
        IntPtr handle = dlopen("./libStereoKitC.so", 2);
        if (handle == IntPtr.Zero)
        {
            IntPtr error = dlerror();
            string message = Marshal.PtrToStringAnsi(error);
            Console.WriteLine($"Error: {message}");
        }
        else
        {
            Console.WriteLine("Library loaded successfully.");
        }
    }
}
```