### PR TITLE
Add `SKOpenXRLoaderFolder` and `SKShaderStandardInclude` to the SK MSBuild properties.

### DIFF
--- a/Examples/StereoKitTest/StereoKitTest_NetAndroid/StereoKitTest_NetAndroid.csproj
+++ b/Examples/StereoKitTest/StereoKitTest_NetAndroid/StereoKitTest_NetAndroid.csproj
@@ -9,6 +9,8 @@
 		<RootNamespace>StereoKitTest</RootNamespace>
 		<ReadOnlyProject>true</ReadOnlyProject>
 
+		<SKOpenXRLoaderFolder Condition="'$(OS)'!='Windows_NT'">/mnt/c/Tools/openxr_loaders/</SKOpenXRLoaderFolder>
+		<SKOpenXRLoaderFolder Condition="'$(OS)'=='Windows_NT'">C:/Tools/openxr_loaders/</SKOpenXRLoaderFolder>
 		<SKOpenXRLoader>Standard</SKOpenXRLoader>
 		<SKAssetFolder>..\..\Assets</SKAssetFolder>
 		<SKAssetDestination>Assets</SKAssetDestination>

--- a/StereoKit/SKShaders.targets
+++ b/StereoKit/SKShaders.targets
@@ -39,12 +39,16 @@
 		<PropertyGroup>
 			<SKOpt Condition="'$(Configuration)'=='Release'">-o3</SKOpt>
 			<SKOpt Condition="'$(Configuration)'=='Debug'">-d</SKOpt>
