### PR TITLE
Fixe for no final audio effect when a UI element vanishes.

### DIFF
--- a/StereoKitC/ui/stereokit_ui.cpp
+++ b/StereoKitC/ui/stereokit_ui.cpp
@@ -66,6 +66,7 @@ void ui_shutdown() {
 
 void ui_step() {
 	ui_core_update();
+	ui_theming_update();
 
 	ui_push_surface(pose_identity);
 }
@@ -865,7 +866,7 @@ bool32_t ui_slider_at_g(bool vertical, const C *id_text, N &value, N min, N max,
 			
 			if (step != 0) {
 				// Play on every change if there's a user specified step value
-				sound_play(skui_snd_tick, skui_hand[hand].finger_world, 1);
+				ui_play_sound(ui_vis_slider_line, skui_hand[hand].finger_world);
 			} else {
 				// If no user specified step, then we'll do a set number of
 				// clicks across the whole bar.
@@ -876,7 +877,7 @@ bool32_t ui_slider_at_g(bool vertical, const C *id_text, N &value, N min, N max,
 				int32_t new_quantize = (int32_t)(percent     * click_steps + 0.5f);
 
 				if (old_quantize != new_quantize) {
-					sound_play(skui_snd_tick, skui_hand[hand].finger_world, 1);
+					ui_play_sound(ui_vis_slider_line, skui_hand[hand].finger_world);
 				}
 			}
 		}
@@ -962,9 +963,7 @@ bool32_t ui_slider_at_g(bool vertical, const C *id_text, N &value, N min, N max,
 	
 	if (hand >= 0 && hand < 2) {
 		if (button_state & button_state_just_active)
-			sound_play(skui_snd_interact, skui_hand[hand].finger_world, 1);
-		else if (button_state & button_state_just_inactive)
-			sound_play(skui_snd_uninteract, skui_hand[hand].finger_world, 1);
+			ui_play_sound_on_off(ui_vis_slider_pinch, id, skui_hand[hand].finger_world);
 	}
 
 	if      (notify_on == ui_notify_change)   return result;

--- a/StereoKitC/ui/ui_core.cpp
+++ b/StereoKitC/ui/ui_core.cpp
@@ -275,9 +275,7 @@ void ui_button_behavior_depth(vec3 window_relative_pos, vec2 size, uint64_t id, 
 	}
 	
 	if (out_button_state & button_state_just_active)
-		sound_play(skui_snd_interact, skui_hand[hand].finger_world, 1);
-	else if (out_button_state & button_state_just_inactive)
-		sound_play(skui_snd_uninteract, skui_hand[hand].finger_world, 1);
+		ui_play_sound_on_off(ui_vis_button, id, skui_hand[hand].finger_world);
 
 	if (out_opt_hand)
 		*out_opt_hand = hand;
@@ -376,7 +374,7 @@ bool32_t _ui_handle_begin(uint64_t id, pose_t &handle_pose, bounds_t handle_boun
 			if (skui_hand[i].focused_prev == id) {
 				color_blend = 1;
 				if (interact_state[i] & button_state_just_active) {
-					sound_play(skui_snd_grab, skui_hand[i].finger_world, 1);
+					ui_play_sound_on(ui_vis_handle, skui_hand[i].finger_world);
 
 					skui_hand[i].active = id;
 					start_handle_pos[i] = handle_pose.position;
@@ -470,7 +468,7 @@ bool32_t _ui_handle_begin(uint64_t id, pose_t &handle_pose, bounds_t handle_boun
 
 					if (interact_state[i] & button_state_just_inactive) {
 						skui_hand[i].active = 0;
-						sound_play(skui_snd_ungrab, skui_hand[i].finger_world, 1);
+						ui_play_sound_off(ui_vis_handle, skui_hand[i].finger_world);
 					}
 					ui_pop_surface();
 					ui_push_surface(handle_pose);

--- a/StereoKitC/ui/ui_theming.h
+++ b/StereoKitC/ui/ui_theming.h
@@ -9,22 +9,21 @@ extern sprite_t skui_toggle_on;
 extern sprite_t skui_radio_off;
 extern sprite_t skui_radio_on;
 
-extern sound_t  skui_snd_interact;
-extern sound_t  skui_snd_uninteract;
-extern sound_t  skui_snd_grab;
-extern sound_t  skui_snd_ungrab;
-extern sound_t  skui_snd_tick;
-
 extern mesh_t     skui_box_dbg;
 extern material_t skui_mat_dbg;
 extern material_t skui_mat;
 
 void ui_theming_init();
+void ui_theming_update();
 void ui_theming_shutdown();
 
-vec2 ui_get_mesh_minsize(ui_vis_ element_visual);
-void ui_draw_el(ui_vis_ element_visual, vec3 start, vec3 size, ui_color_ color, float focus);
-void ui_draw_cube(vec3 start, vec3 size, ui_color_ color, float focus);
+vec2 ui_get_mesh_minsize (ui_vis_ element_visual);
+void ui_draw_el          (ui_vis_ element_visual, vec3 start, vec3 size, ui_color_ color, float focus);
+void ui_play_sound_on_off(ui_vis_ element_visual, uint64_t element_id, vec3 at);
+void ui_play_sound_on    (ui_vis_ element_visual, vec3 at);
+void ui_play_sound_off   (ui_vis_ element_visual, vec3 at);
+void ui_play_sound       (ui_vis_ element_visual, vec3 at);
+void ui_draw_cube        (vec3 start, vec3 size, ui_color_ color, float focus);
 
 void  ui_anim_start  (uint64_t id);
 bool  ui_anim_has    (uint64_t id, float duration);


### PR DESCRIPTION
When a UI element vanishes upon activation, it doesn't get a chance to play its completion audio effect. This stores the completion audio effect external to the UI element, so it can be activated automatically when the UI element id stops being active.