### PR TITLE
Added a path for more graceful shutdown in the event of an exception. For #688

### DIFF
--- a/.github/workflows/verify_compile.yml
+++ b/.github/workflows/verify_compile.yml
@@ -48,7 +48,7 @@ jobs:
     - name: Install Prerequisites
       run: |
         sudo apt-get update
-        sudo apt-get install libfontconfig1-dev libgl1-mesa-dev libx11-xcb-dev libxfixes-dev libxcb-dri2-0-dev libxcb-glx0-dev libxcb-icccm4-dev libxcb-keysyms1-dev libxcb-randr0-dev libxrandr-dev libxxf86vm-dev mesa-common-dev
+        sudo apt-get install lld libfontconfig1-dev libgl1-mesa-dev libx11-xcb-dev libxfixes-dev libxcb-dri2-0-dev libxcb-glx0-dev libxcb-icccm4-dev libxcb-keysyms1-dev libxcb-randr0-dev libxrandr-dev libxxf86vm-dev mesa-common-dev
 
     - name: Build Native Linux x64
       run: cmake --workflow --preset Linuxx64Fast

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -141,7 +141,10 @@
         "CMAKE_SYSTEM_NAME": "Linux",
         "CMAKE_C_COMPILER": "clang",
         "CMAKE_CXX_COMPILER": "clang++",
-        "CMAKE_LINKER": "lld"
+        "CMAKE_LINKER": "lld",
+        "CMAKE_EXE_LINKER_FLAGS": "-fuse-ld=lld",
+        "CMAKE_SHARED_LINKER_FLAGS": "-fuse-ld=lld",
+        "CMAKE_MODULE_LINKER_FLAGS": "-fuse-ld=lld"
       },
       "condition": {
         "type": "equals",

--- a/Examples/StereoKitTest/Program.cs
+++ b/Examples/StereoKitTest/Program.cs
@@ -81,7 +81,6 @@ class Program
 		// Preload the StereoKit library for access to Time.Scale before
 		// initialization occurs.
 		SK.PreLoadLibrary();
-		Time.Scale = Tests.IsTesting ? 0 : 1;
 
 		SK.AddStepper<PassthroughFBExt>();
 		//SK.AddStepper<Win32PerformanceCounterExt>();
@@ -91,6 +90,8 @@ class Program
 		// Initialize StereoKit
 		if (!SK.Initialize(settings))
 			Environment.Exit(1);
+
+		Time.Scale = Tests.IsTesting ? 0 : 1;
 
 		Init();
 

--- a/Examples/StereoKitTest/Tools/PassthroughFBExt.cs
+++ b/Examples/StereoKitTest/Tools/PassthroughFBExt.cs
@@ -68,6 +68,7 @@ namespace StereoKit.Framework
 
 		public void Shutdown()
 		{
+			if (!Enabled) return;
 			Enabled = false;
 			DestroyPassthrough();
 		}

--- a/StereoKit/Native/NativeAPI.cs
+++ b/StereoKit/Native/NativeAPI.cs
@@ -15,6 +15,7 @@ namespace StereoKit
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void        sk_set_window(IntPtr window);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void        sk_set_window_xam(IntPtr window);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void        sk_shutdown();
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void        sk_shutdown_unsafe();
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void        sk_quit();
 		[return: MarshalAs(UnmanagedType.Bool)]
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern bool        sk_step([MarshalAs(UnmanagedType.FunctionPtr)] Action app_update);

--- a/StereoKit/SK.cs
+++ b/StereoKit/SK.cs
@@ -1,5 +1,4 @@
 ﻿using StereoKit.Framework;
-using System.Collections.Generic;
 using System;
 using System.Runtime.InteropServices;
 using System.Reflection;
@@ -172,10 +171,15 @@ namespace StereoKit
 
 			if (IsInitialized)
 			{
-				_steppers.Shutdown();
-				Default.Shutdown();
+				Cleanup();
 				NativeAPI.sk_shutdown();
 			}
+		}
+
+		static void Cleanup()
+		{
+			_steppers.Shutdown();
+			Default.Shutdown();
 		}
 
 		/// <summary>Lets StereoKit know it should quit! It'll finish the
