### PR TITLE
Don't blindly close the X display handle on linux shutdown

### DIFF
--- a/StereoKitC/platforms/linux.cpp
+++ b/StereoKitC/platforms/linux.cpp
@@ -498,7 +498,9 @@ void linux_stop_flat() {
 ///////////////////////////////////////////
 
 void linux_shutdown() {
-	XCloseDisplay(x_dpy);
+	if (x_dpy) { 
+		XCloseDisplay(x_dpy);
+	}
 	linux_swapchain_initialized = false;
 }
 


### PR DESCRIPTION
linux_shutdown() segfaults by trying to do a XCloseDisplay(NULL) in the cases where setup_x_window() wasn't called during init.