### PR TITLE
Theme refresh

### DIFF
--- a/StereoKit/Native/NativeAPI.cs
+++ b/StereoKit/Native/NativeAPI.cs
@@ -709,6 +709,7 @@ namespace StereoKit
 
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   ui_quadrant_size_verts  ([In, Out] Vertex[] ref_vertices, int vertex_count, float overflow);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   ui_quadrant_size_mesh   (IntPtr ref_mesh, float overflow);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr ui_gen_quadrant_mesh    (UICorner rounded_corners, float corner_radius, uint corner_resolution, [MarshalAs(UnmanagedType.Bool)] bool delete_flat_sides, [In] UILathePt[] lathe_pts, int lathe_pt_count);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   ui_show_volumes         ([MarshalAs(UnmanagedType.Bool)] bool show);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   ui_enable_far_interact  ([MarshalAs(UnmanagedType.Bool)] bool enable);
 		[return: MarshalAs(UnmanagedType.Bool)]

--- a/StereoKit/Native/NativeTypes.cs
+++ b/StereoKit/Native/NativeTypes.cs
@@ -810,6 +810,7 @@ namespace StereoKit
 		public Vec2 normal;
 		public Color32 color;
 		[MarshalAs(UnmanagedType.Bool)] public bool connectNext;
+		[MarshalAs(UnmanagedType.Bool)] public bool flipFace;
 	}
 
 	/// <summary>Id of a simulated hand pose, for use with

--- a/StereoKit/Native/NativeTypes.cs
+++ b/StereoKit/Native/NativeTypes.cs
@@ -789,6 +789,29 @@ namespace StereoKit
 		Bottom,
 	}
 
+	public enum UICorner
+	{
+		None        = 0,
+		TopRight    = 1 << 1,
+		TopLeft     = 1 << 0,
+		BottomLeft  = 1 << 3,
+		BottomRight = 1 << 2,
+		All    = TopLeft    | TopRight | BottomLeft | BottomRight,
+		Top    = TopLeft    | TopRight,
+		Bottom = BottomLeft | BottomRight,
+		Left   = TopLeft    | BottomLeft,
+		Right  = TopRight   | BottomRight,
+	}
+
+	[StructLayout(LayoutKind.Sequential)]
+	public struct UILathePt
+	{
+		public Vec2 pt;
+		public Vec2 normal;
+		public Color32 color;
+		[MarshalAs(UnmanagedType.Bool)] public bool connectNext;
+	}
+
 	/// <summary>Id of a simulated hand pose, for use with
 	/// `Input.HandSimPoseRemove`</summary>
 	public struct HandSimId

--- a/StereoKit/Systems/UI.cs
+++ b/StereoKit/Systems/UI.cs
@@ -1422,6 +1422,12 @@ namespace StereoKit
 		public static void QuadrantSizeMesh(ref Mesh mesh, float overflowPercent = 0)
 			=> NativeAPI.ui_quadrant_size_mesh(mesh?._inst ?? IntPtr.Zero, overflowPercent);
 
+		public static Mesh GenQuadrantMesh(UICorner roundedCorners, float cornerRadius, uint cornerResolution, bool deleteFlatSides, params UILathePt[] lathePts)
+		{
+			IntPtr result = NativeAPI.ui_gen_quadrant_mesh(roundedCorners, cornerRadius, cornerResolution, deleteFlatSides, lathePts, lathePts.Length);
+			return result != IntPtr.Zero ? new Mesh(result) : null;
+		}
+
 		/// <summary>This will hash the given text based id into a hash for use
 		/// with certain StereoKit UI functions. This includes the hash of the
 		/// current id stack.</summary>

--- a/StereoKitC/shaders_builtin/shader_builtin_ui.hlsl
+++ b/StereoKitC/shaders_builtin/shader_builtin_ui.hlsl
@@ -1,7 +1,6 @@
 #include "stereokit.hlsli"
 
 //--color:color = 1, 1, 1, 1
-//--ui_tint     = 0
 //--diffuse     = white
 float4       color;
 Texture2D    diffuse   : register(t0);

--- a/StereoKitC/shaders_builtin/shader_builtin_ui.hlsl
+++ b/StereoKitC/shaders_builtin/shader_builtin_ui.hlsl
@@ -1,11 +1,9 @@
 #include "stereokit.hlsli"
 
