### PR TITLE
Texture format fixes for GL.

### DIFF
--- a/Examples/StereoKitTest/Tests/TestTextures.cs
+++ b/Examples/StereoKitTest/Tests/TestTextures.cs
@@ -32,26 +32,31 @@ internal class TestTextures : ITest
 		failedFallbackMat = Material.Default.Copy();
 		failedFallbackMat[MatParamName.DiffuseTex] = failedFallbackTex;
 
-		ulong on64  = 0xFFFF00000000FFFF;
-		ulong off64 = 0xFFFF000000000000;
+		// 0x3C00 is a half float with value 1.0f
+		ulong  on64  = 0x3C00000000003C00;
+		ulong  off64 = 0x3C00000000000000;
+		ushort on16  = 0x3C00;
+		ushort off16 = 0x0000;
 
 		// Test a NPOT size to ensure mips work properly with that
 		int w = 32;
 		int h = 32;
 		int ow = 41;
-		int oh = 32;
+		int oh = 33;
 		testTextures.Add(MakeTest(TexFormat.Rgba32,       new Color32(255,0,0,255), new Color32(0,0,0,255), w,  h ));
 		testTextures.Add(MakeTest(TexFormat.Rgba32Linear, new Color32(255,0,0,255), new Color32(0,0,0,255), ow, oh));
 		testTextures.Add(MakeTest(TexFormat.Bgra32,       new Color32(0,0,255,255), new Color32(0,0,0,255), w,  h ));
 		testTextures.Add(MakeTest(TexFormat.Bgra32Linear, new Color32(0,0,255,255), new Color32(0,0,0,255), ow, oh));
-		testTextures.Add(MakeTest(TexFormat.Rgba64u,      on64, off64, w,  h ));
-		testTextures.Add(MakeTest(TexFormat.Rgba64u,      on64, off64, ow, oh));
+		testTextures.Add(MakeTest(TexFormat.Rgba64f,      on64, off64, w,  h ));
+		testTextures.Add(MakeTest(TexFormat.Rgba64f,      on64, off64, ow, oh));
 		testTextures.Add(MakeTest(TexFormat.Rgba128,      new Color(1,0,0,1), new Color(0,0,0,1), w,  h ));
 		testTextures.Add(MakeTest(TexFormat.Rgba128,      new Color(1,0,0,1), new Color(0,0,0,1), ow, oh));
 		testTextures.Add(MakeTest(TexFormat.R8,           (byte)255, (byte)0, w,  h ));
 		testTextures.Add(MakeTest(TexFormat.R8,           (byte)255, (byte)0, ow, oh));
-		testTextures.Add(MakeTest(TexFormat.R16,          (ushort)ushort.MaxValue, (ushort)0, w,  h ));
-		testTextures.Add(MakeTest(TexFormat.R16,          (ushort)ushort.MaxValue, (ushort)0, ow, oh));
+		testTextures.Add(MakeTest(TexFormat.R16f,         on16, off16, w,  h ));
+		testTextures.Add(MakeTest(TexFormat.R16f,         on16, off16, ow, oh));
+		testTextures.Add(MakeTest(TexFormat.R16u,         ushort.MaxValue, (ushort)0, w,  h ));
+		testTextures.Add(MakeTest(TexFormat.R16u,         ushort.MaxValue, (ushort)0, ow, oh));
 		testTextures.Add(MakeTest(TexFormat.R32,          1.0f, 0, w,  h ));
 		testTextures.Add(MakeTest(TexFormat.R32,          1.0f, 0, ow, oh));
 

--- a/Examples/StereoKitTest/Tests/TestTextures.cs
+++ b/Examples/StereoKitTest/Tests/TestTextures.cs
@@ -55,7 +55,43 @@ internal class TestTextures : ITest
 		testTextures.Add(MakeTest(TexFormat.R32,          1.0f, 0, w,  h ));
 		testTextures.Add(MakeTest(TexFormat.R32,          1.0f, 0, ow, oh));
 
+		Tests.Test(CheckTextureFormats);
+		Tests.Test(CheckTextureRead);
+
 		Tests.Screenshot("TexFormats.jpg", 0, 400, 400, 50, V.XYZ(0,-0.15f, 0), V.XYZ(0,-0.15f,-0.5f) );
