### PR TITLE
Fix for when swapchain gets set to zero, ensures a minimum of 1px to prevent crashes.

### DIFF
--- a/StereoKitC/platforms/android.cpp
+++ b/StereoKitC/platforms/android.cpp
@@ -3,6 +3,7 @@
 
 #include "../log.h"
 #include "../device.h"
+#include "../sk_math.h"
 #include "../xr_backends/openxr.h"
 #include "../systems/render.h"
 #include "../systems/system.h"
@@ -136,8 +137,8 @@ void android_create_swapchain() {
 ///////////////////////////////////////////
 
 void android_resize_swapchain() {
-	int32_t height = ANativeWindow_getWidth (android_window);
-	int32_t width  = ANativeWindow_getHeight(android_window);
+	int32_t height = maxi(1,ANativeWindow_getWidth (android_window));
+	int32_t width  = maxi(1,ANativeWindow_getHeight(android_window));
 
 	if (!android_swapchain_created || (width == sk_info.display_width && height == sk_info.display_height))
 		return;

--- a/StereoKitC/platforms/linux.cpp
+++ b/StereoKitC/platforms/linux.cpp
@@ -15,6 +15,7 @@
 #include "../_stereokit.h"
 #include "../device.h"
 #include "../log.h"
+#include "../sk_math.h"
 #include "../libraries/sk_gpu.h"
 #include "../libraries/sokol_time.h"
 #include "../libraries/unicode.h"
@@ -370,9 +371,12 @@ bool setup_x_window() {
 	Atom wm_delete = XInternAtom(x_dpy, "WM_DELETE_WINDOW", true);
 	XSetWMProtocols(x_dpy, x_win, &wm_delete, 1);
 
+	int32_t width  = maxi(1, sk_settings.flatscreen_width);
+	int32_t height = maxi(1, sk_settings.flatscreen_height);
+
 	skg_tex_fmt_ color_fmt = skg_tex_fmt_rgba32_linear;
 	skg_tex_fmt_ depth_fmt = (skg_tex_fmt_)render_preferred_depth_fmt();
-	linux_swapchain = skg_swapchain_create((void *) x_win, color_fmt, depth_fmt, sk_settings.flatscreen_width, sk_settings.flatscreen_height);
+	linux_swapchain = skg_swapchain_create((void *) x_win, color_fmt, depth_fmt, width, height);
 	linux_swapchain_initialized = true;
 	sk_info.display_width  = linux_swapchain.width;
 	sk_info.display_height = linux_swapchain.height;
@@ -443,8 +447,11 @@ bool linux_start_flat() {
 ///////////////////////////////////////////
 
 void linux_resize(int width, int height) {
+	width  = maxi(1, width);
+	height = maxi(1, height);
 	if (!linux_swapchain_initialized || (width == sk_info.display_width && height == sk_info.display_height))
 		return;
+
 	sk_info.display_width  = width;
 	sk_info.display_height = height;
 	device_data.display_width  = width;

--- a/StereoKitC/platforms/uwp.cpp
+++ b/StereoKitC/platforms/uwp.cpp
@@ -7,6 +7,7 @@
 #include "../stereokit.h"
 #include "../_stereokit.h"
 #include "../device.h"
+#include "../sk_math.h"
 #include "../asset_types/texture.h"
 #include "../libraries/sokol_time.h"
 #include "../libraries/stref.h"
@@ -384,23 +385,23 @@ private:
 	}
 
 	void HandleWindowSizeChanged() {
-		int outputWidth  = (int)dips_to_pixels(m_logicalWidth, m_DPI);
-		int outputHeight = (int)dips_to_pixels(m_logicalHeight, m_DPI);
+		int32_t output_width  = maxi(1,(int32_t)dips_to_pixels(m_logicalWidth,  m_DPI));
+		int32_t output_height = maxi(1,(int32_t)dips_to_pixels(m_logicalHeight, m_DPI));
 
 		DXGI_MODE_ROTATION rotation = ComputeDisplayRotation();
 
 		if (rotation == DXGI_MODE_ROTATION_ROTATE90 || rotation == DXGI_MODE_ROTATION_ROTATE270) {
-			int swap_tmp = outputWidth;
-			outputWidth  = outputHeight;
-			outputHeight = swap_tmp;
+			int swap_tmp = output_width;
+			output_width  = output_height;
+			output_height = swap_tmp;
 		}
 
-		if (outputWidth == sk_info.display_width && outputHeight == sk_info.display_height)
+		if (output_width == sk_info.display_width && output_height == sk_info.display_height)
 			return;
 
 		uwp_resize_pending = true;
-		uwp_resize_width   = outputWidth;
-		uwp_resize_height  = outputHeight;
+		uwp_resize_width   = output_width;
+		uwp_resize_height  = output_height;
 	}
 };
 ViewProvider *ViewProvider::inst = nullptr;
@@ -516,9 +517,12 @@ bool uwp_start_flat() {
 		Sleep(1);
 	}
 
+	int32_t width  = maxi(1, sk_settings.flatscreen_width);
+	int32_t height = maxi(1, sk_settings.flatscreen_height);
+
 	skg_tex_fmt_ color_fmt = skg_tex_fmt_rgba32_linear;
 	skg_tex_fmt_ depth_fmt = (skg_tex_fmt_)render_preferred_depth_fmt();
-	uwp_swapchain = skg_swapchain_create(uwp_window, color_fmt, skg_tex_fmt_none, sk_settings.flatscreen_width, sk_settings.flatscreen_height);
+	uwp_swapchain = skg_swapchain_create(uwp_window, color_fmt, skg_tex_fmt_none, width, height);
 	sk_info.display_width  = uwp_swapchain.width;
 	sk_info.display_height = uwp_swapchain.height;
 	device_data.display_width  = uwp_swapchain.width;

--- a/StereoKitC/platforms/win32.cpp
+++ b/StereoKitC/platforms/win32.cpp
@@ -50,8 +50,11 @@ const wchar_t* REG_VALUE_NAME = L"WindowLocation";
 ///////////////////////////////////////////
 
 void win32_resize(int width, int height) {
+	width  = maxi(1, width);
+	height = maxi(1, height);
 	if (win32_swapchain_initialized == false || (width == device_data.display_width && height == device_data.display_height))
 		return;
+
 	sk_info.display_width  = width;
 	sk_info.display_height = height;
 	device_data.display_width  = width;
@@ -253,8 +256,8 @@ bool win32_start_flat() {
 
 	RECT bounds;
 	GetClientRect(win32_window, &bounds);
-	int32_t width  = bounds.right  - bounds.left;
-	int32_t height = bounds.bottom - bounds.top;
+	int32_t width  = maxi(1, bounds.right  - bounds.left);
+	int32_t height = maxi(1, bounds.bottom - bounds.top);
 
 	skg_tex_fmt_ color_fmt = skg_tex_fmt_rgba32_linear;
 	skg_tex_fmt_ depth_fmt = (skg_tex_fmt_)render_preferred_depth_fmt();


### PR DESCRIPTION
An offscreen window (registry position from the previous session) was getting clamped on startup to a size of 0, and crashing swapchain creation.