-//--name = sk/default_ui
 //--color:color = 1, 1, 1, 1
 //--ui_tint     = 0
 //--diffuse     = white
 float4       color;
-bool         ui_tint;
 Texture2D    diffuse   : register(t0);
 SamplerState diffuse_s : register(s0);
 
@@ -19,7 +17,6 @@ struct psIn {
 	float4 pos     : SV_POSITION;
 	float2 uv      : TEXCOORD0;
 	float3 world   : TEXCOORD1;
-	half3  normal  : NORMAL0;
 	half3  color   : COLOR0;
 	uint   view_id : SV_RenderTargetArrayIndex;
 };
@@ -29,21 +26,18 @@ psIn vs(vsIn input, uint id : SV_InstanceID) {
 	o.view_id = id % sk_view_count;
 	id        = id / sk_view_count;
 
-	float4 world = mul(input.pos, sk_inst[id].world);
-	o.pos    = mul(world, sk_viewproj[o.view_id]);
-	o.normal = normalize(mul(input.norm, (float3x3)sk_inst[id].world));
-	o.world  = world.xyz;
-
+	float3 normal = normalize(mul(input.norm, (float3x3) sk_inst[id].world));
+	float4 world  = mul(input.pos, sk_inst[id].world);
+	o.pos   = mul(world, sk_viewproj[o.view_id]);
+	o.world = world.xyz;
 	o.uv    = input.uv;
-	o.color = (ui_tint == true
-		? lerp(color, sk_inst[id].color, input.color.a)
-		: (color * input.color * sk_inst[id].color)).rgb * sk_lighting(o.normal);
-
+	o.color = (color * input.color * sk_inst[id].color).rgb * sk_lighting(normal);
 	return o;
 }
+
 float4 ps(psIn input) : SV_TARGET {
-	float  glow = sk_finger_glow(input.world, input.normal);
-	float4 col  = float4(lerp(input.color, float3(2,2,2), glow), 1);
+	float  glow = pow(1 - saturate(sk_finger_distance(input.world) / 0.12), 10);
+	float4 col  = float4(lerp(input.color.rgb, half3(1, 1, 1), glow), 1);
 
 	return diffuse.Sample(diffuse_s, input.uv) * col;
 }

--- a/StereoKitC/shaders_builtin/shader_builtin_ui_quadrant.hlsl
+++ b/StereoKitC/shaders_builtin/shader_builtin_ui_quadrant.hlsl
@@ -1,9 +1,5 @@
 #include "stereokit.hlsli"
 
