### PR TITLE
Omit empty frame option.

### DIFF
--- a/Examples/StereoKitTest/StereoKitTest_NetAndroid/AndroidManifest.xml
+++ b/Examples/StereoKitTest/StereoKitTest_NetAndroid/AndroidManifest.xml
@@ -4,7 +4,7 @@
 	
 	<application android:allowBackup="true" android:icon="@mipmap/appicon" android:label="@string/app_name" android:roundIcon="@mipmap/appicon_round" android:supportsRtl="true">
 		<!-- Oculus -->
-		<meta-data android:name="com.oculus.supportedDevices" android:value="quest|quest2|questpro"/>
+		<meta-data android:name="com.oculus.supportedDevices" android:value="quest|quest2|quest3|questpro"/>
 		<meta-data android:name="com.oculus.handtracking.version" android:value="V2.0"/>
 		<uses-native-library android:name="libopenxr_forwardloader.oculus.so" android:required="false"/>
 		<!-- Pico -->

--- a/StereoKit/Native/NativeTypes.cs
+++ b/StereoKit/Native/NativeTypes.cs
@@ -102,6 +102,11 @@ namespace StereoKit
 		/// StereoKit actually landed on.</summary>
 		public OriginMode origin;
 
+		/// <summary>If StereoKit has nothing to render for this frame, it
+		/// skips submitting a proojection layer to OpenXR entirely.</summary>
+		public bool omitEmptyFrames { get { return _omitEmptyFrames > 0; } set { _omitEmptyFrames = value ? 1 : 0; } }
+		private int _omitEmptyFrames;
+
 		/// <summary>A pointer to the JNI's JavaVM structure, only used for
 		/// Android applications. This is optional, even for Android.</summary>
 		public IntPtr androidJavaVm;

--- a/StereoKitC/stereokit.h
+++ b/StereoKitC/stereokit.h
@@ -397,6 +397,7 @@ typedef struct sk_settings_t {
 	float          render_scaling;
 	int32_t        render_multisample;
 	origin_mode_   origin;
+	bool32_t       omit_empty_frames;
 
 	void          *android_java_vm;  // JavaVM*
 	void          *android_activity; // jobject

--- a/StereoKitC/systems/render.h
+++ b/StereoKitC/systems/render.h
@@ -29,6 +29,7 @@ matrix        render_get_cam_final        ();
 matrix        render_get_cam_final_inv    ();
 color128      render_get_clear_color_ln   ();
 vec2          render_get_clip             ();
+render_list_t render_get_primary_list     ();
 void          render_draw_matrix          (const matrix *views, const matrix *projs, int32_t view_count, render_layer_ render_filter);
 void          render_clear                ();
 vec3          render_unproject_pt         (vec3 normalized_screen_pt);
@@ -38,6 +39,9 @@ tex_format_   render_preferred_depth_fmt  ();
 void          render_blit_to_bound        (material_t material);
 void          render_set_sim_origin       (pose_t pose);
 void          render_set_sim_head         (pose_t pose);
+void          render_draw_queue           (const matrix* views, const matrix* projections, int32_t view_count, render_layer_ filter);
+void          render_check_screenshots    ();
+void          render_check_viewpoints     ();
 
 bool          render_init                 ();
 void          render_step                 ();
@@ -50,5 +54,6 @@ void          render_list_pop             ();
 void          render_list_execute         (render_list_t list, render_layer_ filter, uint32_t view_count, int32_t queue_start, int32_t queue_end);
 void          render_list_execute_material(render_list_t list, render_layer_ filter, uint32_t view_count, int32_t queue_start, int32_t queue_end, material_t override_material);
 void          render_list_clear           (render_list_t list);
+int32_t       render_list_item_count      (render_list_t list);
 
 } // namespace sk


### PR DESCRIPTION
If there's nothing to draw, add an option to skip submitting projection layers to OpenXR. This can be a nice optimization for overlay applications that may want to idle without showing anything until they're needed.