### PR TITLE
Snapdragon hand mesh

### DIFF
--- a/Examples/StereoKitTest/Demos/DemoDevice.cs
+++ b/Examples/StereoKitTest/Demos/DemoDevice.cs
@@ -21,6 +21,8 @@ class DemoDevice : ITest
 		Vec2 labelSize = V.XY(0.08f,0);
 		UI.Label("Name", labelSize); UI.SameLine();
 		UI.Label(Device.Name, false);
+		UI.Label("Runtime", labelSize); UI.SameLine();
+		UI.Label(Device.Runtime, false);
 		UI.Label("GPU", labelSize); UI.SameLine();
 		UI.Label(Device.GPU, false);
 		UI.Label("Tracking", labelSize); UI.SameLine();

--- a/StereoKit/Native/NativeAPI.cs
+++ b/StereoKit/Native/NativeAPI.cs
@@ -42,6 +42,7 @@ namespace StereoKit
 		//[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern FovInfo        device_display_get_fov         ();
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern DeviceTracking device_get_tracking            ();
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr         device_get_name                ();
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr         device_get_runtime             ();
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr         device_get_gpu                 ();
 		[return: MarshalAs(UnmanagedType.Bool)]
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern bool           device_has_eye_gaze            ();

--- a/StereoKit/Util/Device.cs
+++ b/StereoKit/Util/Device.cs
@@ -32,6 +32,12 @@
 		/// is the same as systemName from XrSystemProperties. The simulator 
 		/// will say "Simulator".</summary>
 		public static string Name => NativeHelper.FromUtf8(NativeAPI.device_get_name());
+		/// <summary>This is the name of the OpenXR runtime that powers the
+		/// current device! This can help you determine which implementation
+		/// quirks to expect based on the codebase used. On the simulator, this
+		/// will be "Simulator", and in other non-XR modes this will be "None".
+		/// </summary>
+		public static string Runtime => NativeHelper.FromUtf8(NativeAPI.device_get_runtime());
 		/// <summary>The reported name of the GPU, this will differ between D3D
 		/// and GL.</summary>
 		public static string GPU => NativeHelper.FromUtf8(NativeAPI.device_get_gpu());