+	}
+
+	bool CheckTextureFormats()
+	{
+		foreach (FormatTest test in testTextures)
+		{
+			if (test.tex.AssetState < 0)
+				return false;
+		}
+		return true;
+	}
+
+	bool CheckTextureRead()
+	{
+		foreach (FormatTest test in testTextures)
+		{
+			Tex texture = test.tex;
+			if (test.tex.Format != TexFormat.Rgba32       &&
+				test.tex.Format != TexFormat.Rgba32Linear &&
+				test.tex.Format != TexFormat.Bgra32       &&
+				test.tex.Format != TexFormat.Bgra32Linear &&
+				test.tex.Format != TexFormat.R32)
+				continue;
+
+			if (texture.AssetState < 0)
+				continue;
+
+			Color32[] colors1 = texture.GetColors(1);
+			Color32[] colors0 = texture.GetColors(0);
+			if (colors0 == null || colors1 == null)
+				return false;
+		}
+		return true;
 	}
 
 	public void Step()

--- a/StereoKit/Assets/Tex.cs
+++ b/StereoKit/Assets/Tex.cs
@@ -342,7 +342,9 @@ namespace StereoKit
 		/// array if an invalid mip-level is provided.</param>
 		public void GetColors(ref Color32[] colorData, int mipLevel = 0)
 		{
-			int count = Width * Height;
+			int width  = Width  >> mipLevel;
+			int height = Height >> mipLevel;
+			int count  = width * height;
 			if (colorData == null || colorData.Length != count)
 				colorData = new Color32[count];
 
@@ -360,7 +362,9 @@ namespace StereoKit
 		/// </returns>
 		public Color32[] GetColors(int mipLevel = 0)
 		{
-			Color32[] result      = new Color32[Width * Height];
+			int width  = Width  >> mipLevel;
+			int height = Height >> mipLevel;
+			Color32[] result      = new Color32[width * height];
 			GCHandle  pinnedArray = GCHandle.Alloc(result, GCHandleType.Pinned);
 			IntPtr    pointer     = pinnedArray.AddrOfPinnedObject();
 			NativeAPI.tex_get_data_mip(_inst, pointer, (UIntPtr)(result.Length * 4), mipLevel);

--- a/StereoKit/Native/NativeEnums.cs
+++ b/StereoKit/Native/NativeEnums.cs
@@ -440,28 +440,49 @@ namespace StereoKit
 		R8           = 11,
 		/// <summary>A single channel of data, with 16 bits per-pixel! This
 		/// is a good format for height maps, since it stores a fair bit of
-		/// information in it. Values in the shader are always 0.0-1.0.</summary>
+		/// information in it. Values in the shader are always 0.0-1.0.
+		/// TODO: remove during major version update, prefer s, f, or u
+		/// postfixed versions of this format, this item is the same as
+		/// r16u.</summary>
 		R16          = 12,
+		/// <summary>A single channel of data, with 16 bits per-pixel! This
+		/// is a good format for height maps, since it stores a fair bit of
+		/// information in it. The u postfix indicates that the raw color data
+		/// is stored as an unsigned 16 bit integer, which is then normalized
+		/// into the 0, 1 floating point range on the GPU.</summary>
+		R16u         = R16,
+		/// <summary>A single channel of data, with 16 bits per-pixel! This
+		/// is a good format for height maps, since it stores a fair bit of
+		/// information in it. The s postfix indicates that the raw color
+		/// data is stored as a signed 16 bit integer, which is then
+		/// normalized into the -1, +1 floating point range on the GPU.</summary>
+		R16s         = 13,
+		/// <summary>A single channel of data, with 16 bits per-pixel! This
+		/// is a good format for height maps, since it stores a fair bit of
+		/// information in it. The f postfix indicates that the raw color
+		/// data is stored as 16 bit floats, which may be tricky to work with
+		/// in most languages.</summary>
+		R16f         = 14,
 		/// <summary>A single channel of data, with 32 bits per-pixel! This
 		/// basically treats each pixel as a generic float, so you can do all
 		/// sorts of strange and interesting things with this.</summary>
-		R32          = 13,
+		R32          = 15,
 		/// <summary>A depth data format, 24 bits for depth data, and 8 bits
 		/// to store stencil information! Stencil data can be used for things
 		/// like clipping effects, deferred rendering, or shadow effects.</summary>
-		DepthStencil = 14,
+		DepthStencil = 16,
 		/// <summary>32 bits of data per depth value! This is pretty detailed,
 		/// and is excellent for experiences that have a very far view
 		/// distance.</summary>
-		Depth32      = 15,
+		Depth32      = 17,
 		/// <summary>16 bits of depth is not a lot, but it can be enough if
 		/// your far clipping plane is pretty close. If you're seeing lots of
 		/// flickering where two objects overlap, you either need to bring
 		/// your far clip in, or switch to 32/24 bit depth.</summary>
-		Depth16      = 16,
+		Depth16      = 18,
 		/// <summary>A double channel of data that supports 8 bits for the red
 		/// channel and 8 bits for the green channel.</summary>
-		R8g8         = 17,
+		R8g8         = 19,
 	}
 
 	/// <summary>How does the shader grab pixels from the texture? Or more

--- a/StereoKitC/libraries/sk_gpu.h
+++ b/StereoKitC/libraries/sk_gpu.h
@@ -4559,9 +4559,15 @@ void skg_tex_copy_to(const skg_tex_t *tex, skg_tex_t *destination) {
 		skg_tex_set_contents_arr(destination, nullptr, tex->array_count, tex->width, tex->height, tex->multisample);
 	}
 
-	glBindFramebuffer  (GL_FRAMEBUFFER, tex->_framebuffer);
-	glBindTexture      (destination->_target, destination->_texture);
-	glCopyTexSubImage2D(destination->_target, 0, 0,0,0,0,tex->width,tex->height);
+	if (tex->multisample > 1) {
+		glBindFramebuffer  (GL_FRAMEBUFFER, tex->_framebuffer);
+		glBindTexture      (destination->_target, destination->_texture);
+		glBlitFramebuffer  (0, 0, tex->width, tex->height, 0, 0, tex->width, tex->height, GL_COLOR_BUFFER_BIT, GL_NEAREST);
+	} else {
+		glBindFramebuffer  (GL_FRAMEBUFFER, tex->_framebuffer);
+		glBindTexture      (destination->_target, destination->_texture);
+		glCopyTexSubImage2D(destination->_target, 0, 0,0,0,0,tex->width,tex->height);
+	}
 }
 
 ///////////////////////////////////////////

