### PR TITLE
Added `Tex.GetColorData` for better data format support, deprecated `Tex.GetColors`

### DIFF
--- a/Examples/StereoKitTest/Docs/DocTextures.cs
+++ b/Examples/StereoKitTest/Docs/DocTextures.cs
@@ -1,0 +1,37 @@
+﻿using StereoKit;
+
+internal class DocTextures : ITest
+{
+	public void Initialize()
+	{
+		/// :CodeSample: Tex.GetColorData
+		/// ### Get data from a Tex
+		/// Reading texture data from a Tex can be a slow operation, since
+		/// texture memory lives on the GPU, and isn't generally optimized for
+		/// readability. But, sometimes you still have to do it! Just remember
+		/// to avoid doing it too often or casually, and be cautious about how
+		/// you treat the large amounts of memory involved.
+
+		// Reading colors can be as simple as this! Remember to select a color
+		// format that matches the data stored in the texture, as StereoKit
+		// will not convert the data for you. Most images from file are 32 bit
+		// RGBA images!
+		Tex texture = Tex.FromFile("floor.png");
+		Color32[] colors = texture.GetColorData<Color32>();
+
+		// For a more complex texture, such as this generated texture with 32
+		// bits per channel, we can load the data into a float array, with 4
+		// floats per-pixel! A `Color` would probably be fine here too.
+		Tex texture2 = Tex.GenColor(Color.White, 16, 16, TexType.Image, TexFormat.Rgba128);
+		float[] colors2 = texture2.GetColorData<float>(0, 4);
+		/// :End:
+	}
+
+	public void Shutdown()
+	{
+	}
+
+	public void Step()
+	{
+	}
+}

--- a/Examples/StereoKitTest/Tests/TestTextures.cs
+++ b/Examples/StereoKitTest/Tests/TestTextures.cs
@@ -78,23 +78,55 @@ internal class TestTextures : ITest
 
 	bool CheckTextureRead()
 	{
+		// RGBA values
 		foreach (FormatTest test in testTextures)
 		{
 			Tex texture = test.tex;
-			if (test.tex.Format != TexFormat.Rgba32       &&
-				test.tex.Format != TexFormat.Rgba32Linear &&
-				test.tex.Format != TexFormat.Bgra32       &&
-				test.tex.Format != TexFormat.Bgra32Linear &&
-				test.tex.Format != TexFormat.R32)
-				continue;
+			if (texture.AssetState < 0) continue;
 
-			if (texture.AssetState < 0)
-				continue;
-
-			Color32[] colors1 = texture.GetColors(1);
-			Color32[] colors0 = texture.GetColors(0);
-			if (colors0 == null || colors1 == null)
-				return false;
+			switch (test.tex.Format)
+			{
+				case TexFormat.Rgba32:
+				case TexFormat.Rgba32Linear:
+				case TexFormat.Bgra32:
+				case TexFormat.Bgra32Linear:
+					Color32[] colors1 = texture.GetColorData<Color32>(1);
+					Color32[] colors0 = texture.GetColorData<Color32>(0);
+					if (colors0 == null || colors1 == null)
+						return false;
+					break;
+				case TexFormat.Rgba128:
+					Color[] colors1_128 = texture.GetColorData<Color>(1);
+					Color[] colors0_128 = texture.GetColorData<Color>(0);
+					if (colors0_128 == null || colors1_128 == null)
+						return false;
+					break;
+				case TexFormat.R8:
+					byte[] colors1b = texture.GetColorData<byte>(1);
+					byte[] colors0b = texture.GetColorData<byte>(0);
+					if (colors0b == null || colors1b == null)
+						return false;
+					break;
+				case TexFormat.R16f:
+				case TexFormat.R16u:
+					ushort[] colors1s = texture.GetColorData<ushort>(1);
+					ushort[] colors0s = texture.GetColorData<ushort>(0);
+					if (colors0s == null || colors1s == null)
+						return false;
+					break;
+				case TexFormat.R32:
+					float[] colors1f = texture.GetColorData<float>(1);
+					float[] colors0f = texture.GetColorData<float>(0);
+					if (colors0f == null || colors1f == null)
+						return false;
+					break;
+				case TexFormat.Rgba64f:
+					ushort[] colors1l = texture.GetColorData<ushort>(1, 4);
+					ushort[] colors0l = texture.GetColorData<ushort>(0, 4);
+					if (colors0l == null || colors1l == null)
+						return false;
+					break;
+			}
 		}
 		return true;
 	}

