### PR TITLE
Fix an EGL attribute error for NVIDIAs Jetson Orin NX

### DIFF
--- a/StereoKitC/libraries/sk_gpu.h
+++ b/StereoKitC/libraries/sk_gpu.h
@@ -3277,7 +3277,7 @@ int32_t gl_init_emscripten() {
 int32_t gl_init_egl() {
 #ifdef _SKG_GL_LOAD_EGL
 	const EGLint attribs[] = {
-		EGL_SURFACE_TYPE, EGL_WINDOW_BIT,
+		EGL_SURFACE_TYPE, EGL_DONT_CARE,
 		EGL_CONFORMANT,   EGL_OPENGL_ES3_BIT_KHR,
 		EGL_BLUE_SIZE,  8,
 		EGL_GREEN_SIZE, 8,


### PR DESCRIPTION
when launching StereoKitCTest in XR mode (doesn't affect Desktop mode) with monado I get this error:
```
[SK diagnostic] Initializing StereoKit v0.3.9 Linux ARM64...
[SK diagnostic] Initializing Platform
[SK diagnostic] [sk_gpu] EGL version 1.5
[SK error] [sk_gpu] Err eglGetConfigAttrib
[SK error] Failed to initialize sk_gpu!
[SK error] System Platform failed to initialize!
[SK warning] No messagebox capability for this platform!
```
after changing the attribute list I get a successful run:
```
[SK diagnostic] Initializing StereoKit v0.3.9 Linux ARM64...
[SK diagnostic] Initializing Platform
[SK diagnostic] [sk_gpu] EGL version 1.5
[SK diagnostic] [sk_gpu] Using OpenGL: OpenGL ES 3.2 NVIDIA 35.4.1
[SK diagnostic] [sk_gpu] Device: NVIDIA Tegra Orin (nvgpu)/integrated
[SK diagnostic] Starting a XR mode app
[SK diagnostic] Runtime OpenXR Extensions:
[SK diagnostic] ___________________________________
[SK diagnostic] |     Usage | Extension
[SK diagnostic] |-----------|----------------------
[SK diagnostic] |   present | XR_EXT_debug_utils
[SK diagnostic] |   present | XR_EXT_dpad_binding
[SK diagnostic] |   present | XR_EXT_samsung_odyssey_controller
[SK diagnostic] |   present | XR_FB_display_refresh_rate
[SK diagnostic] |   present | XR_KHR_binding_modification
[SK diagnostic] |   present | XR_KHR_composition_layer_cylinder
[SK diagnostic] |   present | XR_KHR_composition_layer_equirect2
[SK diagnostic] |   present | XR_KHR_opengl_enable
[SK diagnostic] |   present | XR_KHR_swapchain_usage_input_attachment_bit
[SK diagnostic] |   present | XR_KHR_visibility_mask
[SK diagnostic] |   present | XR_KHR_vulkan_enable
[SK diagnostic] |   present | XR_KHR_vulkan_enable2
[SK diagnostic] |   present | XR_KHR_vulkan_swapchain_format_list
[SK diagnostic] |   present | XR_ML_ml2_controller_interaction
[SK diagnostic] |   present | XR_MNDX_ball_on_a_stick_controller
[SK diagnostic] |   present | XR_MNDX_force_feedback_curl
[SK diagnostic] |   present | XR_MNDX_hydra
[SK diagnostic] |   present | XR_MNDX_system_buttons
[SK diagnostic] |   present | XR_MND_headless
[SK diagnostic] |   present | XR_MND_swapchain_usage_input_attachment_bit
[SK diagnostic] |   present | XR_OPPO_controller_interaction
[SK diagnostic] | ACTIVATED | XR_EXTX_overlay
[SK diagnostic] | ACTIVATED | XR_EXT_eye_gaze_interaction
[SK diagnostic] | ACTIVATED | XR_EXT_hand_interaction
[SK diagnostic] | ACTIVATED | XR_EXT_hand_tracking
[SK diagnostic] | ACTIVATED | XR_EXT_hp_mixed_reality_controller
[SK diagnostic] | ACTIVATED | XR_EXT_local_floor
[SK diagnostic] | ACTIVATED | XR_KHR_composition_layer_depth
[SK diagnostic] | ACTIVATED | XR_KHR_convert_timespec_time
[SK diagnostic] | ACTIVATED | XR_KHR_opengl_es_enable
[SK diagnostic] | ACTIVATED | XR_MNDX_egl_enable
[SK diagnostic] | ACTIVATED | XR_MSFT_unbounded_reference_space
[SK diagnostic] |___________|______________________
LOG in xrCreateInstance: Instance created
	createInfo->applicationInfo.applicationName: StereoKit C
	createInfo->applicationInfo.applicationVersion: 1
	createInfo->applicationInfo.engineName: StereoKit
	createInfo->applicationInfo.engineVersion: 12297
	appinfo.detected.engine.name: (null)
	appinfo.detected.engine.version: 0.0.0
	quirks.disable_vulkan_format_depth_stencil: false
	quirks.no_validation_error_in_create_ref_space: true
LOG in xrCreateInstance: Selected devices
	Head: 'daemon'
	Eyes: '<none>'
	Left: 'Left Leap Motion v5 driver Hand'
	Right: 'Right Leap Motion v5 driver Hand'
	Gamepad: '<none>'
	Hand-Tracking Left: 'Left Leap Motion v5 driver Hand'
	Hand-Tracking Right: 'Right Leap Motion v5 driver Hand'
[SK diagnostic] Found OpenXR runtime: Monado(XRT) by Collabora et al 'v21.0.0-4141-g5693bf5d' 21.0.0
[SK diagnostic] OpenXR requires GLES v2.0.0 - v3.2.1023
[SK diagnostic] System name: Monado: daemon
[SK diagnostic] Platform does not support single-pass rendering
[SK diagnostic] OpenXR articulated hands ext enabled!
[SK diagnostic] Creating view: PrimaryStereo color:rgba32_sRGB depth:depth32 blend:Opaque
[SK diagnostic] Set view: PrimaryStereo to 2688x2688@1msaa
[SK diagnostic] OpenXR session begin.
[SK diagnostic] Created local app space at an offset of (0,-1.6,0) (0,1.9e-35,0,-1)
[SK diagnostic] Initializing Audio
[SK info] Using audio backend: PulseAudio
[SK diagnostic] Initializing Assets
[SK diagnostic] Initializing Defaults
[SK diagnostic] Initializing Sprites
[SK diagnostic] Initializing Lines
[SK diagnostic] Initializing UI
[SK diagnostic] Initializing Tools
[SK diagnostic] Initializing Renderer
[SK diagnostic] Initializing World
[SK diagnostic] Initializing Physics
[SK diagnostic] Initializing Input
[SK info] Initialization successful
[SK info] Device:   Monado: daemon
[SK info] GPU:      NVIDIA Tegra Orin (nvgpu)/integrated
[SK info] Tracking: 6dof
[SK info] Hands:    true
[SK info] Eyes:     false
[SK info] Display Type:  stereo
[SK info] Display Blend: opaque
[SK info] Display FoV:   45, -45, 45, -45
[SK info] Display Hz:    0.0
[SK info] Display Size:  2688x2688
[SK diagnostic] Focus: Active
[SK diagnostic] Switched left controller profile to khr/simple_controller
[SK diagnostic] Switched right controller profile to khr/simple_controller
```