### PR TITLE
Fix for #750 for the MSFT secondary view configuration

### DIFF
--- a/StereoKitC/xr_backends/openxr_view.cpp
+++ b/StereoKitC/xr_backends/openxr_view.cpp
@@ -159,7 +159,6 @@ void xr_extension_structs_free() {
 	xr_compositor_layers    .free();
 	xr_compositor_layer_sort.free();
 	xr_compositor_layer_ptrs.free();
-	xr_compositor_2nd_layer_ptrs.free();
 
 	xr_end_frame_chain_bytes .free();
 	xr_end_frame_chain_offset.free();
@@ -307,6 +306,7 @@ bool openxr_views_create() {
 			device_display_t display = {};
 			if (!openxr_display_create(types[t], &display))
 				return false;
+			display.active = false;
 
 			XrSecondaryViewConfigurationStateMSFT state = { XR_TYPE_SECONDARY_VIEW_CONFIGURATION_STATE_MSFT };
 			state.active                = false;
@@ -369,6 +369,7 @@ void openxr_views_destroy() {
 	xr_displays_2nd      .free();
 	xr_display_2nd_states.free();
 	xr_display_2nd_layers.free();
+	xr_compositor_2nd_layer_ptrs.free();
 	xr_extension_structs_free();
 }
 
@@ -706,10 +707,12 @@ bool openxr_render_frame() {
 
 	// Check each secondary display to see if it's active or not
 	for (int32_t i = 0; i < xr_displays_2nd.count; i++) {
-		xr_displays_2nd[i].active  = (bool32_t)xr_display_2nd_states[i].active;
+		if (xr_displays_2nd[i].active != (bool32_t)xr_display_2nd_states[i].active) {
+			xr_displays_2nd[i].active = (bool32_t)xr_display_2nd_states[i].active;
 
-		if (xr_displays_2nd[i].active) {
-			openxr_display_swapchain_update(&xr_displays_2nd[i]);
+			if (xr_displays_2nd[i].active) {
+				openxr_display_swapchain_update(&xr_displays_2nd[i]);
+			}
 		}
 	}
 	if (xr_displays[xr_display_primary_idx].render_scale != render_get_scaling() || xr_displays[xr_display_primary_idx].multisample != render_get_multisample()) {

--- a/StereoKitC/xr_backends/openxr_view.cpp
+++ b/StereoKitC/xr_backends/openxr_view.cpp
@@ -105,6 +105,7 @@ array_t<size_t>  xr_compositor_layers     = {};
 array_t<int32_t> xr_compositor_layer_sort = {};
 
 array_t<XrCompositionLayerBaseHeader*> xr_compositor_layer_ptrs = {};
+array_t<XrCompositionLayerBaseHeader*> xr_compositor_2nd_layer_ptrs = {};
 
 ///////////////////////////////////////////
 
@@ -158,6 +159,7 @@ void xr_extension_structs_free() {
 	xr_compositor_layers    .free();
 	xr_compositor_layer_sort.free();
 	xr_compositor_layer_ptrs.free();
+	xr_compositor_2nd_layer_ptrs.free();
 
 	xr_end_frame_chain_bytes .free();
 	xr_end_frame_chain_offset.free();
@@ -704,12 +706,10 @@ bool openxr_render_frame() {
 
 	// Check each secondary display to see if it's active or not
 	for (int32_t i = 0; i < xr_displays_2nd.count; i++) {
-		if (xr_displays_2nd[i].active != (bool32_t)xr_display_2nd_states[i].active) {
-			xr_displays_2nd[i].active  = (bool32_t)xr_display_2nd_states[i].active;
+		xr_displays_2nd[i].active  = (bool32_t)xr_display_2nd_states[i].active;
 
-			if (xr_displays_2nd[i].active) {
-				openxr_display_swapchain_update(&xr_displays_2nd[i]);
-			}
+		if (xr_displays_2nd[i].active) {
+			openxr_display_swapchain_update(&xr_displays_2nd[i]);
 		}
 	}
 	if (xr_displays[xr_display_primary_idx].render_scale != render_get_scaling() || xr_displays[xr_display_primary_idx].multisample != render_get_multisample()) {
@@ -760,6 +760,7 @@ bool openxr_render_frame() {
 
 		// Set up any secondary displays
 		xr_display_2nd_layers.clear();
+		xr_compositor_2nd_layer_ptrs.clear();
 		for (int32_t i = 0; i < xr_displays_2nd.count; i++) {
 			device_display_t* display = &xr_displays_2nd[i];
 			for (uint32_t s = 0; s < display->swapchain_color.backbuffer_views; s++)
@@ -770,11 +771,13 @@ bool openxr_render_frame() {
 				continue;
 			openxr_display_swapchain_acquire(display, render_get_clear_color_ln(), render_get_capture_filter());
 
+			xr_compositor_2nd_layer_ptrs.add((XrCompositionLayerBaseHeader*)&display->projection_layer);
+
 			XrSecondaryViewConfigurationLayerInfoMSFT layer2nd = { XR_TYPE_SECONDARY_VIEW_CONFIGURATION_LAYER_INFO_MSFT };
 			layer2nd.viewConfigurationType = display->type;
 			layer2nd.environmentBlendMode  = display->blend;
 			layer2nd.layerCount            = 1;
-			layer2nd.layers                = (XrCompositionLayerBaseHeader**)&display->projection_layer;
+			layer2nd.layers                = xr_compositor_2nd_layer_ptrs.data + (xr_compositor_2nd_layer_ptrs.count - 1);
 			xr_display_2nd_layers.add(layer2nd);
 		}
 		if (xr_display_2nd_layers.count > 0) {


### PR DESCRIPTION
This PR addresses 2 issues from #750:
1. If the camera is streaming/recording before the SK app initializes, the secondary view config is active. Since we assume [it starts as inactive](https://github.com/StereoKit/StereoKit/blob/092d717609425b8f9cb0bc4be00a3c53c91f2b32/StereoKitC/xr_backends/openxr_view.cpp#L310), the swapchain hadn't been updated
2. If the camera is active, there was an Access Violation error for invalid projection layer data. The data in the array should stay alive for the entire frame so it's not kept local

I can confirm StereoKitTest_UWP works for the following scenarios:
- HL2 is streaming before SK launches
- HL2 can stream on/off during an SK app session

Happy to make any other changes, thanks!