### PR TITLE
WIP: Magic Leap 2 Integration

### DIFF
--- a/Examples/StereoKitTest/StereoKitTest_NetAndroid/AndroidManifest.xml
+++ b/Examples/StereoKitTest/StereoKitTest_NetAndroid/AndroidManifest.xml
@@ -54,4 +54,11 @@
 	<uses-feature    android:name="oculus.software.face_tracking"     android:required="false"/>
 	<uses-feature    android:name="oculus.software.eye_tracking"      android:required="false"/>
 	<uses-feature    android:name="com.oculus.experimental.enabled"   android:required="false"/>
+
+	<!-- Magic Leap 2 specific items -->
+	<uses-permission android:name="com.magicleap.permission.EYE_TRACKING" />
+	<uses-permission android:name="com.magicleap.permission.HAND_TRACKING" />
+	<uses-permission android:name="com.magicleap.permission.SPATIAL_MAPPING" />
+	<uses-feature    android:name="com.magicleap.api_level" android:version="21" />
+
 </manifest>

--- a/Examples/StereoKitTest/StereoKitTest_NetAndroid/StereoKitTest_NetAndroid.csproj
+++ b/Examples/StereoKitTest/StereoKitTest_NetAndroid/StereoKitTest_NetAndroid.csproj
@@ -16,8 +16,8 @@
 		<SKAssetDestination>Assets</SKAssetDestination>
 		<SKShowDebugVars>true</SKShowDebugVars>
 		
-		<!--<TestBuildMode>x64</TestBuildMode>-->
-		<TestBuildMode>ARM64</TestBuildMode>
+		<TestBuildMode>x64</TestBuildMode>
+		<!--<TestBuildMode>ARM64</TestBuildMode>-->
 
 		<RuntimeIdentifiers Condition="'$(TestBuildMode)'=='ARM64'">android-arm64</RuntimeIdentifiers>
 		<RuntimeIdentifiers Condition="'$(TestBuildMode)'=='x64'">android-x64</RuntimeIdentifiers>


### PR DESCRIPTION
Hey Nick, the Magic Leap team is loaning us a device so I'll be working on its integration in my spare time. I'll be keeping this PR updated in the meantime, so that it's easier to show you updates and ask questions.

## Progress
* [StereoKit's first run on Magic Leap 2](https://youtu.be/35YIcJs6i0s)

## Supported Extensions
🔴 not supporting in this PR
🟡 work in progress
🟢 complete
❔ unsure if StereoKit does/will support it?

| Extension | Supported |
| ------------- | ------------- |
| XR_EXT_eye_gaze_interaction | 🟡 |
| XR_EXT_hand_interaction    | ✅  |
| XR_EXT_hand_tracking      | ✅  |
| XR_EXT_local_floor        | ✅  |
| XR_EXT_palm_pose          | ✅  |
| XR_KHR_android_create_instance | ✅ |
| XR_KHR_composition_layer_depth | ✅ |
| XR_KHR_convert_timespec_time | ✅ |
| XR_KHR_opengl_es_enable   | ✅  |
| XR_KHR_vulkan_enable      | ❔  |
| XR_KHR_vulkan_enable2     | ❔  |
| XR_ML_compat              | 🔴  |
| XR_ML_frame_end_info      | 🔴  |
| XR_ML_global_dimmer       | 🟡  |
| XR_ML_localization_map    | ❔  |
| XR_ML_marker_understanding| ❔  |
| XR_ML_ml2_controller_interaction | 🟡 |
| XR_ML_user_calibration    | 🔴  |
| XR_MND_headless           | ❔  |
| XR_MSFT_unbounded_reference_space | ✅ |
| XR_EXT_view_configuration_depth_range | ❔ |

## Known issues
* Very apparent jitter (& sometimes colorful artifacts) when you either move your head too quickly or move around.
This may be a limitation of the on-device SLAM, which causes perceived motion of stationary content. For example, reading SK text while moving around becomes illegible as it seemingly "repeats" multiple times until the tracking restabilizes. This is probably why ML2 offers advice on [how to mitigate user micro-movements](https://developer-docs.magicleap.cloud/docs/guides/best-practices/comfort-content-placement/#how-to-mitigate-user-micro-movements) for UI. If StereoKit is in immediate mode, is it correct to assume there's no buffer in place?
*Please note that this visual artifact won't be seen in the mixed reality video.*
* Eyes demo not working
* Only Release mode works for `StereoKitTest_NetAndroid`

## Initialization Log
```
[StereoKit] Initializing StereoKit v0.3.9 Android x64...
[StereoKit] Initializing Platform
[StereoKit] [sk_gpu] EGL version 1.5
[StereoKit] [sk_gpu] Using OpenGL: OpenGL ES 3.2 Mesa 20.1.2 (git-6582e67fb7)
[StereoKit] [sk_gpu] Device: AMD MERO (DRM 3.37.0, 5.4.19-android-x86_64, LLVM 10.0)
[StereoKit] [sk_gpu] Debug info enabled.
[StereoKit] Starting a XR mode app
[StereoKit] Runtime OpenXR Extensions:
[StereoKit] ___________________________________
[StereoKit] |     Usage | Extension
[StereoKit] |-----------|----------------------
[StereoKit] |   present | XR_EXT_conformance_automation
[StereoKit] |   present | XR_EXT_debug_utils
[StereoKit] |   present | XR_EXT_plane_detection
[StereoKit] |   present | XR_EXT_view_configuration_depth_range
[StereoKit] |   present | XR_KHR_opengl_enable
[StereoKit] |   present | XR_KHR_vulkan_enable
[StereoKit] |   present | XR_KHR_vulkan_enable2
[StereoKit] |   present | XR_ML_compat
[StereoKit] |   present | XR_ML_frame_end_info
[StereoKit] |   present | XR_ML_global_dimmer
[StereoKit] |   present | XR_ML_marker_understanding
[StereoKit] |   present | XR_ML_ml2_controller_interaction
[StereoKit] |   present | XR_ML_private
[StereoKit] |   present | XR_ML_session_performance_info
[StereoKit] |   present | XR_ML_system_notifications
[StereoKit] |   present | XR_ML_user_calibration
[StereoKit] |   present | XR_MND_headless
[StereoKit] | ACTIVATED | XR_EXT_eye_gaze_interaction
[StereoKit] | ACTIVATED | XR_EXT_hand_interaction
[StereoKit] | ACTIVATED | XR_EXT_hand_tracking
[StereoKit] | ACTIVATED | XR_EXT_local_floor
[StereoKit] | ACTIVATED | XR_EXT_palm_pose
[StereoKit] | ACTIVATED | XR_KHR_android_create_instance
[StereoKit] | ACTIVATED | XR_KHR_composition_layer_depth
[StereoKit] | ACTIVATED | XR_KHR_convert_timespec_time
[StereoKit] | ACTIVATED | XR_KHR_opengl_es_enable
[StereoKit] | ACTIVATED | XR_MSFT_unbounded_reference_space
[StereoKit] |___________|______________________
```