### PR TITLE
Cmake Support Linux Arm64 builds. 

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -203,15 +203,18 @@
       "binaryDir":   "${sourceDir}/bin/intermediate/cmake/Linux_ARM64_Release",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE":       "Release",
-        "CMAKE_AR":               "aarch64-linux-gnu-ar",
-        "CMAKE_LINKER":           "aarch64-linux-gnu-ld",
-        "CMAKE_OBJCOPY":          "aarch64-linux-gnu-objcopy",
-        "CMAKE_RANLIB":           "aarch64-linux-gnu-ranlib",
-        "CMAKE_SIZE":             "aarch64-linux-gnu-size",
-        "CMAKE_STRIP":            "aarch64-linux-gnu-strip",
+        "CMAKE_AR":               "/usr/bin/aarch64-linux-gnu-ar",
+        "CMAKE_LINKER":           "/usr/bin/aarch64-linux-gnu-ld",
+        "CMAKE_OBJCOPY":          "/usr/bin/aarch64-linux-gnu-objcopy",
+        "CMAKE_RANLIB":           "/usr/bin/aarch64-linux-gnu-ranlib",
+        "CMAKE_SIZE":             "/usr/bin/aarch64-linux-gnu-size",
+        "CMAKE_STRIP":            "/usr/bin/aarch64-linux-gnu-strip",
         "CMAKE_C_COMPILER":       "aarch64-linux-gnu-gcc",
         "CMAKE_CXX_COMPILER":     "aarch64-linux-gnu-g++",
-        "CMAKE_SYSTEM_PROCESSOR": "arm64"
+        "CMAKE_SYSTEM_PROCESSOR": "arm64",
+        "CMAKE_EXE_LINKER_FLAGS": null,
+        "CMAKE_SHARED_LINKER_FLAGS": null,
+        "CMAKE_MODULE_LINKER_FLAGS": null
       }
     },
     {

--- a/docker/arm-cross-compile-sources.list
+++ b/docker/arm-cross-compile-sources.list
@@ -1,0 +1,7 @@
+deb [arch=arm64] http://ports.ubuntu.com/ jammy main restricted
+deb [arch=arm64] http://ports.ubuntu.com/ jammy-updates main restricted
+deb [arch=arm64] http://ports.ubuntu.com/ jammy universe
+deb [arch=arm64] http://ports.ubuntu.com/ jammy-updates universe
+deb [arch=arm64] http://ports.ubuntu.com/ jammy multiverse
+deb [arch=arm64] http://ports.ubuntu.com/ jammy-updates multiverse
+deb [arch=arm64] http://ports.ubuntu.com/ jammy-backports main restricted universe multiverse

--- a/docker/arm64linux.Dockerfile
+++ b/docker/arm64linux.Dockerfile
@@ -1,0 +1,13 @@
+FROM ubuntu:22.04
+
+COPY runbuild-arm64.sh /var/
+COPY arm-cross-compile-sources.list /etc/apt/sources.list.d/
+RUN sed -i "s/deb http/deb [arch=amd64] http/g" /etc/apt/sources.list
+RUN dpkg --add-architecture arm64
+
+RUN apt-get update
+RUN apt-get install -y build-essential cmake ninja-build clang git
+RUN apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+RUN apt-get install -y lld:arm64 libfontconfig1-dev:arm64 libgl1-mesa-dev:arm64 libx11-xcb-dev:arm64 libxfixes-dev:arm64 libxcb-dri2-0-dev:arm64 libxcb-glx0-dev:arm64 libxcb-icccm4-dev:arm64 libxcb-keysyms1-dev:arm64 libxcb-randr0-dev:arm64 libxrandr-dev:arm64 libxxf86vm-dev:arm64 mesa-common-dev:arm64
+WORKDIR /var/projects/StereoKit
+ENTRYPOINT ["/var/runbuild-arm64.sh"]

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+docker build --network=host -t stereokit/linux_x64 -f x64linux.Dockerfile . && docker run --network=host -v "/$(pwd)/..":/var/projects/StereoKit stereokit/linux_x64
+
+docker build --network=host -t stereokit/linux_arm64 -f arm64linux.Dockerfile . && docker run --network=host -v "/$(pwd)/..":/var/projects/StereoKit stereokit/linux_arm64

--- a/docker/runbuild-arm64.sh
+++ b/docker/runbuild-arm64.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cd /var/projects/StereoKit/
+cmake --preset Linux_Arm64_Release
+cmake --build --preset Linux_Arm64_Release

--- a/docker/runbuild-x64.sh
+++ b/docker/runbuild-x64.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cd /var/projects/StereoKit/
+cmake --preset Linux_x64_Release
+cmake --build --preset Linux_x64_Release

--- a/docker/x64linux.Dockerfile
+++ b/docker/x64linux.Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:22.04
+
+COPY runbuild-x64.sh /var/
+
+RUN apt-get update
+RUN apt-get install -y build-essential cmake ninja-build clang git
+RUN apt-get install -y lld libfontconfig1-dev libgl1-mesa-dev libx11-xcb-dev libxfixes-dev libxcb-dri2-0-dev libxcb-glx0-dev libxcb-icccm4-dev libxcb-keysyms1-dev libxcb-randr0-dev libxrandr-dev libxxf86vm-dev mesa-common-dev
+
+WORKDIR /var/projects/StereoKit
+ENTRYPOINT ["/var/runbuild-x64.sh"]


### PR DESCRIPTION
Added build in docker container as installing arm64 packages overwrites lld which fails the x64 build.

How the docker build works : 
1. Creates a docker image  with all the necessary packages installed. 
2. Mounts the source code in docker container.
3. Runs the CMake command to build.

How to run without docker : 
1. Setup cross compiling for ARM. Requires updating repos and installing arm packages. See docker/arm64linux.Dockerfile for the steps.
2. cmake --preset Linux_x64_Release
3. cmake --build Linux_x64_Release

How to run using docker : 
1. cd docker
4. ./build.sh

FIxes #702