### PR TITLE
Add `UI.SetElementColor` and `UI.SetElementSound`, plus fixes. #793

### DIFF
--- a/Examples/StereoKitTest/Tools/HolographicTheme.cs
+++ b/Examples/StereoKitTest/Tools/HolographicTheme.cs
@@ -33,6 +33,8 @@ namespace StereoKit.Framework
 			UI.SetElementVisual(UIVisual.WindowBody,  backplate,      uiQuadrantMaterial);
 			UI.SetElementVisual(UIVisual.Separator,   quadrantCube,   uiQuadrantMaterial);
 			UI.SetElementVisual(UIVisual.SliderLine,  backplateSmall, uiQuadrantMaterial);
+			UI.SetElementVisual(UIVisual.SliderLineActive,   backplateSmall, uiQuadrantMaterial, new(0.008f, 0.008f));
+			UI.SetElementVisual(UIVisual.SliderLineInactive, backplateSmall, uiQuadrantMaterial, new(0.008f, 0.008f));
 			UI.SetElementVisual(UIVisual.SliderPinch, backplateSmall, uiQuadrantMaterial);
 			UI.SetElementVisual(UIVisual.SliderPush,  backplateSmall, uiQuadrantMaterial);
 			UI.SetElementVisual(UIVisual.Button,      glassMesh,      uiGlassMaterial);

--- a/StereoKit/Native/NativeAPI.cs
+++ b/StereoKit/Native/NativeAPI.cs
@@ -723,6 +723,8 @@ namespace StereoKit
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   ui_set_theme_color_state(UIColor color_type, UIColorState state, Color color_gamma);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern Color  ui_get_theme_color_state(UIColor color_type, UIColorState state);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   ui_set_element_visual   (UIVisual element_visual, IntPtr mesh, IntPtr material, Vec2 min_size);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   ui_set_element_color    (UIVisual element_visual, UIColor color_type);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   ui_set_element_sound    (UIVisual element_visual, IntPtr activate, IntPtr deactivate);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern Pose   ui_popup_pose           (Vec3 shift);
 
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void ui_push_grab_aura        ([MarshalAs(UnmanagedType.Bool)] bool enabled);