--- a/StereoKitC/device.cpp
+++ b/StereoKitC/device.cpp
@@ -22,6 +22,7 @@ void device_data_init(device_data_t* data) {
 
 void device_data_free(device_data_t* data) {
 	sk_free(data->name);
+	sk_free(data->runtime);
 	sk_free(data->gpu);
 	*data = {};
 }
@@ -94,6 +95,12 @@ device_tracking_ device_get_tracking() {
 
 const char* device_get_name() {
 	return device_data.name;
+}
+
+///////////////////////////////////////////
+
+const char* device_get_runtime() {
+	return device_data.runtime;
 }
 
 ///////////////////////////////////////////

--- a/StereoKitC/device.h
+++ b/StereoKitC/device.h
@@ -18,6 +18,7 @@ struct device_data_t {
 	fov_info_t       display_fov;
 	device_tracking_ tracking;
 	char*            name;
+	char*            runtime;
 	char*            gpu;
 	bool32_t         has_eye_gaze;
 	bool32_t         has_hand_tracking;

--- a/StereoKitC/hands/input_hand.cpp
+++ b/StereoKitC/hands/input_hand.cpp
@@ -203,10 +203,19 @@ void input_hand_init() {
 	material_set_transparency(hand_mat, transparency_blend);
 
 	gradient_t color_grad = gradient_create();
-	gradient_add(color_grad, color128{ .4f,.4f,.4f,0 }, 0.0f);
-	gradient_add(color_grad, color128{ .6f,.6f,.6f,0 }, 0.4f);
-	gradient_add(color_grad, color128{ .8f,.8f,.8f,1 }, 0.55f);
-	gradient_add(color_grad, color128{ 1,  1,  1,  1 }, 1.0f);
+	// Snapdragon's implementation of XR_MSFT_hand_tracking_mesh does not work
+	// well with SK's implementation of UV generation just yet, so we set it to
+	// pure white for now instead. Users can always opt out of the extension if
+	// they prefer the fallback hand mesh.
+	if (strstr(device_get_runtime(), "Snapdragon") != nullptr && backend_openxr_ext_enabled("XR_MSFT_hand_tracking_mesh")) {
+		gradient_add(color_grad, color128{ 1,1,1,1 }, 0.0f);
+		gradient_add(color_grad, color128{ 1,1,1,1 }, 1.0f);
+	} else {
+		gradient_add(color_grad, color128{ .4f,.4f,.4f,0 }, 0.0f);
+		gradient_add(color_grad, color128{ .6f,.6f,.6f,0 }, 0.4f);
+		gradient_add(color_grad, color128{ .8f,.8f,.8f,1 }, 0.55f);
+		gradient_add(color_grad, color128{ 1,  1,  1,  1 }, 1.0f);
+	}
 
 	color32 gradient[16 * 16];
 	for (int32_t y = 0; y < 16; y++) {

--- a/StereoKitC/stereokit.h
+++ b/StereoKitC/stereokit.h
@@ -508,6 +508,7 @@ SK_API int32_t          device_display_get_height (void);
 SK_API fov_info_t       device_display_get_fov    (void);
 SK_API device_tracking_ device_get_tracking       (void);
 SK_API const char*      device_get_name           (void);
+SK_API const char*      device_get_runtime        (void);
 SK_API const char*      device_get_gpu            (void);
 SK_API bool32_t         device_has_eye_gaze       (void);
 SK_API bool32_t         device_has_hand_tracking  (void);

--- a/StereoKitC/xr_backends/offscreen.cpp
+++ b/StereoKitC/xr_backends/offscreen.cpp
@@ -35,6 +35,7 @@ bool offscreen_init() {
 	device_data.display_blend     = display_blend_opaque;
 	device_data.display_type      = display_type_flatscreen;
 	device_data.name              = string_copy("Offscreen");
+	device_data.runtime           = string_copy("None");
 
 	local = sk_malloc_zero_t(offscreen_backend_state_t, 1);
 

--- a/StereoKitC/xr_backends/openxr.cpp
+++ b/StereoKitC/xr_backends/openxr.cpp
@@ -247,15 +247,12 @@ bool openxr_create_system() {
 	xr_check(xrGetInstanceProperties(xr_instance, &inst_properties),
 		"xrGetInstanceProperties failed [%s]");
 
+	device_data.runtime = string_copy(inst_properties.runtimeName);
 	log_diagf("Found OpenXR runtime: <~grn>%s<~clr> %u.%u.%u",
 		inst_properties.runtimeName,
 		XR_VERSION_MAJOR(inst_properties.runtimeVersion),
 		XR_VERSION_MINOR(inst_properties.runtimeVersion),
 		XR_VERSION_PATCH(inst_properties.runtimeVersion));
-
-	if (strstr(inst_properties.runtimeName, "Snapdragon") != nullptr) {
-		xr_ext_available.MSFT_hand_tracking_mesh = false; // Hand mesh doesn't currently show up, needs investigation
-	}
 
 	// Create links to the extension functions
 	xr_extensions = xrCreateExtensionTable(xr_instance);
@@ -503,8 +500,8 @@ bool openxr_init() {
 
 		// The Leap hand tracking layer seems to supercede the built-in extensions.
 		if (xr_ext_available.EXT_hand_tracking && has_leap_layer == false) {
-			if (strcmp(inst_properties.runtimeName, "Windows Mixed Reality Runtime") == 0 ||
-				strcmp(inst_properties.runtimeName, "SteamVR/OpenXR") == 0) {
+			if (strcmp(device_get_runtime(), "Windows Mixed Reality Runtime") == 0 ||
+				strcmp(device_get_runtime(), "SteamVR/OpenXR") == 0) {
 				log_diag("Rejecting OpenXR's provided hand tracking extension due to the suspicion that it is inadequate for StereoKit.");
 				xr_has_articulated_hands = false;
 				xr_has_hand_meshes       = false;

--- a/StereoKitC/xr_backends/simulator.cpp
+++ b/StereoKitC/xr_backends/simulator.cpp
@@ -54,6 +54,7 @@ bool simulator_init() {
 	device_data.display_blend     = display_blend_opaque;
 	device_data.display_type      = display_type_flatscreen;
 	device_data.name              = string_copy("Simulator");
+	device_data.runtime           = string_copy("Simulator");
 
 	sim_head_rot     = { -21, 0.0001f, 0 };
 	sim_head_pos     = { 0, 0.2f, 0.0f };

--- a/StereoKitC/xr_backends/window.cpp
+++ b/StereoKitC/xr_backends/window.cpp
@@ -51,6 +51,7 @@ bool window_init() {
 	device_data.display_blend     = display_blend_opaque;
 	device_data.display_type      = display_type_flatscreen;
 	device_data.name              = string_copy("Window");
+	device_data.runtime           = string_copy("None");
 
 	world_origin_mode   = origin_mode_local;
 	world_origin_offset = { {0,0,0}, quat_identity };


### PR DESCRIPTION
Re-enable snapdragon hand meshes, but substitute the normal texture with a solid white texture to bypass the UV calculation issues there.

Also added `Device.Runtime` to determine which runtime is powering the XR device.