### PR TITLE
fix: crashing `mouse_scroll` call from HoloLens 2 UWP

### DIFF
--- a/StereoKitC/platforms/uwp.cpp
+++ b/StereoKitC/platforms/uwp.cpp
@@ -436,9 +436,7 @@ void uwp_set_mouse(vec2 window_pos) {
 ///////////////////////////////////////////
 
 float uwp_get_scroll() {
-	if (ViewProvider::inst != nullptr) {
-		return ViewProvider::inst->mouse_scroll;
-	}
+	return ViewProvider::inst != nullptr ? ViewProvider::inst->mouse_scroll : 0;
 }
 
 ///////////////////////////////////////////

--- a/StereoKitC/platforms/uwp.cpp
+++ b/StereoKitC/platforms/uwp.cpp
@@ -436,11 +436,8 @@ void uwp_set_mouse(vec2 window_pos) {
 ///////////////////////////////////////////
 
 float uwp_get_scroll() {
-	try {
+	if (ViewProvider::inst != nullptr) {
 		return ViewProvider::inst->mouse_scroll;
-	}
-	catch (...) {
-		return 0;
 	}
 }
 

--- a/StereoKitC/platforms/uwp.cpp
+++ b/StereoKitC/platforms/uwp.cpp
@@ -436,7 +436,12 @@ void uwp_set_mouse(vec2 window_pos) {
 ///////////////////////////////////////////
 
 float uwp_get_scroll() {
-	return ViewProvider::inst->mouse_scroll;
+	try {
+		return ViewProvider::inst->mouse_scroll;
+	}
+	catch (...) {
+		return 0;
+	}
 }
 
 ///////////////////////////////////////////


### PR DESCRIPTION
Hey nick, so happy the newest updates came through! I tested this *early adopter* version on the HL2 and receive this native exception at the start (& every step after). Is a simple try/catch enough to handle this call or do you want to check for mouse availability elsewhere?