### PR TITLE
Add missing document tags for doc generation

### DIFF
--- a/StereoKit/Assets/Tex.cs
+++ b/StereoKit/Assets/Tex.cs
@@ -384,6 +384,7 @@ namespace StereoKit
 		/// use when rendering to it.</summary>
 		/// <param name="depthFormat">The format of the depth texture, must
 		/// be a depth format type!</param>
+		/// <returns>A new Tex asset with the specified depth.</returns>
 		public Tex AddZBuffer(TexFormat depthFormat)
 			=> new Tex(NativeAPI.tex_add_zbuffer(_inst, depthFormat));
 		#endregion

--- a/StereoKit/Math/Bounds.cs
+++ b/StereoKit/Math/Bounds.cs
@@ -77,7 +77,7 @@ namespace StereoKit
 		/// same space as the bounds.</param>
 		/// <returns>The bounds that also encapsulate the provided point.
 		/// </returns>
-		Bounds Grown (Vec3 pt)
+		public Bounds Grown (Vec3 pt)
 			=> NativeAPI.bounds_grow_to_fit_pt(this, pt);
 		/// <summary>Grow the Bounds to encapsulate the provided box after it
 		/// has been transformed by the provided matrix transform. This will
@@ -90,13 +90,13 @@ namespace StereoKit
 		/// </param>
 		/// <returns>The bounds that also encapsulate the provided transformed
 		/// box.</returns>
-		Bounds Grown (Bounds box, Matrix boxTransform)
+		public Bounds Grown (Bounds box, Matrix boxTransform)
 			=> NativeAPI.bounds_grow_to_fit_box(this, box, boxTransform);
 		/// <summary>Grow the Bounds to encapsulate the provided box.</summary>
 		/// <param name="box">The box to encapsulate!</param>
 		/// <returns>The bounds that also encapsulate the provided box.
 		/// </returns>
-		Bounds Grown (Bounds box)
+		public Bounds Grown (Bounds box)
 			=> NativeAPI.bounds_grow_to_fit_box(this, box, IntPtr.Zero);
 		/// <summary>This returns a Bounds that encapsulates the transformed
 		/// points of the current Bounds's corners. Note that this will likely
@@ -106,7 +106,7 @@ namespace StereoKit
 		/// corners.</param>
 		/// <returns>A Bounds that encapsulates the transformed points of the
 		/// current Bounds's corners</returns>
-		Bounds Transformed(Matrix transform)
+		public Bounds Transformed(Matrix transform)
 			=> NativeAPI.bounds_transform(this, transform);
 
 		/// <summary>Calculate the intersection between a Ray, and these

--- a/StereoKit/Math/Plane.cs
+++ b/StereoKit/Math/Plane.cs
@@ -24,10 +24,12 @@ namespace StereoKit
 
 		/// <summary>Implicit conversion from the System.Numerics backing type.</summary>
 		/// <param name="p">A System.Numerics plane.</param>
+		/// <returns>Returns a copy of the given Plane.</returns>
 		public static implicit operator Plane(System.Numerics.Plane p) => new Plane(p.Normal, p.D);
 		/// <summary>Implicit conversion to the System.Numerics backing Plane
 		/// type.</summary>
 		/// <param name="p">The StereoKit Plane.</param>
+		/// <returns>Returns a reference of the internal, wrapped Systems.Numerics type.</returns>
 		public static implicit operator System.Numerics.Plane(Plane p) => p.p;
 
 		/// <summary>Creates a Plane directly from the ax + by + cz + d = 0

--- a/StereoKit/Systems/Input.cs
+++ b/StereoKit/Systems/Input.cs
@@ -429,6 +429,9 @@ namespace StereoKit
 		/// Note that this may change during a session, the user may put down
 		/// their controllers, automatically switching to hands, or visa versa.
 		/// </summary>
+		/// <param name="hand">Do  you want the left or right hand? 0 is left,
+		/// and 1 is right.</param>
+		/// <returns>Returns information about hand tracking data source.</returns>
 		public static HandSource HandSource(Handed hand) => NativeAPI.input_hand_source(hand);
 
 		/// <summary>This allows you to completely override the hand's pose 

--- a/StereoKit/Util/Color.cs
+++ b/StereoKit/Util/Color.cs
@@ -243,6 +243,7 @@ namespace StereoKit
 		/// _not_ convert from linear to gamma corrected, or clamp to 0-1
 		/// first.</summary>
 		/// <param name="c">A 128 bit color to crush down.</param>
+		/// <returns>A crushed down color.</returns>
 		public static implicit operator Color32(Color c)
 			=> new Color32((byte)(c.r*255), (byte)(c.g*255), (byte)(c.b*255), (byte)(c.a*255));
 		/// <summary>This will multiply a color linearly, including alpha. Best


### PR DESCRIPTION
StereoKit/StereoKit-Docs currently fails to build for develop branch due to missing entries in the docs. This PR adds the missing entries for various classes.