### PR TITLE
Get MSFT spatial anchor from SK virtual anchor

### DIFF
--- a/StereoKit/Assets/Anchor.cs
+++ b/StereoKit/Assets/Anchor.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 
 namespace StereoKit {
 	public class Anchor : IAsset
@@ -15,7 +16,17 @@ namespace StereoKit {
 		public BtnState Tracked => NativeAPI.anchor_get_tracked(_inst);
 		public bool Persistent => NativeAPI.anchor_get_persistent(_inst);
 		public string Name => NativeHelper.FromUtf8(NativeAPI.anchor_get_name(_inst));
-
+		public bool TryGetPerceptionAnchor<T>(out T spatialAnchor) where T : class
+		{
+			spatialAnchor = null;
+			bool result = NativeAPI.anchor_get_perception_anchor(_inst, out IntPtr pointer);
+			if (result)
+			{
+				spatialAnchor = (T)Marshal.GetObjectForIUnknown(pointer);
+			}
+			return result;
+		}
+		
 		internal Anchor(IntPtr anchor)
 		{
 			_inst = anchor;

--- a/StereoKit/Assets/Anchor.cs
+++ b/StereoKit/Assets/Anchor.cs
@@ -16,13 +16,20 @@ namespace StereoKit {
 		public BtnState Tracked => NativeAPI.anchor_get_tracked(_inst);
 		public bool Persistent => NativeAPI.anchor_get_persistent(_inst);
 		public string Name => NativeHelper.FromUtf8(NativeAPI.anchor_get_name(_inst));
+		
+		/// <summary>Tries to get the underlying perception spatial anchor 
+		/// for platforms using Microsoft spatial anchors.</summary>
+		/// <typeparam name="T">The type of the spatial anchor. Must be an instance 
+		/// of Windows.Perception.Spatial.SpatialAnchor.</typeparam>
+		/// <param name="spatialAnchor">The spatial anchor.</param>
+		/// <returns>True if the perception spatial anchor was successfully obtained, false otherwise.</returns>
 		public bool TryGetPerceptionAnchor<T>(out T spatialAnchor) where T : class
 		{
 			spatialAnchor = null;
 			bool result = NativeAPI.anchor_get_perception_anchor(_inst, out IntPtr pointer);
 			if (result)
 			{
-				spatialAnchor = (T)Marshal.GetObjectForIUnknown(pointer);
+				spatialAnchor = Marshal.GetObjectForIUnknown(pointer) as T;
 			}
 			return result;
 		}

--- a/StereoKit/Native/NativeAPI.cs
+++ b/StereoKit/Native/NativeAPI.cs
@@ -412,7 +412,7 @@ namespace StereoKit
 		[return: MarshalAs(UnmanagedType.Bool)]
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern bool   model_node_info_remove        (IntPtr model, int node, [In] byte[] info_key_u8);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   model_node_info_clear         (IntPtr model, int node);
-        [DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern int    model_node_info_count         (IntPtr model, int node);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern int    model_node_info_count         (IntPtr model, int node);
 		[return: MarshalAs(UnmanagedType.Bool)]
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern bool   model_node_info_iterate       (IntPtr model, int node, ref int ref_iterator, out IntPtr out_key_utf8, out IntPtr out_value_utf8);
 
@@ -607,6 +607,7 @@ namespace StereoKit
 		[DllImport(dll, CallingConvention = call                 )] public static extern IntPtr              anchor_get_index    (int index);
 		[DllImport(dll, CallingConvention = call                 )] public static extern int                 anchor_get_new_count();
 		[DllImport(dll, CallingConvention = call                 )] public static extern IntPtr              anchor_get_new_index(int index);
+		[DllImport(dll, CallingConvention = call                 )] public static extern bool                anchor_get_perception_anchor(IntPtr anchor, out IntPtr perception_spatial_anchor);
 
 		///////////////////////////////////////////
 

--- a/StereoKitC/asset_types/anchor.cpp
+++ b/StereoKitC/asset_types/anchor.cpp
@@ -243,6 +243,16 @@ button_state_ anchor_get_tracked(const anchor_t anchor) {
 
 ///////////////////////////////////////////
 
+bool32_t anchor_get_perception_anchor(const anchor_t anchor, void** perception_spatial_anchor) {
+#if !defined(SK_XR_OPENXR)
+	return false;
+#endif
+	if (anch_sys != anchor_system_openxr_msft) return false;
+	return anchor_oxr_get_perception_anchor(anchor, perception_spatial_anchor);
+}
+
+///////////////////////////////////////////
+
 void anchor_mark_dirty(anchor_t anchor) {
 	if (anchor->changed == false) {
 		anchor->changed = true;

--- a/StereoKitC/stereokit.h
+++ b/StereoKitC/stereokit.h
@@ -2160,6 +2160,7 @@ SK_API pose_t         anchor_get_pose          (const anchor_t anchor);
 SK_API bool32_t       anchor_get_changed       (const anchor_t anchor);
 SK_API const char*    anchor_get_name          (const anchor_t anchor);
 SK_API button_state_  anchor_get_tracked       (const anchor_t anchor);
+SK_API bool32_t       anchor_get_perception_anchor(const anchor_t anchor, void** perception_spatial_anchor);
 
 SK_API void           anchor_clear_stored      (void);
 SK_API anchor_caps_   anchor_get_capabilities  (void);

--- a/StereoKitC/xr_backends/anchor_openxr_msft.cpp
+++ b/StereoKitC/xr_backends/anchor_openxr_msft.cpp
@@ -205,6 +205,7 @@ bool32_t anchor_oxr_msft_persist(anchor_t anchor, bool32_t persist) {
 ///////////////////////////////////////////
 
 bool32_t anchor_oxr_get_perception_anchor(anchor_t anchor, void **perception_spatial_anchor) {
+#if defined(SK_OS_WINDOWS_UWP)
 	if (!xr_ext_available.MSFT_perception_anchor_interop) return false;
 	oxr_msft_world_anchor_t* anchor_data = (oxr_msft_world_anchor_t*)anchor->data;
 	XrResult result = xr_extensions.xrTryGetPerceptionAnchorFromSpatialAnchorMSFT(xr_session, anchor_data->anchor, (IUnknown**)perception_spatial_anchor);
@@ -213,6 +214,10 @@ bool32_t anchor_oxr_get_perception_anchor(anchor_t anchor, void **perception_spa
 		return false;
 	}
 	return true;
+#else
+	log_warn("anchor_oxr_get_perception_anchor not available outside of Windows UWP!");
+	return false;
+#endif
 }
 
 } // namespace sk

--- a/StereoKitC/xr_backends/anchor_openxr_msft.cpp
+++ b/StereoKitC/xr_backends/anchor_openxr_msft.cpp
@@ -202,5 +202,18 @@ bool32_t anchor_oxr_msft_persist(anchor_t anchor, bool32_t persist) {
 	return true;
 }
 
+///////////////////////////////////////////
+
+bool32_t anchor_oxr_get_perception_anchor(anchor_t anchor, void **perception_spatial_anchor) {
+	if (!xr_ext_available.MSFT_perception_anchor_interop) return false;
+	oxr_msft_world_anchor_t* anchor_data = (oxr_msft_world_anchor_t*)anchor->data;
+	XrResult result = xr_extensions.xrTryGetPerceptionAnchorFromSpatialAnchorMSFT(xr_session, anchor_data->anchor, (IUnknown**)perception_spatial_anchor);
+	if (XR_FAILED(result)) {
+		log_warnf("xrTryGetPerceptionAnchorFromSpatialAnchorMSFT failed: %s", openxr_string(result));
+		return false;
+	}
+	return true;
+}
+
 } // namespace sk
 #endif

--- a/StereoKitC/xr_backends/anchor_openxr_msft.h
+++ b/StereoKitC/xr_backends/anchor_openxr_msft.h
@@ -19,6 +19,7 @@ void     anchor_oxr_msft_destroy     (anchor_t anchor);
 void     anchor_oxr_msft_clear_stored();
 bool32_t anchor_oxr_msft_persist     (anchor_t anchor, bool32_t persist);
 anchor_caps_ anchor_oxr_msft_capabilities();
+bool32_t anchor_oxr_get_perception_anchor(anchor_t anchor, void **perception_spatial_anchor);
 
 } // namespace sk
 

--- a/StereoKitC/xr_backends/openxr_extensions.h
+++ b/StereoKitC/xr_backends/openxr_extensions.h
@@ -205,6 +205,7 @@ namespace sk {
 	_(xrConvertWin32PerformanceCounterToTimeKHR)     \
 	_(xrConvertTimeToWin32PerformanceCounterKHR)     \
 	_(xrCreateSpatialAnchorFromPerceptionAnchorMSFT) \
+	_(xrTryGetPerceptionAnchorFromSpatialAnchorMSFT) \
 	_(xrGetAudioOutputDeviceGuidOculus)              \
 	_(xrGetAudioInputDeviceGuidOculus)
 #else


### PR DESCRIPTION
For anchors created in the SK's "virtual" world, it would be helpful to have the "real" spatial anchor since certain UWP actions require it when moving between coordinate systems.

This can be used like the following:
```
bool result = anchor.TryGetPerceptionAnchor(out Windows.Perception.Spatial.SpatialAnchor spatialAnchor);
```