### PR TITLE
fix: check if the newly created MSFT anchor is tracked & overwrite its pose in the space

### DIFF
--- a/StereoKitC/xr_backends/anchor_openxr_msft.cpp
+++ b/StereoKitC/xr_backends/anchor_openxr_msft.cpp
@@ -152,11 +152,15 @@ anchor_t anchor_oxr_msft_create(pose_t pose, const char* name_utf8) {
 		return nullptr;
 	}
 
+	// We'll need to fetch the pose real quick
+	bool32_t tracked = openxr_get_space(space, &pose);
+
 	// Create a StereoKit anchor
 	oxr_msft_world_anchor_t* anchor_data = sk_malloc_t(oxr_msft_world_anchor_t, 1);
 	anchor_data->anchor = anchor;
 	anchor_data->space  = space;
 	anchor_t sk_anchor = anchor_create_manual(oxr_msft_anchor_sys.id, pose, name_utf8, (void*)anchor_data);
+	sk_anchor->tracked = tracked ? button_state_active : button_state_inactive;
 	oxr_msft_anchor_sys.anchors.add(sk_anchor);
 	anchor_addref(sk_anchor);
 	return sk_anchor;


### PR DESCRIPTION
Hi Nick, I'd like to check if an anchor is tracked immediately after its creation. One thing I'm not sure of is if you'd like the pose to be overwritten, even though it's very likely it'd output the same pose in that space?