### PR TITLE
Bounds calculation fixes

### DIFF
--- a/Examples/StereoKitTest/Tests/TestBounds.cs
+++ b/Examples/StereoKitTest/Tests/TestBounds.cs
@@ -105,6 +105,43 @@ class TestBounds : ITest
 		return true;
 	}
 
+	bool TestMeshBounds()
+	{
+		Mesh mesh = Mesh.GenerateCube(Vec3.One*0.5f);
+		return (mesh.Bounds.dimensions - new Vec3(0.5f, 0.5f, 0.5f)).MagnitudeSq < 0.001f;
+	}
+
+	bool TestModelBounds()
+	{
+		Model model = new Model();
+
+		Mesh mesh1 = Mesh.GenerateCube(Vec3.One*0.5f);
+		mesh1.KeepData = false;
+		model.AddNode("root1", Matrix.T(0,0.25f,0), mesh1, Material.Default);
+
+		Mesh mesh2 = Mesh.GenerateCube(Vec3.One*0.5f);
+		model.AddNode("root2", Matrix.T(0,0.75f,0), mesh2, Material.Default);
+
+		Vec3 expectedSize = new Vec3(0.5f, 1f, 0.5f);
+
+		// Make sure bounds are correct when just adding nodes
+		if (Vec3.DistanceSq(model.Bounds.dimensions, expectedSize) > 0.001f)
+			return false;
+
+		// Check if a normal recalculating bounds works as expected as well
+		model.RecalculateBounds();
+		if (Vec3.DistanceSq(model.Bounds.dimensions, expectedSize) > 0.001f)
+				return false;
+
+		// This one also hits some different code paths, especially when
+		// KeepData is false on some meshes.
+		model.RecalculateBoundsExact();
+		if (Vec3.DistanceSq(model.Bounds.dimensions, expectedSize) > 0.001f)
+			return false;
+
+		return true;
+	}
+
 	public void Initialize()
 	{
 		Tests.Test(TestBoundsScaledScalar);
@@ -112,6 +149,8 @@ class TestBounds : ITest
 		Tests.Test(TestBoundsScaledScalarIsPure);
 		Tests.Test(TestBoundsScale);
 		Tests.Test(TestBoundsScaleByVec3);
+		Tests.Test(TestMeshBounds);
+		Tests.Test(TestModelBounds);
 	}
 
 	public void Shutdown() { }

--- a/StereoKitC/asset_types/model.cpp
+++ b/StereoKitC/asset_types/model.cpp
@@ -191,10 +191,13 @@ void model_recalculate_bounds_exact(model_t model) {
 	}
 
 	// Get an initial size
-	vec3     first_corner = model->visuals[0].mesh->verts[0].pos;
-	vec3     minf         = matrix_transform_pt( model->visuals[0].transform_model, first_corner);
-	XMVECTOR min          = XMLoadFloat3((XMFLOAT3*)&minf);
-	XMVECTOR max          = XMLoadFloat3((XMFLOAT3*)&minf);
+	vec3 first_corner = model->visuals[0].mesh->verts != nullptr
+		? model->visuals[0].mesh->verts[0].pos
+		: bounds_corner(model->visuals[0].mesh->bounds, 0);
+
+	vec3     minf = matrix_transform_pt( model->visuals[0].transform_model, first_corner);
+	XMVECTOR min  = XMLoadFloat3((XMFLOAT3*)&minf);
+	XMVECTOR max  = XMLoadFloat3((XMFLOAT3*)&minf);
 
 	// Use all the transformed vertices, and factor them in!
 	for (int32_t m = 0; m < model->visuals.count; m += 1) {
@@ -202,11 +205,21 @@ void model_recalculate_bounds_exact(model_t model) {
 		const mesh_t  mesh            = model->visuals[m].mesh;
 		const vert_t* verts           = mesh->verts;
 
-		for (uint32_t i = 0; i < mesh->vert_count; i += 1) {
-			XMVECTOR pt = matrix_mul_pointx(transform_model, verts[i].pos);
+		if (verts != nullptr) {
+			for (uint32_t i = 0; i < mesh->vert_count; i += 1) {
+				XMVECTOR pt = matrix_mul_pointx(transform_model, verts[i].pos);
 
-			min = XMVectorMin(min, pt);
-			max = XMVectorMax(max, pt);
+				min = XMVectorMin(min, pt);
+				max = XMVectorMax(max, pt);
+			}
+		} else {
+			for (int32_t i = 0; i < 8; i += 1) {
+				vec3     corner = bounds_corner(mesh->bounds, i);
+				XMVECTOR pt     = matrix_mul_pointx(transform_model, corner);
+
+				min = XMVectorMin(min, pt);
+				max = XMVectorMax(max, pt);
+			}
 		}
 	}
 

--- a/StereoKitC/intersect.cpp
+++ b/StereoKitC/intersect.cpp
@@ -155,7 +155,9 @@ bounds_t bounds_grow_to_fit_box_opt(bounds_t *opt_bounds, bounds_t box, const ma
 		min   = XMLoadFloat3((XMFLOAT3*)&minf);
 		max   = XMLoadFloat3((XMFLOAT3*)&maxf);
 	} else {
-		vec3 corner = bounds_corner(box, 0);
+		vec3 corner = opt_transform
+			? matrix_transform_pt(*opt_transform, bounds_corner(box, 0))
+			: bounds_corner(box, 0);
 		min   = XMLoadFloat3((XMFLOAT3*)&corner);
 		max   = min;
 		start = 1;


### PR DESCRIPTION
Fix for RecalculateBoundsExact crashing when KeepData is false for an…y involved meshes, #759. Also adds tests, and a fix for incorrect calculation for non-identity initial nodes.