-//--color:color = 1, 1, 1, 1
-
-float4 color;
-
 struct vsIn {
 	float4 pos      : SV_Position;
 	float3 norm     : NORMAL0;

--- a/StereoKitC/stereokit_ui.h
+++ b/StereoKitC/stereokit_ui.h
@@ -119,6 +119,7 @@ typedef struct ui_lathe_pt_t {
 	vec2     normal;
 	color32  color;
 	bool32_t connect_next;
+	bool32_t flip_face;
 } ui_lathe_pt_t;
 
 typedef struct ui_settings_t {

--- a/StereoKitC/stereokit_ui.h
+++ b/StereoKitC/stereokit_ui.h
@@ -101,6 +101,26 @@ typedef enum ui_cut_ {
 	ui_cut_bottom,
 } ui_cut_;
 
+typedef enum ui_corner_ {
+	ui_corner_none         = 0,
+	ui_corner_top_left     = 1 << 0,
+	ui_corner_top_right    = 1 << 1,
+	ui_corner_bottom_right = 1 << 2,
+	ui_corner_bottom_left  = 1 << 3,
+	ui_corner_all          = ui_corner_top_left    | ui_corner_top_right | ui_corner_bottom_left | ui_corner_bottom_right,
+	ui_corner_top          = ui_corner_top_left    | ui_corner_top_right,
+	ui_corner_bottom       = ui_corner_bottom_left | ui_corner_bottom_right,
+	ui_corner_left         = ui_corner_top_left    | ui_corner_bottom_left,
+	ui_corner_right        = ui_corner_top_right   | ui_corner_bottom_right,
+} ui_corner_;
+
+typedef struct ui_lathe_pt_t {
+	vec2     pt;
+	vec2     normal;
+	color32  color;
+	bool32_t connect_next;
+} ui_lathe_pt_t;
+
 typedef struct ui_settings_t {
 	float margin;
 	float padding;
@@ -113,6 +133,7 @@ typedef struct ui_settings_t {
 
 SK_API void     ui_quadrant_size_verts  (vert_t *ref_vertices, int32_t vertex_count, float overflow_percent);
 SK_API void     ui_quadrant_size_mesh   (mesh_t ref_mesh, float overflow_percent);
+SK_API mesh_t   ui_gen_quadrant_mesh    (ui_corner_ rounded_corners, float corner_radius, uint32_t corner_resolution, bool32_t delete_flat_sides, const ui_lathe_pt_t* lathe_pts, int32_t lathe_pt_count);
 SK_API void     ui_show_volumes         (bool32_t      show);
 SK_API void     ui_enable_far_interact  (bool32_t      enable);
 SK_API bool32_t ui_far_interact_enabled (void);

--- a/StereoKitC/ui/ui_theming.cpp
+++ b/StereoKitC/ui/ui_theming.cpp
@@ -5,6 +5,7 @@
 #include "../libraries/array.h"
 #include "../utils/sdf.h"
 #include "../sk_math.h"
+#include "../platforms/platform.h"
 
 #include <float.h>
 
@@ -71,6 +72,7 @@ void _ui_gen_quadrant_mesh(mesh_t* mesh, ui_corner_ rounded_corners, float corne
 void ui_default_aura_mesh (mesh_t* mesh, float diameter, float rounding, float shrink, int32_t quadrant_slices, int32_t tube_corners);
 void ui_theme_visuals_update ();
 void ui_theme_visuals_release();
+void ui_theme_visuals_assign ();
 
 ///////////////////////////////////////////
 
@@ -176,6 +178,8 @@ void ui_theming_init() {
 	skui_snd_uninteract = sound_find(default_id_sound_unclick);
 	skui_snd_grab       = sound_find(default_id_sound_grab);
 	skui_snd_ungrab     = sound_find(default_id_sound_ungrab);
+
+	ui_theme_visuals_assign();
 
 	ui_set_element_color(ui_vis_none,                 ui_color_common);
 	ui_set_element_color(ui_vis_default,              ui_color_common);
@@ -752,12 +756,12 @@ void _ui_gen_quadrant_mesh(mesh_t *mesh, ui_corner_ rounded_corners, float corne
 		bool rounded_next = (rounded_corners & (ui_corner_)(1 << (int32_t)((c + 1) % 4))) != 0;
 		bool rounded_prev = (rounded_corners & (ui_corner_)(1 << (int32_t)((c+3)%4))) != 0;
 		// 1,1   -1,1   -1,-1   1,-1
-		float u = c == 0 || c == 3 ? 1 : -1;
-		float v = c == 0 || c == 1 ? 1 : -1;
+		float u = c == 0 || c == 3 ? 1.f : -1.f;
+		float v = c == 0 || c == 1 ? 1.f : -1.f;
 
 		vec3     offset       = { -u * corner_radius, -v * corner_radius, 0 };
 		uint32_t corner_count = corner_resolution;
-		float    angle_start  = c * 90;
+		float    angle_start  = c * 90.f;
 		float    curr_radius  = corner_radius;
 		if (delete_flat_sides && rounded == false && (rounded_next == false || rounded_prev == false)) {
 			corner_count = 1;
@@ -780,7 +784,7 @@ void _ui_gen_quadrant_mesh(mesh_t *mesh, ui_corner_ rounded_corners, float corne
 			vec2  dir = vec2{ cosf(ang), sinf(ang) };
 
 			int32_t p_ct = -1;
-			for (uint32_t p = 0; p < lathe_pt_count; p++) {
+			for (uint32_t p = 0; p < (uint32_t)lathe_pt_count; p++) {
 				ui_lathe_pt_t lp = lathe_pts[p];
 				vert_t        vert;
 				vert.col  = lp.color;
@@ -794,7 +798,7 @@ void _ui_gen_quadrant_mesh(mesh_t *mesh, ui_corner_ rounded_corners, float corne
 
 				if (is_root == false) p_ct += 1;
 
-				if (lp.connect_next == false || p+1 == lathe_pt_count || (s+1==corner_count && delete_flat_sides && rounded == false && rounded_next == false)) continue;
+				if (lp.connect_next == false || p+1 == (uint32_t)lathe_pt_count || (s+1==corner_count && delete_flat_sides && rounded == false && rounded_next == false)) continue;
 
 				bool     top_is_root   = lathe_pts[p + 1].pt.x == 0;
 				bool     next_corner   = s + 1 >= corner_count;
@@ -999,7 +1003,11 @@ void ui_theme_visuals_update() {
 		mesh_set_id(theme_mesh_slider_push,  "sk/ui/mesh_slider_push");
 		mesh_set_id(theme_mesh_separator,    "sk/ui/mesh_separator");
 	}
+}
 
+///////////////////////////////////////////
+
+void ui_theme_visuals_assign() {
 	ui_set_element_visual(ui_vis_button,               theme_mesh_button,       theme_mat_transparent);
 	ui_set_element_visual(ui_vis_toggle,               theme_mesh_button,       theme_mat_transparent);
 	ui_set_element_visual(ui_vis_button_round,         theme_mesh_button,       theme_mat_transparent);

--- a/StereoKitC/ui/ui_theming.cpp
+++ b/StereoKitC/ui/ui_theming.cpp
@@ -1008,6 +1008,7 @@ void ui_theme_visuals_update() {
 ///////////////////////////////////////////
 
 void ui_theme_visuals_assign() {
+	ui_set_element_visual(ui_vis_default,              theme_mesh_panel,        theme_mat_opaque);
 	ui_set_element_visual(ui_vis_button,               theme_mesh_button,       theme_mat_transparent);
 	ui_set_element_visual(ui_vis_toggle,               theme_mesh_button,       theme_mat_transparent);
 	ui_set_element_visual(ui_vis_button_round,         theme_mesh_button,       theme_mat_transparent);


### PR DESCRIPTION
## New Theme

This theme strives to maintain consistency with existing apps, while adding a bit of additional polish to clean up the look and feel of StereoKit apps!

- White exterior borders on the UI elements are removed, which helps reduce aliasing on lower resolution displays.
- Drop shadows are now on most UI elements, adding some pleasant gradients and grounding details.
- Text inputs now also have a new look, and are visually distinct from buttons. 

![image](https://github.com/StereoKit/StereoKit/assets/8484884/48e4fdd7-a17f-4570-ad77-6f74e3303431)

The previous proximity ring effect has always had issues with rounded surfaces, and I've never been exactly happy with how it looks. This iteration of the shader goes with a basic highlight glow for the finger. Simpler, but still effective, and a lot less visually noisy.

![image](https://github.com/StereoKit/StereoKit/assets/8484884/45fa3c2c-ade1-476a-9278-d888ab8f9728)

For those looking for a more adventurous departure from SK's current theme, try out a few adjustments to the layout settings! This snippet of code sets `rounding` to half the line height, making for a _very_ delightfully round UI!

```csharp
UI.Settings = new UISettings
{
	margin   = 0.009f,
	padding  = 0.012f,
	gutter   = 0.006f,
	depth    = 0.010f,
	rounding = 0.017f
};
```

![image](https://github.com/StereoKit/StereoKit/assets/8484884/ea632356-07c0-4904-981e-0c8dcab7f612)

## Previous Theme

The layout dimensions of the theme are _not_ changing with this refresh, so you should not expect to see any changes to the layout of your own UI! However, if you need to maintain the look of your app, you can find a recreation of the previous theme in this Gist. This may also be of interest as reference to those wishing to make deeper modifications to the look and feel of the UI.

https://gist.github.com/maluoi/d530747d50318efca7491f10df66d148

## API Additions

This adds `UI.GenQuadrantMesh`, which is a nice flexible mesh generator for [quadrantified button meshes](https://playdeck.net/blog/quadrant-sizing-efficient-ui-rendering). This allows you to define a button by specifying a "lathe" outline.

This does also change StereoKit's core UI shaders, removing the proximity circle, as well as simplifying some tinting code.