--- a/Examples/StereoKitTest/Tools/RenderCamera.cs
+++ b/Examples/StereoKitTest/Tools/RenderCamera.cs
@@ -98,7 +98,7 @@ namespace StereoKit.Framework
 			if (_frameTime + rateTime < Time.TotalUnscaledf)
 			{
 				_frameTime = Time.TotalUnscaledf;
-				_frameSurface.GetColors(ref buffer);
+				_frameSurface.GetColorData(ref buffer);
 
 				Directory.CreateDirectory(folder);
 				Stream writer = new FileStream($"{folder}/image{_frameIndex:D4}.bmp", FileMode.Create);

--- a/StereoKit/Assets/Tex.cs
+++ b/StereoKit/Assets/Tex.cs
@@ -340,19 +340,9 @@ namespace StereoKit
 		/// <param name="mipLevel">Retrieves the color data for a specific
 		/// mip-mapping level. This function will log a fail and return a black
 		/// array if an invalid mip-level is provided.</param>
-		public void GetColors(ref Color32[] colorData, int mipLevel = 0)
-		{
-			int width  = Width  >> mipLevel;
-			int height = Height >> mipLevel;
-			int count  = width * height;
-			if (colorData == null || colorData.Length != count)
-				colorData = new Color32[count];
+		[Obsolete("Use GetColorData<Color32>")]
+		public void GetColors(ref Color32[] colorData, int mipLevel = 0) => GetColorData(ref colorData, mipLevel);
 
-			GCHandle pinnedArray = GCHandle.Alloc(colorData, GCHandleType.Pinned);
-			IntPtr   pointer     = pinnedArray.AddrOfPinnedObject();
-			NativeAPI.tex_get_data_mip(_inst, pointer, (UIntPtr)(count * 4), mipLevel);
-			pinnedArray.Free();
-		}
 		/// <summary>Retrieve the color data of the texture from the GPU. This
 		/// can be a very slow operation, so use it cautiously.</summary>
 		/// <param name="mipLevel">Retrieves the color data for a specific
@@ -360,16 +350,62 @@ namespace StereoKit
 		/// array if an invalid mip-level is provided.</param>
 		/// <returns>The texture's color values in an array sized Width*Height.
 		/// </returns>
-		public Color32[] GetColors(int mipLevel = 0)
+		[Obsolete("Use GetColorData<Color32>")]
+		public Color32[] GetColors(int mipLevel = 0) => GetColorData<Color32>(mipLevel);
+
+		/// <summary>Retrieve the color data of the texture from the GPU. This
+		/// can be a very slow operation, so use it cautiously.</summary>
+		/// <typeparam name="T">This should be a struct or basic type used to
+		/// represent your color/pixel data. Structs should use
+		/// `[StructLayout(LayoutKind.Sequential)]`.</typeparam>
+		/// <param name="mipLevel">Retrieves the color data for a specific
+		/// mip-mapping level. This function will log a fail and return a black
+		/// array if an invalid mip-level is provided.</param>
+		/// <param name="structPerPixel">The number of `T` that fit in a single
+		/// pixel. For example, if your texture format is RGBA128, and your T
+		/// is float, this value would be 4.</param>
+		/// <returns>The texture's color values in an array sized
+		/// Width*Height*structPerPixel.</returns>
+		public T[] GetColorData<T>(int mipLevel = 0, int structPerPixel = 1) where T:struct
 		{
-			int width  = Width  >> mipLevel;
-			int height = Height >> mipLevel;
-			Color32[] result      = new Color32[width * height];
-			GCHandle  pinnedArray = GCHandle.Alloc(result, GCHandleType.Pinned);
-			IntPtr    pointer     = pinnedArray.AddrOfPinnedObject();
-			NativeAPI.tex_get_data_mip(_inst, pointer, (UIntPtr)(result.Length * 4), mipLevel);
-			pinnedArray.Free();
+			T[] result = null;
+			GetColorData(ref result, mipLevel, structPerPixel);
 			return result;
+		}
+
+		/// <summary>Retrieve the color data of the texture from the GPU. This
+		/// can be a very slow operation, so use it cautiously.</summary>
+		/// <typeparam name="T">This should be a struct or basic type used to
+		/// represent your color/pixel data. Structs should use
+		/// `[StructLayout(LayoutKind.Sequential)]`.</typeparam>
+		/// <param name="colorData">An array of colors that will be filled out
+		/// with the texture's data. It can be null, or an incorrect size. If
+		/// so, it will be reallocated to the correct size.</param>
+		/// <param name="mipLevel">Retrieves the color data for a specific
+		/// mip-mapping level. This function will log a fail and return a black
+		/// array if an invalid mip-level is provided.</param>
+		/// <param name="structPerPixel">The number of `T` that fit in a single
+		/// pixel. For example, if your texture format is RGBA128, and your T
+		/// is float, this value would be 4.</param>
+		/// <exception cref="ArgumentException">structPerPixel must be larger
+		/// than 0</exception>
+		public void GetColorData<T>(ref T[] colorData, int mipLevel = 0, int structPerPixel = 1) where T:struct
+		{
+			int structSize  = Marshal.SizeOf<T>();
+			int pixelSize   = structPerPixel * structSize;
+
+			if (structPerPixel <= 0)
+				throw new ArgumentException("structPerPixel must be larger than 0");
+
+			int width      = Width  >> mipLevel;
+			int height     = Height >> mipLevel;
+			int dataLength = width * height * structPerPixel;
+			if (colorData == null || colorData.Length != dataLength) colorData = new T[dataLength];
+
+			GCHandle  pinnedArray = GCHandle.Alloc(colorData, GCHandleType.Pinned);
+			IntPtr    pointer     = pinnedArray.AddrOfPinnedObject();
+			NativeAPI.tex_get_data_mip(_inst, pointer, (UIntPtr)(width * height * pixelSize), mipLevel);
+			pinnedArray.Free();
 		}
 
 		/// <summary>Set the texture's size without providing any color data.


### PR DESCRIPTION
This expands the API to allow for getting colors in formats other than RGBA32.