### PR TITLE
Skybox performance improvements.

### DIFF
--- a/StereoKitC/shaders_builtin/shader_builtin_skybox.hlsl
+++ b/StereoKitC/shaders_builtin/shader_builtin_skybox.hlsl
@@ -19,7 +19,7 @@ psIn vs(vsIn input, uint id : SV_InstanceID) {
 	psIn o;
 	o.view_id = id % sk_view_count;
 	id        = id / sk_view_count;
-	o.pos     = float4(input.pos.xyz, 1);
+	o.pos     = float4(input.pos.xy, 0.99999, 1);
 
 	float4   proj_inv       = mul(o.pos, sk_proj_inv[o.view_id]);
 	float4x4 v              = sk_view[o.view_id];
@@ -32,9 +32,6 @@ psIn vs(vsIn input, uint id : SV_InstanceID) {
 	return o;
 }
 
-psOut ps(psIn input) {
-	psOut result;
-	result.color = sk_cubemap.Sample(sk_cubemap_s, input.norm);
-	result.depth = 0.99999;
-	return result;
+float4 ps(psIn input) : SV_TARGET {
+	return sk_cubemap.Sample(sk_cubemap_s, input.norm);
 }

--- a/StereoKitC/shaders_builtin/shader_builtin_skybox.hlsl
+++ b/StereoKitC/shaders_builtin/shader_builtin_skybox.hlsl
@@ -10,10 +10,6 @@ struct psIn {
 	float3 norm : NORMAL0;
 	uint view_id : SV_RenderTargetArrayIndex;
 };
-struct psOut {
-	float4 color : SV_Target;
-	float  depth : SV_Depth;
-};
 
 psIn vs(vsIn input, uint id : SV_InstanceID) {
 	psIn o;

--- a/StereoKitC/systems/render.cpp
+++ b/StereoKitC/systems/render.cpp
@@ -237,6 +237,7 @@ bool render_init() {
 
 	material_set_id          (local.sky_mat, "sk/render/skybox_material");
 	material_set_queue_offset(local.sky_mat, 100);
+	material_set_depth_write (local.sky_mat, false);
 
 	tex_t sky_cubemap = tex_find(default_id_cubemap);
 	render_set_skytex   (sky_cubemap);


### PR DESCRIPTION
Hard to say exact improvement, but from one renderdoc test in the Simulator on DX11/HLSL, these brought time down from like 4000ns to 600ns.

- Moved explicit depth from pixel->vertex shader.
- Disabled depth writing, skybox depth is only needed for z discard test.