### PR TITLE
Fix for overwritten valid blend modes.

### DIFF
--- a/StereoKitC/xr_backends/openxr.cpp
+++ b/StereoKitC/xr_backends/openxr.cpp
@@ -77,7 +77,6 @@ XrSpace        xr_head_space    = {};
 XrSystemId     xr_system_id     = XR_NULL_SYSTEM_ID;
 XrTime         xr_time          = 0;
 XrTime         xr_eyes_sample_time = 0;
-display_blend_ xr_valid_blends   = display_blend_none;
 bool           xr_system_created = false;
 bool           xr_system_success = false;
 
@@ -914,7 +913,7 @@ bool openxr_poll_events() {
 			case XR_SESSION_STATE_READY: {
 				// Get the session started!
 				XrSessionBeginInfo begin_info = { XR_TYPE_SESSION_BEGIN_INFO };
-				begin_info.primaryViewConfigurationType = xr_display_types[0];
+				begin_info.primaryViewConfigurationType = XR_PRIMARY_CONFIG;
 
 				XrSecondaryViewConfigurationSessionBeginInfoMSFT secondary = { XR_TYPE_SECONDARY_VIEW_CONFIGURATION_SESSION_BEGIN_INFO_MSFT };
 				if (xr_display_types.count > 1) {

--- a/StereoKitC/xr_backends/openxr.h
+++ b/StereoKitC/xr_backends/openxr.h
@@ -84,10 +84,11 @@ extern bool       xr_has_bounds;
 extern bool       xr_has_single_pass;
 extern XrTime     xr_time;
 extern XrTime     xr_eyes_sample_time;
-extern display_blend_ xr_valid_blends;
 extern vec2       xr_bounds_size;
 extern pose_t     xr_bounds_pose;
 extern pose_t     xr_bounds_pose_local;
+
+#define XR_PRIMARY_CONFIG XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO
 
 } // namespace sk
 #endif


### PR DESCRIPTION
Valid blend modes for the primary display were getting overwritten by secondary displays. May fix #681 if I wrote this right, can't easily test the codepath with multiple displays.

`xr_blend_valid` and `xr_set_blend` were also incorrectly swapping any_transparent for additive when blend was the correct swap.