@@ -229,13 +233,17 @@ namespace StereoKit
 		/// StereoKit shuts down.</param>
 		public static void Run(Action onStep = null, Action onShutdown = null)
 		{
-			_stepCallback = onStep;
-			_shutdownCallback = onShutdown;
+			_stepCallback     = onStep;
+			_shutdownCallback = ()=> {
+				onShutdown?.Invoke();
+				Cleanup();
+			};
+
 			try { NativeAPI.sk_run(_stepAction, _shutdownCallback); }
 			catch (Exception e)
 			{
 				// Clean up as much as we can, and toss the exception back up
-				onShutdown?.Invoke();
+				_shutdownCallback();
 				NativeAPI.sk_shutdown_unsafe();
 				throw e;
 			}

--- a/StereoKit/SK.cs
+++ b/StereoKit/SK.cs
@@ -231,7 +231,14 @@ namespace StereoKit
 		{
 			_stepCallback = onStep;
 			_shutdownCallback = onShutdown;
-			NativeAPI.sk_run(_stepAction, _shutdownCallback);
+			try { NativeAPI.sk_run(_stepAction, _shutdownCallback); }
+			catch (Exception e)
+			{
+				// Clean up as much as we can, and toss the exception back up
+				onShutdown?.Invoke();
+				NativeAPI.sk_shutdown_unsafe();
+				throw e;
+			}
 		}
 
 		/// <summary>This registers an instance of the `IStepper` type

--- a/StereoKitC/_stereokit.h
+++ b/StereoKitC/_stereokit.h
@@ -4,15 +4,12 @@
 
 namespace sk {
 
-extern const char   *sk_app_name;
-extern sk_settings_t sk_settings;
-extern system_info_t sk_info;
+void     sk_assert_thread_valid();
+bool32_t sk_has_stepped        ();
+bool32_t sk_is_initialized     ();
+void     sk_set_app_focus      (app_focus_ focus_state);
 
-extern app_focus_ sk_focus;
-extern bool32_t   sk_running;
-extern bool32_t   sk_initialized;
-extern bool32_t   sk_first_step;
-
-void sk_assert_thread_valid();
+const sk_settings_t* sk_get_settings_ref();
+system_info_t*       sk_get_info_ref();
 
 } // namespace sk

--- a/StereoKitC/asset_types/assets.cpp
+++ b/StereoKitC/asset_types/assets.cpp
@@ -300,7 +300,9 @@ void  assets_shutdown_check() {
 ///////////////////////////////////////////
 
 char *assets_file(const char *file_name) {
-	if (file_name == nullptr || sk_settings.assets_folder == nullptr || sk_settings.assets_folder[0] == '\0')
+	const sk_settings_t* settings = sk_get_settings_ref();
+
+	if (file_name == nullptr || settings->assets_folder == nullptr || settings->assets_folder[0] == '\0')
 		return string_copy(file_name);
 
 #if defined(SK_OS_WINDOWS) || defined(SK_OS_WINDOWS_UWP)
@@ -318,9 +320,9 @@ char *assets_file(const char *file_name) {
 		return string_copy(file_name);
 #endif
 
-	int   count  = snprintf(nullptr, 0, "%s/%s", sk_settings.assets_folder, file_name);
+	int   count  = snprintf(nullptr, 0, "%s/%s", settings->assets_folder, file_name);
 	char *result = sk_malloc_t(char, count + 1);
-	snprintf(result, count+1, "%s/%s", sk_settings.assets_folder, file_name);
+	snprintf(result, count+1, "%s/%s", settings->assets_folder, file_name);
 	return result;
 }
 
@@ -462,7 +464,7 @@ bool32_t assets_execute_gpu(bool32_t(*asset_job)(void *data), void *data) {
 
 			// if the app hasn't started stepping yet and this takes too long,
 			// the application may be off the gpu thread unintentionally.
-			if (sk_first_step == false && has_warned == false && stm_ms(stm_since(start)) > 4000) {
+			if (sk_has_stepped() == false && has_warned == false && stm_ms(stm_since(start)) > 4000) {
 				log_warn("A GPU asset is blocking its thread until the main thread is available, has async code accidentally shifted execution to a different thread since SK.Initialize?");
 				has_warned = true;
 			}

--- a/StereoKitC/backend.cpp
+++ b/StereoKitC/backend.cpp
@@ -19,8 +19,8 @@ backend_xr_type_ backend_xr_get_type() {
 		log_err("Unimplemented XR backend code") // <-- Haha, see what I did there? No semicolon! :D
 #endif
 	} else {
-		if (sk_settings.disable_flatscreen_mr_sim) return backend_xr_type_none;
-		else                                       return backend_xr_type_simulator;
+		if (sk_get_settings_ref()->disable_flatscreen_mr_sim) return backend_xr_type_none;
+		else                                                  return backend_xr_type_simulator;
 	}
 }
 

--- a/StereoKitC/hierarchy.cpp
+++ b/StereoKitC/hierarchy.cpp
@@ -10,53 +10,91 @@ namespace sk {
 
 ///////////////////////////////////////////
 
-array_t<hierarchy_item_t> hierarchy_stack       = {};
-bool32_t                  hierarchy_enabled     = false;
-bool32_t                  hierarchy_userenabled = true;
+struct hierarchy_item_t {
+	matrix   transform;
+	matrix   transform_inv;
+	bool32_t has_inverse;
+};
+
+struct hierarchy_state_t {
+	array_t<hierarchy_item_t> stack;
+	bool32_t                  enabled;
+	bool32_t                  userenabled;
+};
+static hierarchy_state_t local = {};
+
+///////////////////////////////////////////
+
+void hierarchy_init() {
+	local = {};
+	local.userenabled = true;
+}
+
+///////////////////////////////////////////
+
+void hierarchy_shutdown() {
+	local.stack.free();
+	local = {};
+}
+
+///////////////////////////////////////////
+
+void hierarchy_step() {
+	if (local.stack.count > 0) {
+		log_err("Render transform stack doesn't have matching begin/end calls!");
+		local.stack.clear();
+	}
+}
 
 ///////////////////////////////////////////
 
 void hierarchy_push(const matrix &transform) {
-	hierarchy_stack.add(hierarchy_item_t{transform, matrix_identity, false});
-	hierarchy_enabled = hierarchy_userenabled;
+	local.stack.add(hierarchy_item_t{transform, matrix_identity, false});
+	local.enabled = local.userenabled;
 
-	int32_t size = hierarchy_stack.count;
+	int32_t size = local.stack.count;
 	if (size > 1)
-		matrix_mul(hierarchy_stack[size - 1].transform, hierarchy_stack[size - 2].transform, hierarchy_stack[size - 1].transform);
+		matrix_mul(local.stack[size - 1].transform, local.stack[size - 2].transform, local.stack[size - 1].transform);
 }
 
 ///////////////////////////////////////////
 
 void hierarchy_pop() {
-	hierarchy_stack.pop();
-	if (hierarchy_stack.count == 0)
-		hierarchy_enabled = false;
+	local.stack.pop();
+	if (local.stack.count == 0)
+		local.enabled = false;
 }
 
 ///////////////////////////////////////////
 
 void hierarchy_set_enabled(bool32_t enabled) {
-	hierarchy_userenabled = enabled;
-	hierarchy_enabled = hierarchy_stack.count != 0 && hierarchy_userenabled;
+	local.userenabled = enabled;
+	local.enabled     = local.stack.count != 0 && local.userenabled;
 }
 
 ///////////////////////////////////////////
 
 bool32_t hierarchy_is_enabled() {
-	return hierarchy_userenabled;
+	return local.userenabled;
+}
+
+///////////////////////////////////////////
+
+bool32_t hierarchy_use_top() {
+	return local.enabled;
 }
 
 ///////////////////////////////////////////
 
 const matrix *hierarchy_to_world() {
-	return hierarchy_enabled ? &hierarchy_stack.last().transform : &matrix_identity;
+	return local.enabled ? &local.stack.last().transform : &matrix_identity;
 }
 
 ///////////////////////////////////////////
 
 const matrix *hierarchy_to_local() {
-	if (hierarchy_enabled) {
-		hierarchy_item_t &item = hierarchy_stack.last();
+	if (local.enabled) {
+		hierarchy_item_t &item = local.stack.last();
 		if (!item.has_inverse)
 			matrix_inverse(item.transform, item.transform_inv);
 		return &item.transform_inv;
@@ -123,6 +161,12 @@ pose_t hierarchy_to_world_pose(const pose_t &local_pose) {
 
 ray_t hierarchy_to_world_ray(ray_t local_ray) {
 	return matrix_transform_ray(*hierarchy_to_world(), local_ray);
+}
+
+///////////////////////////////////////////
+
+matrix hierarchy_top() {
+	return local.stack.last().transform;
 }
 
 } // namespace sk

--- a/StereoKitC/hierarchy.h
+++ b/StereoKitC/hierarchy.h
@@ -5,16 +5,15 @@
 
 namespace sk {
 
-struct hierarchy_item_t {
-	matrix transform;
-	matrix transform_inv;
-	bool32_t has_inverse;
-};
+
 
 ///////////////////////////////////////////
 
-extern array_t<hierarchy_item_t> hierarchy_stack;
-extern bool32_t                  hierarchy_enabled;
-extern bool32_t                  hierarchy_userenabled;
+void hierarchy_init    ();
+void hierarchy_shutdown();
+void hierarchy_step    ();
+
+matrix   hierarchy_top    ();
+bool32_t hierarchy_use_top();
 
 }

--- a/StereoKitC/platforms/android.cpp
+++ b/StereoKitC/platforms/android.cpp
@@ -52,13 +52,12 @@ extern "C" jint JNI_OnLoad_L(JavaVM* vm, void* reserved) {
 ///////////////////////////////////////////
 
 bool android_init() {
-	// don't allow flatscreen fallback on Android
-	sk_settings.no_flatscreen_fallback = true;
+	const sk_settings_t* settings = sk_get_settings_ref();
 
 	android_render_sys = systems_find("FrameRender");
-	android_activity   = (jobject)sk_settings.android_activity;
+	android_activity   = (jobject)settings->android_activity;
 	if (android_vm == nullptr)
-		android_vm = (JavaVM*)sk_settings.android_java_vm;
+		android_vm = (JavaVM*)settings->android_java_vm;
 
 	if (android_vm == nullptr || android_activity == nullptr) {
 		log_fail_reason(95, log_error, "Couldn't find Android's Java VM or Activity, you should load the StereoKitC library with something like Xamarin's JavaSystem.LoadLibrary, or manually assign it using sk_set_settings()");
@@ -110,7 +109,7 @@ bool android_init() {
 	// Android has no universally supported openxr_loader yet, so on this
 	// platform we don't static link it, and instead provide devs a way to ship
 	// other loaders.
-	if (sk_settings.display_preference == display_mode_mixedreality && dlopen("libopenxr_loader.so", RTLD_NOW) == nullptr) {
+	if (settings->display_preference == display_mode_mixedreality && dlopen("libopenxr_loader.so", RTLD_NOW) == nullptr) {
 		log_fail_reason(95, log_error, "openxr_loader failed to load!");
 		return false;
 	}
@@ -124,10 +123,8 @@ bool android_init() {
 void android_create_swapchain() {
 	skg_tex_fmt_ color_fmt = skg_tex_fmt_rgba32_linear;
 	skg_tex_fmt_ depth_fmt = (skg_tex_fmt_)render_preferred_depth_fmt();
-	android_swapchain = skg_swapchain_create(android_window, color_fmt, depth_fmt, sk_info.display_width, sk_info.display_height);
+	android_swapchain = skg_swapchain_create(android_window, color_fmt, depth_fmt, device_data.display_width, device_data.display_height);
 	android_swapchain_created = true;
-	sk_info.display_width  = android_swapchain.width;
-	sk_info.display_height = android_swapchain.height;
 	device_data.display_width  = android_swapchain.width;
 	device_data.display_height = android_swapchain.height;
 	render_update_projection();
@@ -140,13 +137,11 @@ void android_resize_swapchain() {
 	int32_t height = maxi(1,ANativeWindow_getWidth (android_window));
 	int32_t width  = maxi(1,ANativeWindow_getHeight(android_window));
 
-	if (!android_swapchain_created || (width == sk_info.display_width && height == sk_info.display_height))
+	if (!android_swapchain_created || (width == device_data.display_width && height == device_data.display_height))
 		return;
 
 	log_diagf("Resized swapchain: %dx%d", width, height);
 	skg_swapchain_resize(&android_swapchain, width, height);
-	sk_info.display_width  = width;
-	sk_info.display_height = height;
 	device_data.display_width  = width;
 	device_data.display_height = height;
 	render_update_projection();
@@ -181,7 +176,6 @@ bool android_start_post_xr() {
 ///////////////////////////////////////////
 
 bool android_start_flat() {
-	sk_info.display_type      = display_opaque;
 	device_data.display_blend = display_blend_opaque;
 	if (android_window) {
 		android_create_swapchain();

--- a/StereoKitC/platforms/android.cpp
+++ b/StereoKitC/platforms/android.cpp
@@ -127,7 +127,7 @@ void android_create_swapchain() {
 	android_swapchain_created = true;
 	device_data.display_width  = android_swapchain.width;
 	device_data.display_height = android_swapchain.height;
-	render_update_projection();
+
 	log_diagf("Created swapchain: %dx%d color:%s depth:%s", android_swapchain.width, android_swapchain.height, render_fmt_name((tex_format_)color_fmt), render_fmt_name((tex_format_)depth_fmt));
 }
 

--- a/StereoKitC/platforms/platform.cpp
+++ b/StereoKitC/platforms/platform.cpp
@@ -46,7 +46,7 @@ bool platform_init() {
 	// Initialize graphics
 #if defined(SK_XR_OPENXR)
 	void *luid = settings->display_preference == display_mode_mixedreality
-		? openxr_get_luid() 
+		? openxr_get_luid()
 		: nullptr;
 #else
 	void *luid = nullptr;

--- a/StereoKitC/platforms/platform.cpp
+++ b/StereoKitC/platforms/platform.cpp
@@ -41,9 +41,11 @@ bool platform_init() {
 		return false;
 	}
 
+	const sk_settings_t *settings = sk_get_settings_ref();
+
 	// Initialize graphics
 #if defined(SK_XR_OPENXR)
-	void *luid = sk_get_settings().display_preference == display_mode_mixedreality
+	void *luid = settings->display_preference == display_mode_mixedreality
 		? openxr_get_luid() 
 		: nullptr;
 #else
@@ -56,7 +58,7 @@ bool platform_init() {
 		case skg_log_critical: log_errf ("[<~mag>sk_gpu<~clr>] %s", text); break;
 		}
 	});
-	if (skg_init(sk_app_name, luid) <= 0) {
+	if (skg_init(settings->app_name, luid) <= 0) {
 		log_fail_reason(95, log_error, "Failed to initialize sk_gpu!");
 		return false;
 	}
@@ -64,7 +66,7 @@ bool platform_init() {
 
 	// Convert from the legacy display_mode_ type
 	display_type_ display_type = display_type_none;
-	switch (sk_get_settings().display_preference) {
+	switch (settings->display_preference) {
 	case display_mode_flatscreen:   display_type = display_type_flatscreen; break;
 	case display_mode_mixedreality: display_type = display_type_stereo;     break;
 	case display_mode_none:         display_type = display_type_none;       break;
@@ -72,7 +74,7 @@ bool platform_init() {
 
 	// Start up the current mode!
 	if (!platform_set_mode(display_type)) {
-		if (!sk_settings.no_flatscreen_fallback && display_type != display_type_flatscreen) {
+		if (!settings->no_flatscreen_fallback && display_type != display_type_flatscreen) {
 			log_clear_any_fail_reason();
 			log_infof("Couldn't create a stereo display, falling back to flatscreen");
 			if (!platform_set_mode(display_type_flatscreen))
@@ -193,8 +195,8 @@ bool platform_set_mode(display_type_ mode) {
 #elif defined(SK_OS_WEB)
 		result = web_start_flat    ();
 #endif
-		if (sk_settings.disable_flatscreen_mr_sim) none_init();
-		else                                       simulator_init();
+		if (sk_get_settings_ref()->disable_flatscreen_mr_sim) none_init();
+		else                                                  simulator_init();
 	}
 
 	return result;
@@ -237,8 +239,8 @@ void platform_step_begin() {
 		web_step_begin_flat    ();
 #endif
 		input_step();
-		if (sk_settings.disable_flatscreen_mr_sim) none_step_begin();
-		else                                       simulator_step_begin();
+		if (sk_get_settings_ref()->disable_flatscreen_mr_sim) none_step_begin();
+		else                                                  simulator_step_begin();
 	} break;
 	}
 	platform_utils_update();
@@ -256,8 +258,8 @@ void platform_step_end() {
 #endif
 		break;
 	case display_type_flatscreen: {
-		if (sk_settings.disable_flatscreen_mr_sim) none_step_end();
-		else                                       simulator_step_end();
+		if (sk_get_settings_ref()->disable_flatscreen_mr_sim) none_step_end();
+		else                                                  simulator_step_end();
 #if   defined(SK_OS_ANDROID)
 		android_step_end_flat();
 #elif defined(SK_OS_LINUX)
@@ -285,8 +287,8 @@ void platform_stop_mode() {
 #endif
 		break;
 	case display_type_flatscreen: {
-		if (sk_settings.disable_flatscreen_mr_sim) none_shutdown();
-		else                                       simulator_shutdown();
+		if (sk_get_settings_ref()->disable_flatscreen_mr_sim) none_shutdown();
+		else                                                  simulator_shutdown();
 #if   defined(SK_OS_ANDROID)
 		android_stop_flat();
 #elif defined(SK_OS_LINUX)

--- a/StereoKitC/platforms/web.cpp
+++ b/StereoKitC/platforms/web.cpp
@@ -142,10 +142,8 @@ web_key_map_t web_keymap[] = {
 ///////////////////////////////////////////
 
 WEB_EXPORT void sk_web_canvas_resize(int32_t width, int32_t height) {
-	if (!web_swapchain_initialized || (width == sk_info.display_width && height == sk_info.display_height))
+	if (!web_swapchain_initialized || (width == device_data.display_width && height == device_data.display_height))
 		return;
-	sk_info.display_width  = width;
-	sk_info.display_height = height;
 	device_data.display_width  = width;
 	device_data.display_height = height;
 	log_diagf("Resized to: %d<~BLK>x<~clr>%d", width, height);
@@ -181,16 +179,15 @@ void web_shutdown() {
 ///////////////////////////////////////////
 
 bool web_start_flat() {
-	sk_info.display_type      = display_opaque;
 	device_data.display_blend = display_blend_opaque;
 
 	skg_tex_fmt_ color_fmt = skg_tex_fmt_rgba32_linear;
 	skg_tex_fmt_ depth_fmt = (skg_tex_fmt_)render_preferred_depth_fmt(); // skg_tex_fmt_depthstencil
 
-	web_swapchain = skg_swapchain_create(nullptr, color_fmt, depth_fmt, sk_settings.flatscreen_width, sk_settings.flatscreen_height);
+	const sk_settings_t *settings = sk_get_settings_ref();
+
+	web_swapchain = skg_swapchain_create(nullptr, color_fmt, depth_fmt, settings->flatscreen_width, settings->flatscreen_height);
 	web_swapchain_initialized = true;
-	sk_info.display_width  = web_swapchain.width;
-	sk_info.display_height = web_swapchain.height;
 	device_data.display_width  = web_swapchain.width;
 	device_data.display_height = web_swapchain.height;
 	

--- a/StereoKitC/platforms/win32.cpp
+++ b/StereoKitC/platforms/win32.cpp
@@ -276,7 +276,6 @@ bool win32_start_flat() {
 	tex_release(zbuffer);
 
 	log_diagf("Created swapchain: %dx%d color:%s depth:%s", win32_swapchain.width, win32_swapchain.height, render_fmt_name((tex_format_)color_fmt), render_fmt_name((tex_format_)depth_fmt));
-	render_update_projection();
 
 	return true;
 }

--- a/StereoKitC/platforms/win32.cpp
+++ b/StereoKitC/platforms/win32.cpp
@@ -55,8 +55,6 @@ void win32_resize(int width, int height) {
 	if (win32_swapchain_initialized == false || (width == device_data.display_width && height == device_data.display_height))
 		return;
 
-	sk_info.display_width  = width;
-	sk_info.display_height = height;
 	device_data.display_width  = width;
 	device_data.display_height = height;
 	log_diagf("Resized to: %d<~BLK>x<~clr>%d", width, height);
@@ -78,12 +76,12 @@ void win32_physical_key_interact() {
 
 bool win32_window_message_common(UINT message, WPARAM wParam, LPARAM lParam) {
 	switch(message) {
-	case WM_LBUTTONDOWN: if (sk_focus == app_focus_active) input_key_inject_press  (key_mouse_left);   return true;
-	case WM_LBUTTONUP:   if (sk_focus == app_focus_active) input_key_inject_release(key_mouse_left);   return true;
-	case WM_RBUTTONDOWN: if (sk_focus == app_focus_active) input_key_inject_press  (key_mouse_right);  return true;
-	case WM_RBUTTONUP:   if (sk_focus == app_focus_active) input_key_inject_release(key_mouse_right);  return true;
-	case WM_MBUTTONDOWN: if (sk_focus == app_focus_active) input_key_inject_press  (key_mouse_center); return true;
-	case WM_MBUTTONUP:   if (sk_focus == app_focus_active) input_key_inject_release(key_mouse_center); return true;
+	case WM_LBUTTONDOWN: if (sk_app_focus() == app_focus_active) input_key_inject_press  (key_mouse_left);   return true;
+	case WM_LBUTTONUP:   if (sk_app_focus() == app_focus_active) input_key_inject_release(key_mouse_left);   return true;
+	case WM_RBUTTONDOWN: if (sk_app_focus() == app_focus_active) input_key_inject_press  (key_mouse_right);  return true;
+	case WM_RBUTTONUP:   if (sk_app_focus() == app_focus_active) input_key_inject_release(key_mouse_right);  return true;
+	case WM_MBUTTONDOWN: if (sk_app_focus() == app_focus_active) input_key_inject_press  (key_mouse_center); return true;
+	case WM_MBUTTONUP:   if (sk_app_focus() == app_focus_active) input_key_inject_release(key_mouse_center); return true;
 	case WM_XBUTTONDOWN: input_key_inject_press  (GET_XBUTTON_WPARAM(wParam) == XBUTTON1 ? key_mouse_back : key_mouse_forward); return true;
 	case WM_XBUTTONUP:   input_key_inject_release(GET_XBUTTON_WPARAM(wParam) == XBUTTON1 ? key_mouse_back : key_mouse_forward); return true;
 	case WM_KEYDOWN:     input_key_inject_press  ((key_)wParam); win32_physical_key_interact(); if ((key_)wParam == key_del) input_text_inject_char(0x7f); return true;
@@ -91,7 +89,7 @@ bool win32_window_message_common(UINT message, WPARAM wParam, LPARAM lParam) {
 	case WM_SYSKEYDOWN:  input_key_inject_press  ((key_)wParam); win32_physical_key_interact(); return true;
 	case WM_SYSKEYUP:    input_key_inject_release((key_)wParam); win32_physical_key_interact(); return true;
 	case WM_CHAR:        input_text_inject_char   ((uint32_t)wParam); return true;
-	case WM_MOUSEWHEEL:  if (sk_focus == app_focus_active) win32_scroll += (short)HIWORD(wParam); return true;
+	case WM_MOUSEWHEEL:  if (sk_app_focus() == app_focus_active) win32_scroll += (short)HIWORD(wParam); return true;
 	default: return false;
 	}
 }
@@ -114,7 +112,7 @@ bool win32_start_pre_xr() {
 ///////////////////////////////////////////
 
 bool win32_start_post_xr() {
-	wchar_t *app_name_w = platform_to_wchar(sk_app_name);
+	wchar_t *app_name_w = platform_to_wchar(sk_get_settings_ref()->app_name);
 
 	// Create a window just to grab input
 	WNDCLASSW wc = {0}; 
@@ -170,19 +168,20 @@ void win32_shutdown() {
 ///////////////////////////////////////////
 
 bool win32_start_flat() {
-	sk_info.display_type      = display_opaque;
+	const sk_settings_t* settings = sk_get_settings_ref();
+
 	device_data.display_blend = display_blend_opaque;
 
-	wchar_t *app_name_w = platform_to_wchar(sk_app_name);
+	wchar_t *app_name_w = platform_to_wchar(settings->app_name);
 
 	WNDCLASSW wc = {0};
 	wc.lpfnWndProc   = [](HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam) {
 		if (!win32_window_message_common(message, wParam, lParam)) {
 			switch(message) {
 			case WM_CLOSE:      sk_quit(); PostQuitMessage(0);   break;
-			case WM_SETFOCUS:   sk_focus = app_focus_active;     break;
-			case WM_KILLFOCUS:  sk_focus = app_focus_background; break;
-			case WM_MOUSEWHEEL: if (sk_focus == app_focus_active) win32_scroll += (short)HIWORD(wParam); break;
+			case WM_SETFOCUS:   sk_set_app_focus(app_focus_active);     break;
+			case WM_KILLFOCUS:  sk_set_app_focus(app_focus_background); break;
+			case WM_MOUSEWHEEL: if (sk_app_focus() == app_focus_active) win32_scroll += (short)HIWORD(wParam); break;
 			case WM_SYSCOMMAND: {
 				// Has the user pressed the restore/'un-maximize' button?
 				// WM_SIZE happens -after- this event, and contains the new size.
@@ -229,14 +228,14 @@ bool win32_start_flat() {
 		RegQueryValueExW(reg_key, REG_VALUE_NAME, 0, nullptr, (BYTE*)&rect, &data_size);
 		RegCloseKey     (reg_key);
 	} else {
-		rect.left   = sk_settings.flatscreen_pos_x;
-		rect.right  = sk_settings.flatscreen_pos_x + sk_settings.flatscreen_width;
-		rect.top    = sk_settings.flatscreen_pos_y;
-		rect.bottom = sk_settings.flatscreen_pos_y + sk_settings.flatscreen_height;
+		rect.left   = settings->flatscreen_pos_x;
+		rect.right  = settings->flatscreen_pos_x + settings->flatscreen_width;
+		rect.top    = settings->flatscreen_pos_y;
+		rect.bottom = settings->flatscreen_pos_y + settings->flatscreen_height;
 		AdjustWindowRect(&rect, WS_OVERLAPPEDWINDOW | WS_VISIBLE, false);
 	}
-	if (rect.right == rect.left) rect.right  = rect.left + sk_settings.flatscreen_width;
-	if (rect.top == rect.bottom) rect.bottom = rect.top  + sk_settings.flatscreen_height;
+	if (rect.right == rect.left)   rect.right  = rect.left + settings->flatscreen_width;
+	if (rect.top   == rect.bottom) rect.bottom = rect.top  + settings->flatscreen_height;
 	
 	win32_window = CreateWindowW(
 		app_name_w,
@@ -266,13 +265,11 @@ bool win32_start_flat() {
 #endif
 	win32_swapchain = skg_swapchain_create(win32_window, color_fmt, skg_tex_fmt_none, width, height);
 	win32_swapchain_initialized = true;
-	sk_info.display_width  = win32_swapchain.width;
-	sk_info.display_height = win32_swapchain.height;
 	device_data.display_width  = win32_swapchain.width;
 	device_data.display_height = win32_swapchain.height;
 	win32_target = tex_create(tex_type_rendertarget, tex_format_rgba32);
 	tex_set_id       (win32_target, "sk/platform/swapchain");
-	tex_set_color_arr(win32_target, sk_info.display_width, sk_info.display_height, nullptr, 1, nullptr, win32_multisample);
+	tex_set_color_arr(win32_target, win32_swapchain.width, win32_swapchain.height, nullptr, 1, nullptr, win32_multisample);
 
 	tex_t zbuffer = tex_add_zbuffer (win32_target, (tex_format_)depth_fmt);
 	tex_set_id (zbuffer, "sk/platform/swapchain_zbuffer");
@@ -304,7 +301,7 @@ void win32_stop_flat() {
 
 	if (win32_icon)   DestroyIcon  (win32_icon);
 	if (win32_window) DestroyWindow(win32_window);
-	wchar_t* app_name_w = platform_to_wchar(sk_app_name);
+	wchar_t* app_name_w = platform_to_wchar(sk_get_settings_ref()->app_name);
 	UnregisterClassW(app_name_w, win32_hinst);
 	sk_free(app_name_w);
 

--- a/StereoKitC/sk_math.cpp
+++ b/StereoKitC/sk_math.cpp
@@ -190,7 +190,7 @@ void matrix_mul(const matrix &a, const matrix &b, matrix &out_matrix) {
 
 ///////////////////////////////////////////
 
-void matrix_mul(const matrix &a, const matrix &b, DirectX::XMMATRIX &out_matrix) {
+void matrix_mul(matrix a, matrix b, DirectX::XMMATRIX &out_matrix) {
 	XMMATRIX mat_a, mat_b;
 	math_matrix_to_fast(a, &mat_a);
 	math_matrix_to_fast(b, &mat_b);

--- a/StereoKitC/sk_math_dx.h
+++ b/StereoKitC/sk_math_dx.h
@@ -13,7 +13,7 @@
 
 namespace sk {
 	
-void matrix_mul(const matrix &a, const matrix &b, DirectX::XMMATRIX &out_matrix);
+void matrix_mul(matrix a, matrix b, DirectX::XMMATRIX &out_matrix);
 void matrix_mul(const matrix &a, const DirectX::XMMATRIX &b, DirectX::XMMATRIX &out_matrix);
 vec3 matrix_mul_direction(const DirectX::XMMATRIX &transform, const vec3 &direction);
 

--- a/StereoKitC/stereokit.cpp
+++ b/StereoKitC/stereokit.cpp
@@ -29,122 +29,69 @@ namespace sk {
 
 ///////////////////////////////////////////
 
-const char   *sk_app_name;
-void        (*sk_app_step_func)(void);
-sk_settings_t sk_settings    = {};
-system_info_t sk_info        = {};
-app_focus_    sk_focus       = app_focus_active;
-bool32_t      sk_running     = false;
-bool32_t      sk_stepping    = false;
-bool32_t      sk_initialized = false;
-bool32_t      sk_first_step  = false;
-thrd_id_t     sk_init_thread = {};
+struct sk_state_t {
+	void        (*app_step_func)(void);
+	sk_settings_t settings;
+	system_info_t info ;
+	app_focus_    focus;
+	bool32_t      running;
+	bool32_t      stepping;
+	bool32_t      initialized;
+	bool32_t      first_step ;
+	thrd_id_t     init_thread;
 
-double  sk_timev_scale    = 1;
-float   sk_timevf         = 0;
-double  sk_timev          = 0;
-float   sk_timevf_us      = 0;
-double  sk_timev_us       = 0;
-double  sk_time_start     = 0;
-double  sk_timev_step     = 0;
-float   sk_timev_stepf    = 0;
-double  sk_timev_step_us  = 0;
-float   sk_timev_stepf_us = 0;
-uint64_t sk_timev_raw     = 0;
+	double   timev_scale;
+	float    timevf;
+	double   timev;
+	float    timevf_us;
+	double   timev_us;
+	double   time_start;
+	double   timev_step;
+	float    timev_stepf;
+	double   timev_step_us;
+	float    timev_stepf_us;
+	uint64_t timev_raw;
 
-uint64_t  app_init_time = 0;
-system_t *app_system    = nullptr;
+	uint64_t  app_init_time;
+	system_t *app_system;
+};
+static sk_state_t local;
 
 ///////////////////////////////////////////
 
 void sk_step_timer();
-
-///////////////////////////////////////////
-
-sk_settings_t sk_get_settings() {
-	return sk_settings;
-}
-
-///////////////////////////////////////////
-
-system_info_t sk_system_info() {
-	return sk_info;
-}
-
-///////////////////////////////////////////
-
-const char *sk_version_name() {
-	return SK_VERSION " "
-#if defined(SK_OS_WEB)
-		"Web"
-#elif defined(SK_OS_ANDROID)
-		"Android"
-#elif defined(SK_OS_LINUX)
-		"Linux"
-#elif defined(SK_OS_WINDOWS)
-		"Win32"
-#elif defined(SK_OS_WINDOWS_UWP)
-		"UWP"
-#else
-		"MysteryPlatform"
-#endif
-		
-		" "
-		
-#if defined(__x86_64__) || defined(_M_X64)
-		"x64"
-#elif defined(__aarch64__) || defined(_M_ARM64)
-		"ARM64"
-#elif defined(_M_ARM)
-		"ARM"
-#elif defined(i386) || defined(__i386__) || defined(__i386) || defined(_M_IX86)
-		"x86"
-#else
-		"MysteryArchitecture"
-#endif
-	;
-}
-
-///////////////////////////////////////////
-
-uint64_t sk_version_id() {
-	return SK_VERSION_ID;
-}
-
-///////////////////////////////////////////
-
-app_focus_ sk_app_focus() {
-	return sk_focus;
-}
-
-///////////////////////////////////////////
-
-void sk_app_step() {
-	if (sk_app_step_func != nullptr)
-		sk_app_step_func();
-}
+void sk_app_step();
 
 ///////////////////////////////////////////
 
 bool32_t sk_init(sk_settings_t settings) {
-	sk_settings    = settings;
-	sk_app_name    = sk_settings.app_name == nullptr ? "StereoKit App" : sk_settings.app_name;
-	sk_init_thread = thrd_id_current();
-	if (sk_settings.log_filter != log_none)
-		log_set_filter(sk_settings.log_filter);
+	local = {};
+	local.timev_scale = 1;
+
+	local.settings    = settings;
+	local.init_thread = thrd_id_current();
+	if (local.settings.log_filter != log_none)
+		log_set_filter(local.settings.log_filter);
 
 	// Set some default values
-	if (sk_settings.flatscreen_width  == 0)
-		sk_settings.flatscreen_width  = 1280;
-	if (sk_settings.flatscreen_height == 0)
-		sk_settings.flatscreen_height = 720;
-	if (sk_settings.render_scaling == 0)
-		sk_settings.render_scaling = 1;
-	if (sk_settings.render_multisample == 0)
-		sk_settings.render_multisample = 1;
+	if (local.settings.app_name == nullptr)
+		local.settings.app_name = "StereoKit App";
+	if (local.settings.flatscreen_width  == 0)
+		local.settings.flatscreen_width  = 1280;
+	if (local.settings.flatscreen_height == 0)
+		local.settings.flatscreen_height = 720;
+	if (local.settings.render_scaling == 0)
+		local.settings.render_scaling = 1;
+	if (local.settings.render_multisample == 0)
+		local.settings.render_multisample = 1;
 
-	render_set_scaling    (sk_settings.render_scaling);
-	render_set_multisample(sk_settings.render_multisample);
+#if defined(SK_OS_ANDROID)
+	// don't allow flatscreen fallback on Android
+	local.settings.no_flatscreen_fallback = true;
+#endif
+
+	render_set_scaling    (local.settings.render_scaling);
+	render_set_multisample(local.settings.render_multisample);
 
 	log_diagf("Initializing StereoKit v%s...", sk_version_name());
 
@@ -319,26 +266,14 @@ bool32_t sk_init(sk_settings_t settings) {
 	sys_app.func_step             = sk_app_step;
 	systems_add(&sys_app);
 
-	sk_initialized = systems_initialize();
-	if (!sk_initialized) log_show_any_fail_reason();
+	local.initialized = systems_initialize();
+	if (!local.initialized) log_show_any_fail_reason();
 	else                 log_clear_any_fail_reason();
 
-	app_system    = systems_find("App");
-	app_init_time = stm_now();
-	sk_running    = sk_initialized;
-	return sk_initialized;
-}
-
-///////////////////////////////////////////
-
-void sk_set_window(void *window) {
-	platform_set_window(window);
-}
-
-///////////////////////////////////////////
-
-void sk_set_window_xam(void *window) {
-	platform_set_window_xam(window);
+	local.app_system    = systems_find("App");
+	local.app_init_time = stm_now();
+	local.running       = local.initialized;
+	return local.initialized;
 }
 
 ///////////////////////////////////////////
@@ -349,47 +284,60 @@ void sk_shutdown() {
 		abort();
 	}
 
+	sk_shutdown_unsafe();
+}
+
+///////////////////////////////////////////
+
+void sk_shutdown_unsafe(void) {
 	log_show_any_fail_reason();
 
 	systems_shutdown();
-	sk_initialized = false;
-
 	sk_mem_log_allocations();
+
+	local = {};
+}
+
+///////////////////////////////////////////
+
+void sk_app_step() {
+	if (local.app_step_func != nullptr)
+		local.app_step_func();
 }
 
 ///////////////////////////////////////////
 
 void sk_quit() {
-	sk_running = false;
+	local.running = false;
 }
 
 ///////////////////////////////////////////
 
 bool32_t sk_step(void (*app_step)(void)) {
-	if (app_system->profile_start_duration == 0)
-		app_system->profile_start_duration = stm_since(app_init_time);
+	if (local.app_system->profile_start_duration == 0)
+		local.app_system->profile_start_duration = stm_since(local.app_init_time);
 
 	// TODO: remove this in v0.4 when sk_step is formally replaced by sk_run
 	sk_assert_thread_valid();
-	sk_first_step = true;
-	sk_stepping   = true;
+	local.first_step = true;
+	local.stepping   = true;
 	
-	sk_app_step_func = app_step;
+	local.app_step_func = app_step;
 	sk_step_timer();
 
 	systems_step();
 
-	if (device_display_get_type() == display_type_flatscreen && sk_focus != app_focus_active && !sk_settings.disable_unfocused_sleep)
+	if (device_display_get_type() == display_type_flatscreen && local.focus != app_focus_active && !local.settings.disable_unfocused_sleep)
 		platform_sleep(100);
-	sk_stepping = false;
-	return sk_running;
+	local.stepping = false;
+	return local.running;
 }
 
 ///////////////////////////////////////////
 
 void sk_run(void (*app_update)(void), void (*app_shutdown)(void)) {
 	sk_assert_thread_valid();
-	sk_first_step = true;
+	local.first_step = true;
 	
 #if defined(SK_OS_WEB)
 	web_start_main_loop(app_update, app_shutdown);
@@ -415,7 +363,7 @@ void sk_run_data(void (*app_update)(void *update_data), void *update_data, void 
 	_sk_run_data_shutdown_data = shutdown_data;
 
 	sk_assert_thread_valid();
-	sk_first_step = true;
+	local.first_step = true;
 
 #if defined(SK_OS_WEB)
 	web_start_main_loop(
@@ -435,20 +383,20 @@ void sk_run_data(void (*app_update)(void *update_data), void *update_data, void 
 ///////////////////////////////////////////
 
 void sk_step_timer() {
-	sk_timev_raw = stm_now();
-	double time_curr = stm_sec(sk_timev_raw);
+	local.timev_raw = stm_now();
+	double time_curr = stm_sec(local.timev_raw);
 
-	if (sk_time_start == 0)
-		sk_time_start = time_curr;
-	double new_time = time_curr - sk_time_start;
-	sk_timev_step_us  =  new_time - sk_timev_us;
-	sk_timev_step     = (new_time - sk_timev_us) * sk_timev_scale;
-	sk_timev_us       = new_time;
-	sk_timev         += sk_timev_step;
-	sk_timev_stepf_us = (float)sk_timev_step_us;
-	sk_timev_stepf    = (float)sk_timev_step;
-	sk_timevf_us      = (float)sk_timev_us;
-	sk_timevf         = (float)sk_timev;
+	if (local.time_start == 0)
+		local.time_start = time_curr;
+	double new_time = time_curr - local.time_start;
+	local.timev_step_us  =  new_time - local.timev_us;
+	local.timev_step     = (new_time - local.timev_us) * local.timev_scale;
+	local.timev_us       = new_time;
+	local.timev         += local.timev_step;
+	local.timev_stepf_us = (float)local.timev_step_us;
+	local.timev_stepf    = (float)local.timev_step;
+	local.timevf_us      = (float)local.timev_us;
+	local.timevf         = (float)local.timev;
 }
 
 ///////////////////////////////////////////
@@ -460,10 +408,10 @@ void sk_assert_thread_valid() {
 	// asset code and cause a blocking loop as the asset waits for the main
 	// thread to step. This function is used to detect and warn of such a
 	// situation.
-	if (sk_initialized && sk_first_step)
+	if (local.initialized && local.first_step)
 		return;
 	
-	if (thrd_id_equal(sk_init_thread, thrd_id_current()) == false) {
+	if (thrd_id_equal(local.init_thread, thrd_id_current()) == false) {
 		const char* err = "SK.Run and pre-Run GPU asset creation currently must be called on the same thread as SK.Initialize! Has async code accidentally bumped you to another thread?";
 		log_err(err);
 		platform_msgbox_err(err, "Fatal Error");
@@ -473,7 +421,110 @@ void sk_assert_thread_valid() {
 
 ///////////////////////////////////////////
 
-bool32_t sk_is_stepping() { return sk_stepping; }
+void sk_set_window(void* window) {
+	platform_set_window(window);
+}
+
+///////////////////////////////////////////
+
+void sk_set_window_xam(void* window) {
+	platform_set_window_xam(window);
+}
+
+///////////////////////////////////////////
+
+const char *sk_version_name() {
+	return SK_VERSION " "
+#if defined(SK_OS_WEB)
+		"Web"
+#elif defined(SK_OS_ANDROID)
+		"Android"
+#elif defined(SK_OS_LINUX)
+		"Linux"
+#elif defined(SK_OS_WINDOWS)
+		"Win32"
+#elif defined(SK_OS_WINDOWS_UWP)
+		"UWP"
+#else
+		"MysteryPlatform"
+#endif
+		
+		" "
+		
+#if defined(__x86_64__) || defined(_M_X64)
+		"x64"
+#elif defined(__aarch64__) || defined(_M_ARM64)
+		"ARM64"
+#elif defined(_M_ARM)
+		"ARM"
+#elif defined(i386) || defined(__i386__) || defined(__i386) || defined(_M_IX86)
+		"x86"
+#else
+		"MysteryArchitecture"
+#endif
+	;
+}
+
+///////////////////////////////////////////
+
+uint64_t sk_version_id() { return SK_VERSION_ID; }
+
+///////////////////////////////////////////
+
+app_focus_ sk_app_focus() { return local.focus; }
+
+///////////////////////////////////////////
+
+void sk_set_app_focus(app_focus_ focus_state) { local.focus = focus_state; }
+
+///////////////////////////////////////////
+
+sk_settings_t sk_get_settings() { return local.settings; }
+
+///////////////////////////////////////////
+
+system_info_t sk_system_info() {
+	system_info_t result = local.info;
+	// Right now there's some major overlap in system_info_t and the device
+	// APIs. Ultimately, system_info_t will become deprecated or significantly
+	// changed, but until then, we'll fill in the data by treating the device
+	// APIs as the source of truth.
+	//
+	// All references to the following system_info_t valuables have been
+	// scrubbed out of the core code and should not be used!
+	result.display_width        = device_display_get_width();
+	result.display_height       = device_display_get_height();
+	result.eye_tracking_present = device_has_eye_gaze();
+	switch (device_display_get_blend()) {
+		case display_blend_none:            result.display_type = display_none;            break;
+		case display_blend_opaque:          result.display_type = display_opaque;          break;
+		case display_blend_additive:        result.display_type = display_additive;        break;
+		case display_blend_blend:           result.display_type = display_blend;           break;
+		case display_blend_any_transparent: result.display_type = display_any_transparent; break;
+		default: result.display_type = display_none; break;
+	}
+	return result;
+}
+
+///////////////////////////////////////////
+
+const sk_settings_t* sk_get_settings_ref() { return &local.settings; }
+
+///////////////////////////////////////////
+
+system_info_t* sk_get_info_ref() { return &local.info; }
+
+///////////////////////////////////////////
+
+bool32_t sk_has_stepped() { return local.first_step; }
+
+///////////////////////////////////////////
+
+bool32_t sk_is_stepping() { return local.stepping; }
+
+///////////////////////////////////////////
+
+bool32_t sk_is_initialized() { return local.initialized; }
 
 ///////////////////////////////////////////
 
@@ -498,38 +549,38 @@ double time_elapsed_unscaled (){ return time_step_unscaled  (); };
 float  time_elapsedf         (){ return time_stepf          (); };
 double time_elapsed          (){ return time_step           (); };
 double time_total_raw        (){ return stm_sec(stm_now()); }
-float  time_totalf_unscaled  (){ return sk_timevf_us;       };
-double time_total_unscaled   (){ return sk_timev_us;        };
-float  time_totalf           (){ return sk_timevf;          };
-double time_total            (){ return sk_timev;           };
-float  time_stepf_unscaled   (){ return sk_timev_stepf_us;  };
-double time_step_unscaled    (){ return sk_timev_step_us;   };
-float  time_stepf            (){ return sk_timev_stepf;     };
-double time_step             (){ return sk_timev_step;      };
-void   time_scale(double scale) { sk_timev_scale = scale; }
+float  time_totalf_unscaled  (){ return local.timevf_us;       };
+double time_total_unscaled   (){ return local.timev_us;        };
+float  time_totalf           (){ return local.timevf;          };
+double time_total            (){ return local.timev;           };
+float  time_stepf_unscaled   (){ return local.timev_stepf_us;  };
+double time_step_unscaled    (){ return local.timev_step_us;   };
+float  time_stepf            (){ return local.timev_stepf;     };
+double time_step             (){ return local.timev_step;      };
+void   time_scale(double scale) { local.timev_scale = scale; }
 
 ///////////////////////////////////////////
 
 void time_set_time(double total_seconds, double frame_elapsed_seconds) {
 	if (frame_elapsed_seconds < 0) {
-		frame_elapsed_seconds = sk_timev_step_us;
+		frame_elapsed_seconds = local.timev_step_us;
 		if (frame_elapsed_seconds == 0)
 			frame_elapsed_seconds = 1.f / 90.f;
 	}
 	total_seconds = fmax(total_seconds, 0);
 
-	sk_timev_raw  = stm_now();
-	sk_time_start = stm_sec(sk_timev_raw) - total_seconds;
+	local.timev_raw  = stm_now();
+	local.time_start = stm_sec(local.timev_raw) - total_seconds;
 
-	sk_timev_step_us  = frame_elapsed_seconds;
-	sk_timev_step     = frame_elapsed_seconds * sk_timev_scale;
-	sk_timev_us       = total_seconds;
-	sk_timev          = total_seconds;
-	sk_timev_stepf_us = (float)sk_timev_step_us;
-	sk_timev_stepf    = (float)sk_timev_step;
-	sk_timevf_us      = (float)sk_timev_us;
-	sk_timevf         = (float)sk_timev;
-	physics_sim_time  = sk_timev;
+	local.timev_step_us  = frame_elapsed_seconds;
+	local.timev_step     = frame_elapsed_seconds * local.timev_scale;
+	local.timev_us       = total_seconds;
+	local.timev          = total_seconds;
+	local.timev_stepf_us = (float)local.timev_step_us;
+	local.timev_stepf    = (float)local.timev_step;
+	local.timevf_us      = (float)local.timev_us;
+	local.timevf         = (float)local.timev;
+	physics_sim_time  = local.timev;
 }
 
 } // namespace sk

--- a/StereoKitC/stereokit.h
+++ b/StereoKitC/stereokit.h
@@ -418,6 +418,7 @@ SK_API bool32_t      sk_init               (sk_settings_t settings);
 SK_API void          sk_set_window         (void *window);
 SK_API void          sk_set_window_xam     (void *window);
 SK_API void          sk_shutdown           (void);
+SK_API void          sk_shutdown_unsafe    (void);
 SK_API void          sk_quit               (void);
 SK_API bool32_t      sk_step               (void (*app_step)(void));
 SK_API void          sk_run                (void (*app_step)(void), void (*app_shutdown)(void) sk_default(nullptr));

--- a/StereoKitC/systems/defaults.cpp
+++ b/StereoKitC/systems/defaults.cpp
@@ -53,6 +53,18 @@ sound_t      sk_default_unclick;
 sound_t      sk_default_grab;
 sound_t      sk_default_ungrab;
 
+const spherical_harmonics_t sk_default_lighting = { {
+	{ 0.74f,  0.74f,  0.73f},
+	{ 0.24f,  0.25f,  0.26f},
+	{ 0.09f,  0.09f,  0.09f},
+	{ 0.05f,  0.05f,  0.06f},
+	{-0.01f, -0.01f, -0.01f},
+	{-0.03f, -0.03f, -0.03f},
+	{ 0.00f,  0.00f,  0.00f},
+	{-0.02f, -0.02f, -0.02f},
+	{ 0.04f,  0.04f,  0.04f},
+} };
+
 ///////////////////////////////////////////
 
 tex_t defaults_texture(const char *id, color128 color) {
@@ -128,23 +140,10 @@ bool defaults_init() {
 	tex_set_error_fallback  (sk_default_tex_error);
 
 	// Cubemap
-	spherical_harmonics_t lighting = { {
-		{ 0.74f,  0.74f,  0.73f}, 
-		{ 0.24f,  0.25f,  0.26f}, 
-		{ 0.09f,  0.09f,  0.09f}, 
-		{ 0.05f,  0.05f,  0.06f}, 
-		{-0.01f, -0.01f, -0.01f}, 
-		{-0.03f, -0.03f, -0.03f}, 
-		{ 0.00f,  0.00f,  0.00f}, 
-		{-0.02f, -0.02f, -0.02f}, 
-		{ 0.04f,  0.04f,  0.04f}, 
-	} };
-	render_set_skylight(lighting);
+	spherical_harmonics_t lighting = sk_default_lighting;
 	sh_brightness(lighting, 0.75f);
 	sk_default_cubemap = tex_gen_cubemap_sh(lighting, 16, 0.3f);
 	tex_set_id(sk_default_cubemap, default_id_cubemap);
-	render_set_skytex(sk_default_cubemap);
-	render_enable_skytex(true);
 
 	// Default quad mesh
 	sk_default_quad = mesh_create();

--- a/StereoKitC/systems/defaults.h
+++ b/StereoKitC/systems/defaults.h
@@ -36,4 +36,6 @@ extern text_style_t sk_default_text_style;
 extern sound_t      sk_default_click;
 extern sound_t      sk_default_unclick;
 
+extern const spherical_harmonics_t sk_default_lighting;
+
 } // namespace sk

--- a/StereoKitC/systems/input_keyboard.cpp
+++ b/StereoKitC/systems/input_keyboard.cpp
@@ -30,7 +30,7 @@ struct input_keyboard_state_t {
 	bool                      key_suspended;
 	float                     last_physical_keypress;
 };
-input_keyboard_state_t local = {};
+static input_keyboard_state_t local = {};
 
 ///////////////////////////////////////////
 

--- a/StereoKitC/systems/render.cpp
+++ b/StereoKitC/systems/render.cpp
@@ -847,7 +847,7 @@ void render_step() {
 	if (hierarchy_stack.count > 0)
 		log_err("Render transform stack doesn't have matching begin/end calls!");
 
-	if (render_sky_show && sk_system_info().display_type == display_opaque) {
+	if (render_sky_show && device_display_get_blend() == display_blend_opaque) {
 		render_add_mesh(render_sky_mesh, render_sky_mat, matrix_identity, {1,1,1,1}, render_layer_vfx);
 	}
 }

--- a/StereoKitC/systems/sprite_drawer.cpp
+++ b/StereoKitC/systems/sprite_drawer.cpp
@@ -73,8 +73,8 @@ void sprite_drawer_add     (sprite_t sprite, const matrix &at, color32 color) {
 
 	// Get the heirarchy based transform
 	XMMATRIX tr;
-	if (hierarchy_enabled) {
-		matrix_mul(hierarchy_stack.last().transform, at, tr);
+	if (hierarchy_use_top()) {
+		matrix_mul(hierarchy_top(), at, tr);
 	} else {
 		math_matrix_to_fast(at, &tr);
 	}

--- a/StereoKitC/systems/text.cpp
+++ b/StereoKitC/systems/text.cpp
@@ -507,8 +507,8 @@ float text_add_in_g(const C* text, const matrix& transform, vec2 size, text_fit_
 	if (size.x <= 0) return 0; // Zero width text isn't visible, and causes issues when trying to determine text height.
 
 	XMMATRIX tr;
-	if (hierarchy_enabled) {
-		matrix_mul(transform, hierarchy_stack.last().transform, tr);
+	if (hierarchy_use_top()) {
+		matrix_mul(transform, hierarchy_top(), tr);
 	} else {
 		math_matrix_to_fast(transform, &tr);
 	}

--- a/StereoKitC/xr_backends/openxr_input.cpp
+++ b/StereoKitC/xr_backends/openxr_input.cpp
@@ -67,7 +67,7 @@ bool oxri_init() {
 	xrc_offset_rot[0] = quat_identity;
 	xrc_offset_rot[1] = quat_identity;
 
-	xr_eyes_pointer = input_add_pointer(input_source_gaze | (sk_info.eye_tracking_present ? input_source_gaze_eyes : input_source_gaze_head));
+	xr_eyes_pointer = input_add_pointer(input_source_gaze | (device_has_eye_gaze() ? input_source_gaze_eyes : input_source_gaze_head));
 
 	XrActionSetCreateInfo actionset_info = { XR_TYPE_ACTION_SET_CREATE_INFO };
 	snprintf(actionset_info.actionSetName,          sizeof(actionset_info.actionSetName),          "input");
@@ -185,7 +185,7 @@ bool oxri_init() {
 	}
 
 	// Eye tracking
-	if (sk_info.eye_tracking_present) {
+	if (device_has_eye_gaze()) {
 		action_info = { XR_TYPE_ACTION_CREATE_INFO };
 		action_info.actionType = XR_ACTION_TYPE_POSE_INPUT;
 		snprintf(action_info.actionName,          sizeof(action_info.actionName),          "eye_gaze");
@@ -317,7 +317,7 @@ bool oxri_init() {
 			xrc_profile_info_t info;
 			info.profile = profile_path;
 			info.name    = "microsoft/motion_controller";
-			if (sk_info.display_type == display_opaque) {
+			if (device_display_get_blend() == display_blend_opaque) {
 				info.offset_rot[handed_left ] = quat_from_angles(-45, 0, 0);
 				info.offset_rot[handed_right] = quat_from_angles(-45, 0, 0);
 				info.offset_pos[handed_left ] = { 0.01f, -0.01f, 0.015f };
@@ -362,7 +362,7 @@ bool oxri_init() {
 			xrc_profile_info_t info;
 			info.profile = profile_path;
 			info.name    = "hp/mixed_reality_controller";
-			if (sk_info.display_type == display_opaque) {
+			if (device_display_get_blend() == display_blend_opaque) {
 				info.offset_rot[handed_left ] = quat_from_angles(-45, 0, 0);
 				info.offset_rot[handed_right] = quat_from_angles(-45, 0, 0);
 				info.offset_pos[handed_left ] = { 0.01f, -0.01f, 0.015f };
@@ -788,7 +788,7 @@ void oxri_update_poses() {
 	}
 
 	// eye input
-	if (sk_info.eye_tracking_present) {
+	if (device_has_eye_gaze()) {
 		pointer_t           *pointer     = input_get_pointer(xr_eyes_pointer);
 		XrActionStatePose    action_pose = {XR_TYPE_ACTION_STATE_POSE};
 		XrActionStateGetInfo action_info = {XR_TYPE_ACTION_STATE_GET_INFO};
@@ -873,7 +873,7 @@ void oxri_update_frame() {
 	input_controller_menubtn = button_make_state(input_controller_menubtn & button_state_active, menu_button);
 
 	// eye input
-	if (sk_info.eye_tracking_present) {
+	if (device_has_eye_gaze()) {
 		pointer_t           *pointer     = input_get_pointer(xr_eyes_pointer);
 		XrActionStatePose    action_pose = {XR_TYPE_ACTION_STATE_POSE};
 		XrActionStateGetInfo action_info = {XR_TYPE_ACTION_STATE_GET_INFO};

--- a/StereoKitC/xr_backends/openxr_scene_understanding.cpp
+++ b/StereoKitC/xr_backends/openxr_scene_understanding.cpp
@@ -387,7 +387,7 @@ bool32_t oxr_su_raycast(ray_t ray, ray_t *out_intersection) {
 ///////////////////////////////////////////
 
 void oxr_su_set_occlusion_enabled(bool32_t enabled) {
-	enabled = sk_info.world_occlusion_present && enabled;
+	enabled = sk_get_info_ref()->world_occlusion_present > 0 && enabled > 0;
 	if (xr_scene_next_req.occlusion == enabled) return;
 
 	xr_scene_next_req.occlusion = enabled;
@@ -404,7 +404,7 @@ bool32_t oxr_su_get_occlusion_enabled() {
 ///////////////////////////////////////////
 
 void oxr_su_set_raycast_enabled(bool32_t enabled) {
-	enabled = sk_info.world_raycast_present && enabled;
+	enabled = sk_get_info_ref()->world_raycast_present > 0 && enabled > 0;
 	if (xr_scene_next_req.raycast == enabled) return;
 
 	xr_scene_next_req.raycast = enabled;

--- a/StereoKitC/xr_backends/openxr_view.cpp
+++ b/StereoKitC/xr_backends/openxr_view.cpp
@@ -278,9 +278,9 @@ bool openxr_views_create() {
 
 	// Register dispay type with the system
 	switch (xr_displays[0].blend) {
-	case XR_ENVIRONMENT_BLEND_MODE_OPAQUE:      sk_info.display_type = display_opaque;      break;
-	case XR_ENVIRONMENT_BLEND_MODE_ADDITIVE:    sk_info.display_type = display_additive;    break;
-	case XR_ENVIRONMENT_BLEND_MODE_ALPHA_BLEND: sk_info.display_type = display_passthrough; break;
+	case XR_ENVIRONMENT_BLEND_MODE_OPAQUE:      device_data.display_blend = display_blend_opaque;   break;
+	case XR_ENVIRONMENT_BLEND_MODE_ADDITIVE:    device_data.display_blend = display_blend_additive; break;
+	case XR_ENVIRONMENT_BLEND_MODE_ALPHA_BLEND: device_data.display_blend = display_blend_blend;    break;
 	// Just max_enum
 	default: break;
 	}
@@ -308,7 +308,7 @@ bool openxr_create_view(XrViewConfigurationType view_type, device_display_t &out
 
 	// Get the surface format information before we create surfaces!
 	openxr_preferred_format(out_view.color_format, out_view.depth_format);
-	if (!openxr_preferred_blend(view_type, sk_settings.blend_preference, &xr_valid_blends, &out_view.blend)) return false;
+	if (!openxr_preferred_blend(view_type, sk_get_settings_ref()->blend_preference, &xr_valid_blends, &out_view.blend)) return false;
 
 	// Tell OpenXR what sort of color space we're rendering in
 	if (xr_ext_available.FB_color_space) {
@@ -487,8 +487,6 @@ bool openxr_update_swapchains(device_display_t &display) {
 	}
 
 	if (display.type == XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO) {
-		sk_info.display_width  = w;
-		sk_info.display_height = h;
 		device_data.display_width  = w;
 		device_data.display_height = h;
 	}
@@ -845,7 +843,7 @@ bool openxr_render_layer(XrTime predictedTime, device_display_t &layer, render_l
 
 		// Call the rendering callback with our view and swapchain info
 		tex_t    target = layer.swapchain_color.textures[index];
-		color128 col    = sk_info.display_type == display_opaque
+		color128 col    = device_display_get_blend() == display_blend_opaque
 			? render_get_clear_color_ln()
 			: color128{ 0,0,0,0 };
 		skg_tex_target_bind(&target->tex);

--- a/StereoKitC/xr_backends/simulator.cpp
+++ b/StereoKitC/xr_backends/simulator.cpp
@@ -46,9 +46,6 @@ bool simulator_init() {
 	case origin_mode_stage: world_origin_mode = origin_mode_local; world_origin_offset = { sim_head_pos - vec3{0,1.5f,0}, initial_rot }; sim_bounds_pose = { world_origin_offset.position, quat_inverse(world_origin_offset.orientation) }; break;
 	}
 
-	render_set_sim_origin(world_origin_offset);
-	render_set_sim_head  (pose_t{ sim_head_pos, quat_from_angles(sim_head_rot.x, sim_head_rot.y, sim_head_rot.z) });
-
 	return true;
 }
 
@@ -98,7 +95,6 @@ void simulator_step_begin() {
 		}
 		// Apply movement to the camera
 		sim_head_pos += orientation * movement * time_stepf_unscaled() * sim_move_speed;
-		render_set_sim_head({ sim_head_pos, orientation });
 	} else {
 		sim_mouse_look = false;
 	}
@@ -124,6 +120,9 @@ void simulator_step_begin() {
 	pointer_head->tracked = button_state_active;
 	pointer_head->ray.pos = input_eyes_pose_world.position;
 	pointer_head->ray.dir = input_eyes_pose_world.orientation * vec3_forward;
+
+	render_set_sim_origin(world_origin_offset);
+	render_set_sim_head  (pose_t{ sim_head_pos, quat_from_angles(sim_head_rot.x, sim_head_rot.y, sim_head_rot.z) });
 }
 
 ///////////////////////////////////////////

--- a/StereoKitC/xr_backends/simulator.cpp
+++ b/StereoKitC/xr_backends/simulator.cpp
@@ -40,7 +40,7 @@ bool simulator_init() {
 	sim_gaze_pointer = input_add_pointer(input_source_gaze | input_source_gaze_head);
 
 	quat initial_rot = quat_from_angles(0, sim_head_rot.y, 0);
-	switch (sk_settings.origin) {
+	switch (sk_get_settings_ref()->origin) {
 	case origin_mode_local: world_origin_mode = origin_mode_local; world_origin_offset = { sim_head_pos,                  initial_rot }; sim_bounds_pose = { 0,-1.5f,0, quat_inverse(initial_rot) }; break;
 	case origin_mode_floor: world_origin_mode = origin_mode_local; world_origin_offset = { sim_head_pos - vec3{0,1.5f,0}, initial_rot }; sim_bounds_pose = { world_origin_offset.position, quat_inverse(world_origin_offset.orientation) }; break;
 	case origin_mode_stage: world_origin_mode = origin_mode_local; world_origin_offset = { sim_head_pos - vec3{0,1.5f,0}, initial_rot }; sim_bounds_pose = { world_origin_offset.position, quat_inverse(world_origin_offset.orientation) }; break;
@@ -106,7 +106,7 @@ void simulator_step_begin() {
 		sim_mouse_look = false;
 	}
 
-	if (sk_settings.disable_flatscreen_mr_sim) {
+	if (sk_get_settings_ref()->disable_flatscreen_mr_sim) {
 		input_eyes_track_state = button_make_state(input_eyes_track_state & button_state_active, false);
 	} else {
 		bool sim_tracked = (input_key(key_alt) & button_state_active) > 0 ? true : false;


### PR DESCRIPTION
`SK.Run` now catches any exception, shuts down, cleans up, and tosses the exception back up. This gives the app a better chance at restarting StereoKit in the case of an error.

This also packages up the state of a couple modules (`stereokit.cpp`, `renderer.cpp`, `line_drawer.cpp`, `hierarchy.cpp`) so they get more appropriately cleaned up on shutdown and don't leave ghost state lying around. Still plenty more to go, but this got me through some of my tests.

Edit: Also I guess some build stuff. Using gold as the linker was never the plan, not sure why it popped back in there.