### PR TITLE
Remove __android_log_write in favor of syslog, so that liblog.so can be removed as a dependency.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,9 +92,7 @@ endif()
 ###########################################
 
 if (ANDROID)
-  set(ANDROID_LOG_LIBRARY log)
   set(ANDROID_LIBS
-    log
     android
     EGL)
   if (SK_DYNAMIC_OPENXR)


### PR DESCRIPTION
Lynx doesn't seem to find liblog.so. This is a strange pain-point in Android, and I've seen it before, so we're just trying to dodge around liblog.so to reduce build complexity.

Nothing major changes here, but logs for StereoKit `LogLevel.Diagnostic` now come through as "Debug" instead of "Verbose" in Android's logcat.