### PR TITLE
Skybox fixes.

### DIFF
--- a/StereoKitC/shaders_builtin/shader_builtin_skybox.hlsl
+++ b/StereoKitC/shaders_builtin/shader_builtin_skybox.hlsl
@@ -1,7 +1,5 @@
 #include "stereokit.hlsli"
 
-//--name = sk/skybox
-
 struct vsIn {
 	float4 pos : SV_Position;
 };
@@ -15,16 +13,10 @@ psIn vs(vsIn input, uint id : SV_InstanceID) {
 	psIn o;
 	o.view_id = id % sk_view_count;
 	id        = id / sk_view_count;
-	o.pos     = float4(input.pos.xy, 0.99999, 1);
+	o.pos     = float4(input.pos.xy, 1, 1);
 
-	float4   proj_inv       = mul(o.pos, sk_proj_inv[o.view_id]);
-	float4x4 v              = sk_view[o.view_id];
-	float4x4 transpose_view = float4x4(
-		v._11, v._21, v._31, v._41,
-		v._12, v._22, v._32, v._42,
-		v._13, v._23, v._33, v._43,
-		v._14, v._24, v._34, v._44 );
-	o.norm = mul(float4(proj_inv.xyz, 0), transpose_view).xyz;
+	float4 proj_inv = mul(o.pos, sk_proj_inv[o.view_id]);
+	o.norm = mul(float4(proj_inv.xyz, 0), transpose(sk_view[o.view_id])).xyz;
 	return o;
 }
 

--- a/StereoKitC/systems/render.cpp
+++ b/StereoKitC/systems/render.cpp
@@ -238,6 +238,7 @@ bool render_init() {
 	material_set_id          (local.sky_mat, "sk/render/skybox_material");
 	material_set_queue_offset(local.sky_mat, 100);
 	material_set_depth_write (local.sky_mat, false);
+	material_set_depth_test  (local.sky_mat, depth_test_less_or_eq);
 
 	tex_t sky_cubemap = tex_find(default_id_cubemap);
 	render_set_skytex   (sky_cubemap);


### PR DESCRIPTION
Some strange Android behavior related to the skybox, Quest was recently or occasionally displaying as black? Not sure when this started happening, or if it actually is happening consistently, maybe some recent driver thing?

Simplified a bit of shader code workarounds as well. Previously `transpose` was not working with either SK's transpiler or the Android driver's shader compiler. Seems to be fine now though. Also shifted depth back to a full 1, and swapped the depth test to less_eq to work properly with that.