+			
+			<!-- Needs to be normalized for Linux, also a trailing '\' will act
+			     as an escape character for quotes. -->
+			<IncludeFolderNormalized>$([MSBuild]::NormalizeDirectory('$(SKShaderStandardInclude)').TrimEnd('\'))</IncludeFolderNormalized>
 		</PropertyGroup>
 
 		<!-- Setup metadata for custom build tool -->
 		<ItemGroup>
 			<SKShader Condition="'%(SKShader.RelFile)'!=''">
-				<Command>"$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)../tools/$(SKShadercExe)'))" $(SKOpt) -e -t xge -i "$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)../tools/'))include" -o "$([System.String]::Copy('$(IntermediateOutputPath)$(SKAssetDestination)/%(SKShader.RelFolder)').Replace('\','/'))" "%(SKShader.Identity)"</Command>
+				<Command>"$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)../tools/$(SKShadercExe)'))" $(SKOpt) -e -t xge -i "$(IncludeFolderNormalized)" -o "$([System.String]::Copy('$(IntermediateOutputPath)$(SKAssetDestination)/%(SKShader.RelFolder)').Replace('\','/'))" "%(SKShader.Identity)"</Command>
 				<Outputs>$(IntermediateOutputPath)$(SKAssetDestination)/%(SKShader.RelFile).sks</Outputs>
 				<RelativeName>%(SKShader.RelFile).sks</RelativeName>
 			</SKShader>

--- a/StereoKit/StereoKit.props
+++ b/StereoKit/StereoKit.props
@@ -1,15 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <Project>
 	<PropertyGroup>
-		<SKAssetFolder      Condition="'$(SKAssetFolder)'      == ''">Assets</SKAssetFolder>
-		<SKAssetDestination Condition="'$(SKAssetDestination)' == ''">$(SKAssetFolder)</SKAssetDestination>
-		<SKCopyAssets       Condition="'$(SKCopyAssets)'       == ''">True</SKCopyAssets>
-		<SKOpenXRLoader     Condition="'$(SKOpenXRLoader)'     == ''">Standard</SKOpenXRLoader>
-		<SKShowDebugVars    Condition="'$(SKShowDebugVars)'    == ''">false</SKShowDebugVars>
-		<SKAutoFindShaders  Condition="'$(SKAutoFindShaders)'  == ''">True</SKAutoFindShaders>
-
-		<!--Quest no longer uses a custom loader-->
-		<SKOpenXRLoader Condition="'$(SKOpenXRLoader.ToLower())' == 'oculus'">Standard</SKOpenXRLoader>
+		<SKAssetFolder           Condition="'$(SKAssetFolder)'           == ''">Assets</SKAssetFolder>
+		<SKAssetDestination      Condition="'$(SKAssetDestination)'      == ''">$(SKAssetFolder)</SKAssetDestination>
+		<SKCopyAssets            Condition="'$(SKCopyAssets)'            == ''">True</SKCopyAssets>
+		<SKOpenXRLoader          Condition="'$(SKOpenXRLoader)'          == ''">Standard</SKOpenXRLoader>
+		<SKShowDebugVars         Condition="'$(SKShowDebugVars)'         == ''">false</SKShowDebugVars>
+		<SKAutoFindShaders       Condition="'$(SKAutoFindShaders)'       == ''">True</SKAutoFindShaders>
+		<SKOpenXRLoaderFolder    Condition="'$(SKOpenXRLoaderFolder)'    == ''">$(ProjectDir)openxr_loader/</SKOpenXRLoaderFolder>
+		<SKShaderStandardInclude Condition="'$(SKShaderStandardInclude)' == ''">$(MSBuildThisFileDirectory)../tools/include/</SKShaderStandardInclude>
 	</PropertyGroup>
 	
 	<Target Name="StereoKit_Properties" BeforeTargets="BeforeBuild">
@@ -24,6 +23,12 @@
 			<SKBuildNET Condition="'$(TargetFrameworkIdentifier)'=='MonoAndroid'"  >Mono</SKBuildNET>
 			<SKBuildNET Condition="'$(TargetFrameworkIdentifier)'=='.NETFramework'">Framework</SKBuildNET>
 			<SKBuildNET Condition="'$(TargetPlatformIdentifier)'=='UAP'"           >UWP</SKBuildNET>
+
+			<SKOpenXRLoaderFolder>$([MSBuild]::NormalizePath('$(SKOpenXRLoaderFolder)'))</SKOpenXRLoaderFolder>
+			<SKShaderStandardInclude>$([MSBuild]::NormalizePath('$(SKShaderStandardInclude)'))</SKShaderStandardInclude>
+			
+			<!--Quest no longer uses a custom loader-->
+			<SKOpenXRLoader Condition="'$(SKOpenXRLoader.ToLower())' == 'oculus'">Standard</SKOpenXRLoader>
 		</PropertyGroup>
 
 		<Message Condition="'$(SKShowDebugVars)'=='true'" Importance="high" Text="[StereoKit NuGet] ____StereoKit MSBuild Variables____"/>
@@ -31,7 +36,9 @@
 		<Message Condition="'$(SKShowDebugVars)'=='true'" Importance="high" Text="[StereoKit NuGet] SKAssetDestination         : $(SKAssetDestination)"/>
 		<Message Condition="'$(SKShowDebugVars)'=='true'" Importance="high" Text="[StereoKit NuGet] SKCopyAssets               : $(SKCopyAssets)"/>
 		<Message Condition="'$(SKShowDebugVars)'=='true'" Importance="high" Text="[StereoKit NuGet] SKAutoFindShaders          : $(SKAutoFindShaders)"/>
+		<Message Condition="'$(SKShowDebugVars)'=='true'" Importance="high" Text="[StereoKit NuGet] SKShaderStandardInclude    : $(SKShaderStandardInclude)"/>
 		<Message Condition="'$(SKShowDebugVars)'=='true'" Importance="high" Text="[StereoKit NuGet] SKOpenXRLoader             : $(SKOpenXRLoader)"/>
+		<Message Condition="'$(SKShowDebugVars)'=='true'" Importance="high" Text="[StereoKit NuGet] SKOpenXRLoaderFolder       : $(SKOpenXRLoaderFolder)"/>
 		<Message Condition="'$(SKShowDebugVars)'=='true'" Importance="high" Text="[StereoKit NuGet] TargetFramework            : $(TargetFramework)"/>
 		<Message Condition="'$(SKShowDebugVars)'=='true'" Importance="high" Text="[StereoKit NuGet] TargetFrameworkIdentifier  : $(TargetFrameworkIdentifier)"/>
 		<Message Condition="'$(SKShowDebugVars)'=='true'" Importance="high" Text="[StereoKit NuGet] GetTargetPlatformIdentifier: $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)'))"/>

--- a/StereoKit/StereoKit.targets
+++ b/StereoKit/StereoKit.targets
@@ -9,8 +9,8 @@
 	<Target Name="StereoKit_Libraries" BeforeTargets="AfterBuild" AfterTargets="StereoKit_Properties" Condition="'$(OutputType)'!='Library' or '$(SKBuildPlatform)'=='Android'">
 		<Message Importance="high" Text="[StereoKit NuGet] Copying native libraries for .NET $(SKBuildNET) $(SKBuildPlatform)."/>
 		<Message Importance="high" Condition= "'$(SKBuildPlatform)'=='Android'" Text="[StereoKit NuGet] Using the $(SKOpenXRLoader) &lt;SKOpenXRLoader&gt; version of the Android OpenXR loader."/>
-		<Error Condition="'$(SKBuildPlatform)'=='Android' and '$(SKOpenXRLoader)'!='None' and !Exists('$(MSBuildThisFileDirectory)../android_openxr_loaders/arm64/$(SKOpenXRLoader.ToLower())/libopenxr_loader.so') and !Exists('$(ProjectDir)openxr_loader/$(SKOpenXRLoader)/libopenxr_loader.so')" Text="StereoKit could not find the Android OpenXR Loader indicated by &lt;SKOpenXRLoader&gt;! Please copy your platform specific libopenxr_loader.so file in this folder: $(ProjectDir)openxr_loader/[x64|arm64]/$(SKOpenXRLoader)/" />
-		
+		<Error Condition="'$(SKBuildPlatform)'=='Android' and '$(SKOpenXRLoader)'!='None' and !Exists('$(MSBuildThisFileDirectory)../android_openxr_loaders/arm64/$(SKOpenXRLoader.ToLower())/libopenxr_loader.so') and !Exists('$(MSBuildThisFileDirectory)../android_openxr_loaders/x64/$(SKOpenXRLoader.ToLower())/libopenxr_loader.so') and !Exists('$(SKOpenXRLoaderFolder)$(SKOpenXRLoader)/arm64/libopenxr_loader.so') and !Exists('$(SKOpenXRLoaderFolder)$(SKOpenXRLoader)/x64/libopenxr_loader.so')" Text="StereoKit could not find the Android OpenXR Loader indicated by &lt;SKOpenXRLoader&gt;! Please copy your platform specific libopenxr_loader.so file in this folder: $(SKOpenXRLoaderFolder)[x64|arm64]/$(SKOpenXRLoader)/" />
+
 		<!-- The managed .pdb is not copied by default, so we copy it here to
 		     enable debugging of the managed dll.-->
 		<Copy
@@ -61,10 +61,10 @@
 		<AndroidNativeLibrary Condition="'$(SKOpenXRLoader)'!='None'" Abi="x86_64" Include="$(MSBuildThisFileDirectory)../android_openxr_loaders/x64/$(SKOpenXRLoader.ToLower())/*.so">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</AndroidNativeLibrary>
-		<AndroidNativeLibrary Condition="'$(SKOpenXRLoader)'!='None'" Abi="arm64-v8a" Include="$(ProjectDir)openxr_loader/arm64/$(SKOpenXRLoader)/*.so">
+		<AndroidNativeLibrary Condition="'$(SKOpenXRLoader)'!='None'" Abi="arm64-v8a" Include="$(SKOpenXRLoaderFolder)arm64/$(SKOpenXRLoader)/*.so">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</AndroidNativeLibrary>
-		<AndroidNativeLibrary Condition="'$(SKOpenXRLoader)'!='None'" Abi="x86_64" Include="$(ProjectDir)openxr_loader/x64/$(SKOpenXRLoader)/*.so">
+		<AndroidNativeLibrary Condition="'$(SKOpenXRLoader)'!='None'" Abi="x86_64" Include="$(SKOpenXRLoaderFolder)x64/$(SKOpenXRLoader)/*.so">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</AndroidNativeLibrary>
 	</ItemGroup>

--- a/tools/Build-Nuget.ps1
+++ b/tools/Build-Nuget.ps1
@@ -3,17 +3,21 @@ param(
     [switch]$noTest = $false,
     [switch]$noBuild = $false,
     [string]$key = '',
-    [string]$saveKey = ''
+    [string]$saveKey = '',
+    [switch]$noLinux = $false,
+    [switch]$noWin32 = $false,
+    [switch]$noUWP = $false,
+    [switch]$noAndroid = $false
 )
 
 function Get-LineNumber { return $MyInvocation.ScriptLineNumber }
 function Get-ScriptName { return $MyInvocation.ScriptName }
 
 # In case we only want to build a subset of the package
-$buildWindows    = $true -and -not $noBuild
-$buildWindowsUWP = $true -and -not $noBuild
-$buildLinux      = $true -and -not $noBuild
-$buildAndroid    = $true -and -not $noBuild
+$buildWindows    = -not $noWin32 -and -not $noBuild
+$buildWindowsUWP = -not $noUWP -and -not $noBuild
+$buildLinux      = -not $noLinux -and -not $noBuild
+$buildAndroid    = -not $noAndroid -and -not $noBuild
 
 $clean = $true -and -not $noBuild
 


### PR DESCRIPTION
&lt;SKOpenXRLoaderFolder> can be used to specify a folder where you keep all your custom OpenXR Loaders. This will be checked in addition to the NuGet's openxr loader folder.

`$(SKShaderStandardInclude)` is also now provided so that MSBuild users can easily find the location of the NuGet's common shader include folder.