### PR TITLE
Don't define `JNI_OnLoad` for Android when compiled as a static library.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,6 +143,14 @@ else()
   message("-- Building with physics!")
 endif()
 
+# On Android, shared lib SK has a JNI_OnLoad, which can conflict with dev
+# provided JNI_OnLoad in apps that consume SK as a static library.
+if (SK_BUILD_SHARED_LIBS)
+  add_definitions("-DSK_BUILD_SHARED")
+else()
+  add_definitions("-DSK_BUILD_STATIC")
+endif()
+
 ###########################################
 ## Dependencies                          ##
 ###########################################

--- a/StereoKitC/StereoKitC.vcxproj
+++ b/StereoKitC/StereoKitC.vcxproj
@@ -68,7 +68,7 @@
       <LanguageStandard>stdcpp17</LanguageStandard>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <DisableSpecificWarnings>26812</DisableSpecificWarnings>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_WINDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_WINDLL;SK_BUILD_SHARED;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -87,7 +87,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <DisableSpecificWarnings>26812</DisableSpecificWarnings>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_WINDLL;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_WINDLL;SK_BUILD_SHARED;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/StereoKitC/StereoKitC_UWP/StereoKitC_UWP.vcxproj
+++ b/StereoKitC/StereoKitC_UWP/StereoKitC_UWP.vcxproj
@@ -93,7 +93,7 @@
       <!--Temporarily disable cppwinrt heap enforcement to work around xaml compiler generated std::shared_ptr use -->
       <AdditionalOptions Condition="'$(CppWinRTHeapEnforcement)'==''">/DWINRT_NO_MAKE_DETECTION %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>28204</DisableSpecificWarnings>
-      <PreprocessorDefinitions>_WINRT_DLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_WINRT_DLL;_CRT_SECURE_NO_WARNINGS;WINDOWS_UWP;SK_BUILD_SHARED;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalUsingDirectories>$(WindowsSDK_WindowsMetadata);$(AdditionalUsingDirectories)</AdditionalUsingDirectories>
     </ClCompile>
     <Link>
@@ -103,7 +103,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
     <ClCompile>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WINDOWS_UWP;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <AdditionalOptions>/ignore:4099 %(AdditionalOptions)</AdditionalOptions>
@@ -112,7 +112,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
     <ClCompile>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WINDOWS_UWP;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">true</CompileAsWinRT>
       <CompileAsWinRT Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">true</CompileAsWinRT>
     </ClCompile>

--- a/StereoKitC/platforms/android.cpp
+++ b/StereoKitC/platforms/android.cpp
@@ -33,6 +33,11 @@ system_t         *android_render_sys = nullptr;
 
 ///////////////////////////////////////////
 
+// When consumed as a static library, the user's app will need to provide its
+// own JNI_OnLoad function, which will then conflict with this one. So we only
+// provide this for shared libraries.
+#if defined(SK_BUILD_SHARED)
+
 extern "C" jint JNI_OnLoad(JavaVM* vm, void* reserved) {
 	android_vm = vm;
 	return JNI_VERSION_1_6;
@@ -40,6 +45,8 @@ extern "C" jint JNI_OnLoad(JavaVM* vm, void* reserved) {
 extern "C" jint JNI_OnLoad_L(JavaVM* vm, void* reserved) {
 	return JNI_OnLoad(vm, reserved);
 }
+
+#endif
 
 ///////////////////////////////////////////
 


### PR DESCRIPTION
This also adds `SK_BUILD_SHARED/STATIC` to the project defines.