### PR TITLE
Update to OpenXR Loader, fix for Quest v62

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,9 +177,9 @@ endif()
 #### OpenXR - https://www.khronos.org/openxr/ ####
 if (SK_BUILD_OPENXR_LOADER)
   CPMAddPackage( # We're scraping the comment after the NAME for some other scripts
-    NAME openxr_loader # 1.0.30
+    NAME openxr_loader # 1.0.34
     GITHUB_REPOSITORY KhronosGroup/OpenXR-SDK
-    GIT_TAG 55224479ab13db8ebc8ab1e3d49197bce6201b0b
+    GIT_TAG 288d3a7ebc1ad959f62d51da75baa3d27438c499
     OPTIONS
     "BUILD_WITH_SYSTEM_JSONCPP OFF"
     "BUILD_WITH_XCB_HEADERS OFF"


### PR DESCRIPTION
Quest v62 broke the official OpenXR Loader, OpenXR Loader v1.0.34 fixes the issue.

Details here:
https://communityforums.atmeta.com/t5/OpenXR-Development/v62-breaks-apps-using-the-official-Khronos-OpenXR-Loader/td-p/1148407