--- a/StereoKitC/libraries/sk_gpu.h
+++ b/StereoKitC/libraries/sk_gpu.h
@@ -4730,6 +4730,7 @@ bool skg_tex_get_mip_contents_arr(skg_tex_t *tex, int32_t mip_level, int32_t arr
 		char text[128];
 		snprintf(text, 128, "skg_tex_get_mip_contents_arr: eating a gl error from somewhere else: %d", result);
 		skg_log(skg_log_warning, text);
+		result = glGetError();
 	}
 	
 	// Double check on mips first

--- a/StereoKitC/libraries/sk_gpu.h
+++ b/StereoKitC/libraries/sk_gpu.h
@@ -2966,6 +2966,8 @@ const char *skg_semantic_to_d3d(skg_el_semantic_ semantic) {
 #define GL_UNSIGNED_INT_8_8_8_8 0x8035
 #define GL_UNSIGNED_INT_8_8_8_8_REV 0x8367
 #define GL_MAX_SAMPLES 0x8D57
+#define GL_PACK_ALIGNMENT 0x0D05
+#define GL_UNPACK_ALIGNMENT 0x0CF5
 
 #define GL_FRAGMENT_SHADER 0x8B30
 #define GL_VERTEX_SHADER 0x8B31
@@ -3049,6 +3051,7 @@ GLE(void,     glTexStorage3DMultisample, uint32_t target, uint32_t samples, int3
 GLE(void,     glCopyTexSubImage2D,       uint32_t target, int32_t level, int32_t xoffset, int32_t yoffset, int32_t x, int32_t y, uint32_t width, uint32_t height) \
 GLE(void,     glGetTexImage,             uint32_t target, int32_t level, uint32_t format, uint32_t type, void *img) \
 GLE(void,     glReadPixels,              int32_t x, int32_t y, uint32_t width, uint32_t height, uint32_t format, uint32_t type, void *data) \
+GLE(void,     glPixelStorei,             uint32_t pname, int32_t param) \
 GLE(void,     glActiveTexture,           uint32_t texture) \
 GLE(void,     glGenerateMipmap,          uint32_t target) \
 GLE(void,     glBindAttribLocation,      uint32_t program, uint32_t index, const char *name) \
@@ -4663,6 +4666,9 @@ void skg_tex_set_contents_arr(skg_tex_t *tex, const void **data_frames, int32_t 
 
 	glBindTexture(tex->_target, tex->_texture);
 
+	if (tex->format == skg_tex_fmt_r8)
+		glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+
 	tex->_format    = (uint32_t)skg_tex_fmt_to_native   (tex->format);
 	uint32_t layout =           skg_tex_fmt_to_gl_layout(tex->format);
 	uint32_t type   =           skg_tex_fmt_to_gl_type  (tex->format);
@@ -4683,6 +4689,8 @@ void skg_tex_set_contents_arr(skg_tex_t *tex, const void **data_frames, int32_t 
 		glTexImage2D(GL_TEXTURE_2D, 0, tex->_format, width, height, 0, layout, type, data_frames == nullptr ? nullptr : data_frames[0]);
 		#endif
 	}
+
+	glPixelStorei(GL_UNPACK_ALIGNMENT, 4);
 
 	if (tex->mips == skg_mip_generate)
 		glGenerateMipmap(tex->_target);

--- a/StereoKitC/stereokit.h
+++ b/StereoKitC/stereokit.h
@@ -955,28 +955,49 @@ typedef enum tex_format_ {
 	tex_format_r8 = 11,
 	/*A single channel of data, with 16 bits per-pixel! This
 	  is a good format for height maps, since it stores a fair bit of
-	  information in it. Values in the shader are always 0.0-1.0.*/
+	  information in it. Values in the shader are always 0.0-1.0.
+	  TODO: remove during major version update, prefer s, f, or u
+	  postfixed versions of this format, this item is the same as
+	  r16u.*/
 	tex_format_r16 = 12,
+	/*A single channel of data, with 16 bits per-pixel! This
+	  is a good format for height maps, since it stores a fair bit of
+	  information in it. The u postfix indicates that the raw color data
+	  is stored as an unsigned 16 bit integer, which is then normalized
+	  into the 0, 1 floating point range on the GPU.*/
+	tex_format_r16u = tex_format_r16,
+	/*A single channel of data, with 16 bits per-pixel! This
+	  is a good format for height maps, since it stores a fair bit of
+	  information in it. The s postfix indicates that the raw color
+	  data is stored as a signed 16 bit integer, which is then
+	  normalized into the -1, +1 floating point range on the GPU.*/
+	tex_format_r16s = 13,
+	/*A single channel of data, with 16 bits per-pixel! This
+	  is a good format for height maps, since it stores a fair bit of
+	  information in it. The f postfix indicates that the raw color
+	  data is stored as 16 bit floats, which may be tricky to work with
+	  in most languages.*/
+	tex_format_r16f = 14,
 	/*A single channel of data, with 32 bits per-pixel! This
 	  basically treats each pixel as a generic float, so you can do all
 	  sorts of strange and interesting things with this.*/
-	tex_format_r32 = 13,
+	tex_format_r32 = 15,
 	/*A depth data format, 24 bits for depth data, and 8 bits
 	  to store stencil information! Stencil data can be used for things
 	  like clipping effects, deferred rendering, or shadow effects.*/
-	tex_format_depthstencil = 14,
+	tex_format_depthstencil = 16,
 	/*32 bits of data per depth value! This is pretty detailed,
 	  and is excellent for experiences that have a very far view
 	  distance.*/
-	tex_format_depth32 = 15,
+	tex_format_depth32 = 17,
 	/*16 bits of depth is not a lot, but it can be enough if
 	  your far clipping plane is pretty close. If you're seeing lots of
 	  flickering where two objects overlap, you either need to bring
 	  your far clip in, or switch to 32/24 bit depth.*/
-	tex_format_depth16 = 16,
+	tex_format_depth16 = 18,
 	/*A double channel of data that supports 8 bits for the red
 	  channel and 8 bits for the green channel.*/
-	tex_format_r8g8 = 17,
+	tex_format_r8g8 = 19,
 
 } tex_format_;
 


### PR DESCRIPTION
This fixes a couple issues with less commonly used texture formats, and extends some of the texture format tests.

- Fixes byte alignment issues for 8 and 16 bpp NPOT textures
- Clarifies 16 bit texture formats into "half float", "unsigned short" and "short" variants. This fixes a few problems in the code related to format ambiguity.
- Fixes an infinite loop in an error eating check.
- Fixes C# code failing to calculate the correct size when reading from mip levels.
- `skg_tex_copy_to` now kinda accounts for MSAA surfaces. This may need more attention.