--- a/StereoKit/Native/NativeTypes.cs
+++ b/StereoKit/Native/NativeTypes.cs
@@ -686,6 +686,9 @@ namespace StereoKit
 	/// </summary>
 	public enum UIColor
 	{
+		/// <summary>The default category, used to indicate that no category
+		/// has been selected.</summary>
+		None,
 		/// <summary>This is the main accent color used by window headers,
 		/// separators, etc.</summary>
 		Primary = 0,

--- a/StereoKit/Native/NativeTypes.cs
+++ b/StereoKit/Native/NativeTypes.cs
@@ -688,10 +688,10 @@ namespace StereoKit
 	{
 		/// <summary>The default category, used to indicate that no category
 		/// has been selected.</summary>
-		None,
+		None = 0,
 		/// <summary>This is the main accent color used by window headers,
 		/// separators, etc.</summary>
-		Primary = 0,
+		Primary,
 		/// <summary>This is a background sort of color that should generally
 		/// be dark. Used by window bodies and backgrounds of certain elements.
 		/// </summary>

--- a/StereoKit/Systems/UI.cs
+++ b/StereoKit/Systems/UI.cs
@@ -1354,7 +1354,7 @@ namespace StereoKit
 		/// This lets UI elements to accommodate for this minimum size, and
 		/// behave somewhat more appropriately.</param>
 		public static void SetElementVisual(UIVisual visual, Mesh mesh, Material material = null, Vec2 minSize = default)
-			=> NativeAPI.ui_set_element_visual(visual, mesh?._inst ?? IntPtr.Zero, material?._inst ?? IntPtr.Zero, Vec2.Zero);
+			=> NativeAPI.ui_set_element_visual(visual, mesh?._inst ?? IntPtr.Zero, material?._inst ?? IntPtr.Zero, minSize);
 
 		/// <summary>This allows you to override the color category that a UI
 		/// element is assigned to.</summary>

--- a/StereoKit/Systems/UI.cs
+++ b/StereoKit/Systems/UI.cs
@@ -1333,7 +1333,7 @@ namespace StereoKit
 		public static void PanelEnd() => NativeAPI.ui_panel_end();
 
 		/// <summary>Override the visual assets attached to a particular UI
-		/// element. 
+		/// element.
 		/// 
 		/// Note that StereoKit's default UI assets use a type of quadrant
 		/// sizing that is implemented in the Material _and_ the Mesh. You
@@ -1355,6 +1355,27 @@ namespace StereoKit
 		/// behave somewhat more appropriately.</param>
 		public static void SetElementVisual(UIVisual visual, Mesh mesh, Material material = null, Vec2 minSize = default)
 			=> NativeAPI.ui_set_element_visual(visual, mesh?._inst ?? IntPtr.Zero, material?._inst ?? IntPtr.Zero, Vec2.Zero);
+
+		/// <summary>This allows you to override the color category that a UI
+		/// element is assigned to.</summary>
+		/// <param name="visual">The UI element type to set the color category
+		/// of.</param>
+		/// <param name="colorCategory">The category of color to assign to this
+		/// UI element. Use UI.SetThemeColor in combination with this to assign
+		/// a specific color.</param>
+		public static void SetElementColor(UIVisual visual, UIColor colorCategory)
+			=> NativeAPI.ui_set_element_color(visual, colorCategory);
+
+		/// <summary>This sets the sound that a particulat UI element will make
+		/// when you interact with it. One sound when the interaction starts,
+		/// and one when it ends.</summary>
+		/// <param name="visual">The UI element to apply the sounds to.</param>
+		/// <param name="activate">The sound made when the interaction begins.
+		/// A null sound will fall back to the default sound.</param>
+		/// <param name="deactivate">The sound made when the interaction ends.
+		/// A null sound will fall back to the default sound.</param>
+		public static void SetElementSound(UIVisual visual, Sound activate, Sound deactivate)
+			=> NativeAPI.ui_set_element_sound(visual, activate?._inst ?? IntPtr.Zero, deactivate?._inst ?? IntPtr.Zero);
 
 		/// <summary>This creates a Pose that is friendly towards UI popup
 		/// windows, or windows that are created due to some type of user

--- a/StereoKitC/stereokit_ui.h
+++ b/StereoKitC/stereokit_ui.h
@@ -65,7 +65,8 @@ typedef enum ui_vis_ {
 } ui_vis_;
 
 typedef enum ui_color_ {
-	ui_color_primary = 0,
+	ui_color_none = 0,
+	ui_color_primary,
 	ui_color_background,
 	ui_color_common,
 	ui_color_complement,
@@ -128,6 +129,8 @@ SK_API color128 ui_get_theme_color      (ui_color_ color_type);
 SK_API void     ui_set_theme_color_state(ui_color_ color_type, ui_color_state_ state, color128 color_gamma);
 SK_API color128 ui_get_theme_color_state(ui_color_ color_type, ui_color_state_ state);
 SK_API void     ui_set_element_visual   (ui_vis_ element_visual, mesh_t mesh, material_t material sk_default(nullptr), vec2 min_size sk_default(vec2_zero));
+SK_API void     ui_set_element_color    (ui_vis_ element_visual, ui_color_ color_category);
+SK_API void     ui_set_element_sound    (ui_vis_ element_visual, sound_t activate, sound_t deactivate);
 SK_API bool32_t ui_has_keyboard_focus   (void);
 SK_API pose_t   ui_popup_pose           (vec3 shift);
 

--- a/StereoKitC/ui/stereokit_ui.cpp
+++ b/StereoKitC/ui/stereokit_ui.cpp
@@ -743,7 +743,7 @@ void ui_progress_bar_at_ex(float percent, vec3 start_pos, vec2 size, float focus
 ///////////////////////////////////////////
 
 void ui_progress_bar_at(float percent, vec3 start_pos, vec2 size) {
-	ui_progress_bar_at_ex(percent, start_pos, size, 1, false);
+	ui_progress_bar_at_ex(percent, start_pos, size, 0, false);
 }
 
 ///////////////////////////////////////////
@@ -1097,24 +1097,22 @@ void ui_window_end() {
 		(skui_hand[1].focused_prev != win->hash && skui_hand[1].focused_prev_prev == win->hash))
 		ui_anim_start(win->hash, 1);
 
-	float color_blend = ui_id_focused(win->hash) & button_state_active ? 1.0f : 0.0f;
+	float focus = ui_id_focused(win->hash) & button_state_active ? 1.0f : 0.0f;
 	if (ui_anim_has(win->hash, 0, skui_anim_focus_duration)) {
-		float t = ui_anim_elapsed(win->hash, 0, skui_anim_focus_duration);
-		color_blend = math_ease_smooth(0, 1, t);
+		focus = math_ease_smooth(0, 1, ui_anim_elapsed(win->hash, 0, skui_anim_focus_duration));
 	} else if (ui_anim_has(win->hash, 1, skui_anim_focus_duration)) {
-		float t = ui_anim_elapsed(win->hash, 1, skui_anim_focus_duration);
-		color_blend = math_ease_smooth(1, 0, t);
+		focus = math_ease_smooth(1, 0, ui_anim_elapsed(win->hash, 1, skui_anim_focus_duration));
 	}
 
 	if (win->move != ui_move_none && ui_grab_aura_enabled()) {
 		vec3 aura_start = vec3{ start.x+skui_aura_radius,  start.y+skui_aura_radius,  start.z };
 		vec3 aura_size  = vec3{ size .x+skui_aura_radius*2,size .y+skui_aura_radius*2,size .z };
 		if (win->type & ui_win_head) { aura_start.y += line_height; aura_size.y += line_height; }
-		ui_draw_el(ui_vis_aura, aura_start, aura_size, color_blend);
+		ui_draw_el(ui_vis_aura, aura_start, aura_size, focus);
 	}
 
 	if (win->type & ui_win_head) {
-		ui_draw_el(win->type == ui_win_head ? ui_vis_window_head_only : ui_vis_window_head, start + vec3{0,line_height,0}, { size.x, line_height, size.z }, color_blend);
+		ui_draw_el(win->type == ui_win_head ? ui_vis_window_head_only : ui_vis_window_head, start + vec3{0,line_height,0}, { size.x, line_height, size.z }, focus);
 	}
 	if (win->type & ui_win_body) {
 		ui_draw_el(win->type == ui_win_body ? ui_vis_window_body_only : ui_vis_window_body, start, size, 0);

--- a/StereoKitC/ui/stereokit_ui.cpp
+++ b/StereoKitC/ui/stereokit_ui.cpp
@@ -404,7 +404,7 @@ bool32_t ui_toggle_img_at_g(const C* text, bool32_t& pressed, sprite_t toggle_of
 	finger_offset = pressed ? fminf(skui_pressed_depth * skui_settings.depth, finger_offset) : finger_offset;
 
 	float activation = (1 - (finger_offset / skui_settings.depth)) * 0.5f + ((focus & button_state_active) > 0 ? 0.5f : 0);
-	ui_draw_el(ui_vis_button, window_relative_pos, vec3{ size.x,size.y,finger_offset }, fmaxf(activation, color_blend));
+	ui_draw_el(ui_vis_toggle, window_relative_pos, vec3{ size.x,size.y,finger_offset }, fmaxf(activation, color_blend));
 	_ui_button_img_surface(text, pressed?toggle_on:toggle_off, image_layout, text_align_center, window_relative_pos, size, finger_offset);
 
 	return state & button_state_just_active;

--- a/StereoKitC/ui/stereokit_ui.cpp
+++ b/StereoKitC/ui/stereokit_ui.cpp
@@ -131,7 +131,7 @@ void ui_hseparator() {
 	vec2 size;
 	ui_layout_reserve_sz({ 0, text_style_get_char_height(ui_get_text_style())*0.4f }, false, &pos, &size);
 
-	ui_draw_el(ui_vis_separator, pos, vec3{ size.x, size.y, size.y / 2.0f }, ui_color_primary, 0);
+	ui_draw_el(ui_vis_separator, pos, vec3{ size.x, size.y, size.y / 2.0f }, 0);
 }
 
 ///////////////////////////////////////////
@@ -329,7 +329,7 @@ bool32_t ui_button_img_at_g(const C* text, sprite_t image, ui_btn_layout_ image_
 	}
 
 	float activation = (1 - (finger_offset / skui_settings.depth)) * 0.5f + ((focus & button_state_active) > 0 ? 0.5f : 0);
-	ui_draw_el(ui_vis_button, window_relative_pos, vec3{ size.x,size.y,finger_offset }, ui_color_common, fmaxf(activation, color_blend));
+	ui_draw_el(ui_vis_button, window_relative_pos, vec3{ size.x,size.y,finger_offset }, fmaxf(activation, color_blend));
 	_ui_button_img_surface(text, image, image_layout, text_align_center, window_relative_pos, size, finger_offset);
 
 	return state & button_state_just_active;
@@ -404,7 +404,7 @@ bool32_t ui_toggle_img_at_g(const C* text, bool32_t& pressed, sprite_t toggle_of
 	finger_offset = pressed ? fminf(skui_pressed_depth * skui_settings.depth, finger_offset) : finger_offset;
 
 	float activation = (1 - (finger_offset / skui_settings.depth)) * 0.5f + ((focus & button_state_active) > 0 ? 0.5f : 0);
-	ui_draw_el(ui_vis_button, window_relative_pos, vec3{ size.x,size.y,finger_offset }, ui_color_common, fmaxf(activation, color_blend));
+	ui_draw_el(ui_vis_button, window_relative_pos, vec3{ size.x,size.y,finger_offset }, fmaxf(activation, color_blend));
 	_ui_button_img_surface(text, pressed?toggle_on:toggle_off, image_layout, text_align_center, window_relative_pos, size, finger_offset);
 
 	return state & button_state_just_active;
@@ -474,7 +474,7 @@ bool32_t ui_button_round_at_g(const C *text, sprite_t image, vec3 window_relativ
 	}
 
 	float activation = (1 - (finger_offset / skui_settings.depth)) * 0.5f + ((focus & button_state_active) > 0 ? 0.5f : 0);
-	ui_draw_el(ui_vis_button_round, window_relative_pos, { diameter, diameter, finger_offset }, ui_color_common, fmaxf(activation, color_blend));
+	ui_draw_el(ui_vis_button_round, window_relative_pos, { diameter, diameter, finger_offset }, fmaxf(activation, color_blend));
 
 	float sprite_scale = fmaxf(1, sprite_get_aspect(image));
 	float sprite_size  = (diameter * 0.7f) / sprite_scale;
@@ -634,7 +634,7 @@ bool32_t ui_input_g(const C *id, C *buffer, int32_t buffer_size, vec2 size, text
 
 	// Render the input UI
 	vec2 text_bounds = { final_size.x - skui_settings.padding * 2,final_size.y };
-	ui_draw_el(ui_vis_input, final_pos, vec3{ final_size.x, final_size.y, skui_settings.depth/2 }, ui_color_common, color_blend);
+	ui_draw_el(ui_vis_input, final_pos, vec3{ final_size.x, final_size.y, skui_settings.depth/2 }, color_blend);
 
 	// Swap out for a string of asterisks to hide any password
 	const C* draw_text = buffer;
@@ -676,7 +676,7 @@ bool32_t ui_input_g(const C *id, C *buffer, int32_t buffer_size, vec2 size, text
 
 		// Show a blinking text carat
 		if ((int)((time_totalf_unscaled()-skui_input_blink)*2)%2==0) {
-			ui_draw_el(ui_vis_carat, final_pos - vec3{ skui_settings.padding - carat_pos.x, -carat_pos.y, skui_settings.depth/2 }, vec3{ line * 0.1f, line, line * 0.1f }, ui_color_text, 0);
+			ui_draw_el(ui_vis_carat, final_pos - vec3{ skui_settings.padding - carat_pos.x, -carat_pos.y, skui_settings.depth/2 }, vec3{ line * 0.1f, line, line * 0.1f }, 0);
 		}
 	}
 
@@ -713,17 +713,17 @@ void ui_progress_bar_at_ex(float percent, vec3 start_pos, vec2 size, float focus
 	float bar_length = math_saturate(percent) * size.x;
 	vec2  min_size   = ui_get_mesh_minsize(ui_vis_slider_line_active);
 	if (bar_length <= min_size.x) {
-		ui_draw_el(ui_vis_slider_line,
+		ui_draw_el_color(ui_vis_slider_line, ui_vis_slider_line_inactive,
 			vec3{ 0,      bar_y,      0 },
 			vec3{ size.x, bar_height, bar_depth },
-			ui_color_common, focus);
+			focus);
 		hierarchy_pop();
 		return;
 	} else if (bar_length >= size.x-min_size.x) {
-		ui_draw_el(ui_vis_slider_line,
+		ui_draw_el_color(ui_vis_slider_line, ui_vis_slider_line_active,
 			vec3{ 0,      bar_y,      0 },
 			vec3{ size.x, bar_height, bar_depth },
-			ui_color_primary, focus);
+			focus);
 		hierarchy_pop();
 		return;
 	}
@@ -732,11 +732,11 @@ void ui_progress_bar_at_ex(float percent, vec3 start_pos, vec2 size, float focus
 	ui_draw_el(ui_vis_slider_line_active,
 		vec3{ 0,          bar_y,      0 },
 		vec3{ bar_length, bar_height, bar_depth },
-		ui_color_primary, focus);
+		focus);
 	ui_draw_el(ui_vis_slider_line_inactive,
 		vec3{        - bar_length, bar_y,      0 },
 		vec3{ size.x - bar_length, bar_height, bar_depth },
-		ui_color_common, focus);
+		focus);
 	hierarchy_pop();
 }
 
@@ -868,7 +868,7 @@ bool32_t ui_slider_at_g(bool vertical, const C *id_text, N &value, N min, N max,
 			
 			if (step != 0) {
 				// Play on every change if there's a user specified step value
-				ui_play_sound(ui_vis_slider_line, skui_hand[hand].finger_world);
+				ui_play_sound_on(ui_vis_slider_line, skui_hand[hand].finger_world);
 			} else {
 				// If no user specified step, then we'll do a set number of
 				// clicks across the whole bar.
@@ -879,7 +879,7 @@ bool32_t ui_slider_at_g(bool vertical, const C *id_text, N &value, N min, N max,
 				int32_t new_quantize = (int32_t)(percent     * click_steps + 0.5f);
 
 				if (old_quantize != new_quantize) {
-					ui_play_sound(ui_vis_slider_line, skui_hand[hand].finger_world);
+					ui_play_sound_on(ui_vis_slider_line, skui_hand[hand].finger_world);
 				}
 			}
 		}
@@ -915,12 +915,12 @@ bool32_t ui_slider_at_g(bool vertical, const C *id_text, N &value, N min, N max,
 		ui_draw_el(ui_vis_slider_push,
 			vec3{x - slide_x_rel, y - slide_y_rel, window_relative_pos.z},
 			vec3{button_size.x, button_size.y, fmaxf(finger_offset,rule_size*skui_pressed_depth +mm2m)},
-			ui_color_primary, color_blend);
+			color_blend);
 	} else if (confirm_method == ui_confirm_pinch || confirm_method == ui_confirm_variable_pinch) {
 		ui_draw_el(ui_vis_slider_pinch,
 			vec3{x - slide_x_rel, y - slide_y_rel, window_relative_pos.z},
 			vec3{button_size.x, button_size.y, button_depth},
-			ui_color_primary, color_blend);
+			color_blend);
 
 		vec3 pinch_local = hand < 0
 			? vec3_zero
@@ -959,7 +959,7 @@ bool32_t ui_slider_at_g(bool vertical, const C *id_text, N &value, N min, N max,
 					? vec3{ x - slide_x_rel, scaled_at - slide_y_rel * scale, window_relative_pos.z + z }
 					: vec3{ scaled_at - slide_x_rel * scale, y - slide_y_rel, window_relative_pos.z + z },
 				vec3{ button_size.x, button_size.y, button_depth },
-				ui_color_primary, color_blend);
+				color_blend);
 		}
 	}
 	
@@ -1110,14 +1110,14 @@ void ui_window_end() {
 		vec3 aura_start = vec3{ start.x+skui_aura_radius,  start.y+skui_aura_radius,  start.z };
 		vec3 aura_size  = vec3{ size .x+skui_aura_radius*2,size .y+skui_aura_radius*2,size .z };
 		if (win->type & ui_win_head) { aura_start.y += line_height; aura_size.y += line_height; }
-		ui_draw_el(ui_vis_aura, aura_start, aura_size, ui_color_text, color_blend); 
+		ui_draw_el(ui_vis_aura, aura_start, aura_size, color_blend);
 	}
 
 	if (win->type & ui_win_head) {
-		ui_draw_el(win->type == ui_win_head ? ui_vis_window_head_only : ui_vis_window_head, start + vec3{0,line_height,0}, { size.x, line_height, size.z }, ui_color_primary, color_blend);
+		ui_draw_el(win->type == ui_win_head ? ui_vis_window_head_only : ui_vis_window_head, start + vec3{0,line_height,0}, { size.x, line_height, size.z }, color_blend);
 	}
 	if (win->type & ui_win_body) {
-		ui_draw_el(win->type == ui_win_body ? ui_vis_window_body_only : ui_vis_window_body, start, size, ui_color_background, 0);
+		ui_draw_el(win->type == ui_win_body ? ui_vis_window_body_only : ui_vis_window_body, start, size, 0);
 	}
 	ui_handle_end();
 	ui_pop_id();
@@ -1134,7 +1134,7 @@ void ui_panel_at(vec3 start, vec2 size, ui_pad_ padding) {
 		start_offset = { gutter,  gutter,  0 };
 		size_offset  = { gutter2, gutter2, 0 };
 	}
-	ui_draw_el(ui_vis_panel, start+start_offset, vec3{ size.x, size.y, skui_settings.depth* 0.1f }+size_offset, ui_color_complement, 0);
+	ui_draw_el(ui_vis_panel, start+start_offset, vec3{ size.x, size.y, skui_settings.depth* 0.1f }+size_offset, 0);
 }
 
 } // namespace sk

--- a/StereoKitC/ui/ui_core.cpp
+++ b/StereoKitC/ui/ui_core.cpp
@@ -487,7 +487,6 @@ bool32_t _ui_handle_begin(uint64_t id, pose_t &handle_pose, bounds_t handle_boun
 		ui_draw_el(ui_vis_handle,
 			handle_bounds.center+handle_bounds.dimensions/2,
 			handle_bounds.dimensions,
-			ui_color_primary,
 			color_blend);
 		ui_nextline();
 	}

--- a/StereoKitC/ui/ui_theming.cpp
+++ b/StereoKitC/ui/ui_theming.cpp
@@ -193,29 +193,34 @@ void ui_theming_init() {
 	skui_aura_mat = material_find(default_id_material_ui_aura);
 
 	ui_set_element_visual(ui_vis_default,              skui_box,         skui_mat_quad, skui_box_min);
-	ui_set_element_color (ui_vis_default,              ui_color_common);
 	ui_set_element_visual(ui_vis_window_head,          skui_box_top,     nullptr);
-	ui_set_element_color (ui_vis_window_head,          ui_color_primary);
 	ui_set_element_visual(ui_vis_window_body,          skui_box_bot,     nullptr);
-	ui_set_element_color (ui_vis_window_body,          ui_color_background);
 	ui_set_element_visual(ui_vis_separator,            skui_box_dbg,     skui_mat);
-	ui_set_element_color (ui_vis_separator,            ui_color_primary);
 	ui_set_element_visual(ui_vis_carat,                skui_box_dbg,     skui_mat);
 	ui_set_element_visual(ui_vis_button_round,         skui_cylinder,    skui_mat);
 	ui_set_element_visual(ui_vis_slider_line,          skui_small,       skui_mat_quad, skui_small_min);
 	ui_set_element_visual(ui_vis_slider_line_active,   skui_small_left,  skui_mat_quad, skui_small_min);
-	ui_set_element_color (ui_vis_slider_line_active,   ui_color_primary);
 	ui_set_element_visual(ui_vis_slider_line_inactive, skui_small_right, skui_mat_quad, skui_small_min);
-	ui_set_element_color (ui_vis_slider_line_inactive, ui_color_common);
 	ui_set_element_visual(ui_vis_slider_pinch,         skui_small,       skui_mat_quad, skui_small_min);
-	ui_set_element_color (ui_vis_slider_pinch,         ui_color_primary);
 	ui_set_element_visual(ui_vis_slider_push,          skui_small,       skui_mat_quad, skui_small_min);
-	ui_set_element_color (ui_vis_slider_push,          ui_color_primary);
 	ui_set_element_visual(ui_vis_aura,                 skui_aura_mesh,   skui_aura_mat);
+
+	ui_set_element_color (ui_vis_default,              ui_color_common);
+	ui_set_element_color (ui_vis_window_head,          ui_color_primary);
+	ui_set_element_color (ui_vis_window_head_only,     ui_color_primary);
+	ui_set_element_color (ui_vis_window_body,          ui_color_background);
+	ui_set_element_color (ui_vis_window_body_only,     ui_color_background);
+	ui_set_element_color (ui_vis_separator,            ui_color_primary);
+	ui_set_element_color (ui_vis_slider_line,          ui_color_common);
+	ui_set_element_color (ui_vis_slider_line_active,   ui_color_primary);
+	ui_set_element_color (ui_vis_slider_line_inactive, ui_color_common);
+	ui_set_element_color (ui_vis_slider_pinch,         ui_color_primary);
+	ui_set_element_color (ui_vis_slider_push,          ui_color_primary);
 	ui_set_element_color (ui_vis_aura,                 ui_color_text);
 	ui_set_element_color (ui_vis_panel,                ui_color_complement);
 	ui_set_element_color (ui_vis_handle,               ui_color_primary);
 	ui_set_element_color (ui_vis_button,               ui_color_common);
+	ui_set_element_color (ui_vis_toggle,               ui_color_common);
 	ui_set_element_color (ui_vis_button_round,         ui_color_common);
 	ui_set_element_color (ui_vis_input,                ui_color_common);
 	ui_set_element_color (ui_vis_carat,                ui_color_text);
@@ -239,6 +244,8 @@ void ui_theming_shutdown() {
 	for (int32_t i = 0; i < ui_vis_max; i++) {
 		mesh_release    (skui_visuals[i].mesh);
 		material_release(skui_visuals[i].material);
+		sound_release   (skui_visuals[i].snd_activate);
+		sound_release   (skui_visuals[i].snd_deactivate);
 		skui_visuals[i] = {};
 	}
 
@@ -305,17 +312,16 @@ void ui_theming_update() {
 ///////////////////////////////////////////
 
 void ui_set_element_visual(ui_vis_ element_visual, mesh_t mesh, material_t material, vec2 min_size) {
-	ui_el_visual_t visual = {};
+	ui_el_visual_t *vis = &skui_visuals[element_visual];
 
-	if (mesh                                  != nullptr) mesh_addref     (mesh);
-	if (material                              != nullptr) material_addref (material);
-	if (skui_visuals[element_visual].mesh     != nullptr) mesh_release    (skui_visuals[element_visual].mesh);
-	if (skui_visuals[element_visual].material != nullptr) material_release(skui_visuals[element_visual].material);
+	if (mesh          != nullptr) mesh_addref     (mesh);
+	if (material      != nullptr) material_addref (material);
+	if (vis->mesh     != nullptr) mesh_release    (vis->mesh);
+	if (vis->material != nullptr) material_release(vis->material);
 
-	visual.mesh     = mesh;
-	visual.material = material;
-	visual.min_size = min_size;
-	skui_visuals[element_visual] = visual;
+	vis->mesh     = mesh;
+	vis->material = material;
+	vis->min_size = min_size;
 }
 
 ///////////////////////////////////////////

--- a/StereoKitC/ui/ui_theming.h
+++ b/StereoKitC/ui/ui_theming.h
@@ -17,13 +17,14 @@ void ui_theming_init();
 void ui_theming_update();
 void ui_theming_shutdown();
 
-vec2 ui_get_mesh_minsize (ui_vis_ element_visual);
-void ui_draw_el          (ui_vis_ element_visual, vec3 start, vec3 size, float focus);
-void ui_draw_el_color    (ui_vis_ element_visual, ui_vis_ element_color, vec3 start, vec3 size, float focus);
-void ui_play_sound_on_off(ui_vis_ element_visual, uint64_t element_id, vec3 at);
-void ui_play_sound_on    (ui_vis_ element_visual, vec3 at);
-void ui_play_sound_off   (ui_vis_ element_visual, vec3 at);
-void ui_draw_cube        (vec3 start, vec3 size, ui_color_ color, float focus);
+vec2     ui_get_mesh_minsize (ui_vis_ element_visual);
+void     ui_draw_el          (ui_vis_ element_visual, vec3 start, vec3 size, float focus);
+void     ui_draw_el_color    (ui_vis_ element_visual, ui_vis_ element_color, vec3 start, vec3 size, float focus);
+color128 ui_get_el_color     (ui_vis_ element_visual, float focus);
+void     ui_play_sound_on_off(ui_vis_ element_visual, uint64_t element_id, vec3 at);
+void     ui_play_sound_on    (ui_vis_ element_visual, vec3 at);
+void     ui_play_sound_off   (ui_vis_ element_visual, vec3 at);
+void     ui_draw_cube        (vec3 start, vec3 size, ui_color_ color, float focus);
 
 void  ui_anim_start  (uint64_t id, int32_t channel);
 bool  ui_anim_has    (uint64_t id, int32_t channel, float duration);

--- a/StereoKitC/ui/ui_theming.h
+++ b/StereoKitC/ui/ui_theming.h
@@ -18,11 +18,11 @@ void ui_theming_update();
 void ui_theming_shutdown();
 
 vec2 ui_get_mesh_minsize (ui_vis_ element_visual);
-void ui_draw_el          (ui_vis_ element_visual, vec3 start, vec3 size, ui_color_ color, float focus);
+void ui_draw_el          (ui_vis_ element_visual, vec3 start, vec3 size, float focus);
+void ui_draw_el_color    (ui_vis_ element_visual, ui_vis_ element_color, vec3 start, vec3 size, float focus);
 void ui_play_sound_on_off(ui_vis_ element_visual, uint64_t element_id, vec3 at);
 void ui_play_sound_on    (ui_vis_ element_visual, vec3 at);
 void ui_play_sound_off   (ui_vis_ element_visual, vec3 at);
-void ui_play_sound       (ui_vis_ element_visual, vec3 at);
 void ui_draw_cube        (vec3 start, vec3 size, ui_color_ color, float focus);
 
 void  ui_anim_start  (uint64_t id, int32_t channel);


### PR DESCRIPTION
Also fixes a few other things

- UI.SetElementVisual now properly sends minimum size down to C++.
- UI.Toggle properly uses the visual from UIVisual.Toggle instead of button.
- Progress bars are no longer permanently focused.