### PR TITLE
Added support for `XR_EXT_hand_tracking_data_source`.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,10 +178,10 @@ endif()
 #### OpenXR - https://www.khronos.org/openxr/ ####
 if (SK_BUILD_OPENXR_LOADER)
   CPMAddPackage( # We're scraping the comment after the NAME for some other scripts
-    NAME openxr_loader # 1.0.27
-    VERSION 1.0.27
+    NAME openxr_loader # 1.0.28
+    VERSION 1.0.28
     GITHUB_REPOSITORY KhronosGroup/OpenXR-SDK
-    GIT_TAG "release-1.0.27"
+    GIT_TAG "release-1.0.28"
     OPTIONS
     "BUILD_WITH_SYSTEM_JSONCPP OFF"
     "DYNAMIC_LOADER ${SK_DYNAMIC_OPENXR}"

--- a/StereoKitC/hands/hand_oxr_articulated.cpp
+++ b/StereoKitC/hands/hand_oxr_articulated.cpp
@@ -80,6 +80,17 @@ void hand_oxra_init() {
 		XrHandTrackerCreateInfoEXT info = { XR_TYPE_HAND_TRACKER_CREATE_INFO_EXT };
 		info.hand         = h == handed_left ? XR_HAND_LEFT_EXT : XR_HAND_RIGHT_EXT;
 		info.handJointSet = XR_HAND_JOINT_SET_DEFAULT_EXT;
+
+		// Tell OpenXR we _only_ want real articulated hands, nothing simulated
+		// from controllers. Only works when EXT_hand_tracking_data_source is
+		// present.
+		XrHandTrackingDataSourceEXT     unobstructed = XR_HAND_TRACKING_DATA_SOURCE_UNOBSTRUCTED_EXT;
+		XrHandTrackingDataSourceInfoEXT data_source  = { XR_TYPE_HAND_TRACKING_DATA_SOURCE_INFO_EXT };
+		data_source.requestedDataSourceCount = 1;
+		data_source.requestedDataSources     = &unobstructed;
+		if (xr_ext_available.EXT_hand_tracking_data_source)
+			info.next = &data_source;
+
 		XrResult result = xr_extensions.xrCreateHandTrackerEXT(xr_session, &info, &oxra_hand_tracker[h]);
 		if (XR_FAILED(result)) {
 			log_warnf("xrCreateHandTrackerEXT failed: [%s]", openxr_string(result));

--- a/StereoKitC/xr_backends/openxr.cpp
+++ b/StereoKitC/xr_backends/openxr.cpp
@@ -466,31 +466,34 @@ bool openxr_init() {
 	// Key indicators are Windows+x64+(WMR or SteamVR), and skip if Ultraleap's hand
 	// tracking layer is present.
 	//
-	// TODO: Remove this when the hand tracking extension is improved.
+	// TODO: Remove this when the hand tracking data source extension is more
+	// generally available.
 #if defined(_M_X64) && (defined(SK_OS_WINDOWS) || defined(SK_OS_WINDOWS_UWP))
-	// We don't need to ask for the Ultraleap layer above so we don't have it
-	// stored anywhere. Gotta check it again.
-	bool     has_leap_layer = false;
-	uint32_t xr_layer_count = 0;
-	xrEnumerateApiLayerProperties(0, &xr_layer_count, nullptr);
-	XrApiLayerProperties *xr_layers = sk_malloc_t(XrApiLayerProperties, xr_layer_count);
-	for (uint32_t i = 0; i < xr_layer_count; i++) xr_layers[i] = { XR_TYPE_API_LAYER_PROPERTIES };
-	xrEnumerateApiLayerProperties(xr_layer_count, &xr_layer_count, xr_layers);
-	for (uint32_t i = 0; i < xr_layer_count; i++) {
-		if (strcmp(xr_layers[i].layerName, "XR_APILAYER_ULTRALEAP_hand_tracking") == 0) {
-			has_leap_layer = true;
-			break;
+	if (xr_ext_available.EXT_hand_tracking_data_source == false) {
+		// We don't need to ask for the Ultraleap layer above so we don't have it
+		// stored anywhere. Gotta check it again.
+		bool     has_leap_layer = false;
+		uint32_t xr_layer_count = 0;
+		xrEnumerateApiLayerProperties(0, &xr_layer_count, nullptr);
+		XrApiLayerProperties *xr_layers = sk_malloc_t(XrApiLayerProperties, xr_layer_count);
+		for (uint32_t i = 0; i < xr_layer_count; i++) xr_layers[i] = { XR_TYPE_API_LAYER_PROPERTIES };
+		xrEnumerateApiLayerProperties(xr_layer_count, &xr_layer_count, xr_layers);
+		for (uint32_t i = 0; i < xr_layer_count; i++) {
+			if (strcmp(xr_layers[i].layerName, "XR_APILAYER_ULTRALEAP_hand_tracking") == 0) {
+				has_leap_layer = true;
+				break;
+			}
 		}
-	}
-	sk_free(xr_layers);
+		sk_free(xr_layers);
 
-	// The Leap hand tracking layer seems to supercede the built-in extensions.
-	if (xr_ext_available.EXT_hand_tracking && has_leap_layer == false) {
-		if (strcmp(inst_properties.runtimeName, "Windows Mixed Reality Runtime") == 0 ||
-			strcmp(inst_properties.runtimeName, "SteamVR/OpenXR") == 0) {
-			log_diag("Rejecting OpenXR's provided hand tracking extension due to the suspicion that it is inadequate for StereoKit.");
-			xr_has_articulated_hands = false;
-			xr_has_hand_meshes       = false;
+		// The Leap hand tracking layer seems to supercede the built-in extensions.
+		if (xr_ext_available.EXT_hand_tracking && has_leap_layer == false) {
+			if (strcmp(inst_properties.runtimeName, "Windows Mixed Reality Runtime") == 0 ||
+				strcmp(inst_properties.runtimeName, "SteamVR/OpenXR") == 0) {
+				log_diag("Rejecting OpenXR's provided hand tracking extension due to the suspicion that it is inadequate for StereoKit.");
+				xr_has_articulated_hands = false;
+				xr_has_hand_meshes       = false;
+			}
 		}
 	}
 #endif

--- a/StereoKitC/xr_backends/openxr_extensions.h
+++ b/StereoKitC/xr_backends/openxr_extensions.h
@@ -125,6 +125,7 @@ namespace sk {
 #define FOR_EACH_EXT_ALL(_) \
 	_(KHR_composition_layer_depth,       true) \
 	_(EXT_hand_tracking,                 true) \
+	_(EXT_hand_tracking_data_source,     true) \
 	_(EXT_palm_pose,                     true) \
 	_(EXT_eye_gaze_interaction,          true) \
 	_(EXT_local_floor,                   true) \


### PR DESCRIPTION
At long last, just need a runtime to test it on now! This also updates openxr_loader to v1.0.28.

This does not immediately fix #652, but will once SteamVR implements the extension. Might still want to add an exception bypass if it takes too long.