### PR TITLE
Remove redundant log formatting overloads.

### DIFF
--- a/StereoKit/Systems/Log.cs
+++ b/StereoKit/Systems/Log.cs
@@ -70,15 +70,6 @@ namespace StereoKit
 		/// <param name="level">Severity level of this log message.</param>
 		/// <param name="text">Formatted text with color tags! See the Log
 		/// class docs for guidance on color tags.</param>
-		/// <param name="items">Format arguments.</param>
-		public static void Write(LogLevel level, string text, params object[] items)
-			=> NativeAPI.log_write(level, string.Format(text, items));
-
-		/// <summary>Writes a formatted line to the log with the specified
-		/// severity level!</summary>
-		/// <param name="level">Severity level of this log message.</param>
-		/// <param name="text">Formatted text with color tags! See the Log
-		/// class docs for guidance on color tags.</param>
 		public static void Write(LogLevel level, string text)
 			=> NativeAPI.log_write(level, text);
 
@@ -93,14 +84,6 @@ namespace StereoKit
 		/// severity level!</summary>
 		/// <param name="text">Formatted text with color tags! See the Log
 		/// class docs for guidance on color tags.</param>
-		/// <param name="items">Format arguments.</param>
-		public static void Info(string text, params object[] items)
-			=> NativeAPI.log_write(LogLevel.Info, string.Format(text, items));
-
-		/// <summary>Writes a formatted line to the log using a LogLevel.Info
-		/// severity level!</summary>
-		/// <param name="text">Formatted text with color tags! See the Log
-		/// class docs for guidance on color tags.</param>
 		public static void Info(string text)
 			=> NativeAPI.log_write(LogLevel.Info, text);
 
@@ -108,24 +91,8 @@ namespace StereoKit
 		/// severity level!</summary>
 		/// <param name="text">Formatted text with color tags! See the Log
 		/// class docs for guidance on color tags.</param>
-		/// <param name="items">Format arguments.</param>
-		public static void Warn(string text, params object[] items)
-			=> NativeAPI.log_write(LogLevel.Warning, string.Format(text, items));
-
-		/// <summary>Writes a formatted line to the log using a LogLevel.Warn
-		/// severity level!</summary>
-		/// <param name="text">Formatted text with color tags! See the Log
-		/// class docs for guidance on color tags.</param>
 		public static void Warn(string text)
 			=> NativeAPI.log_write(LogLevel.Warning, text);
-
-		/// <summary>Writes a formatted line to the log using a
-		/// LogLevel.Error severity level!</summary>
-		/// <param name="text">Formatted text with color tags! See the Log
-		/// class docs for guidance on color tags.</param>
-		/// <param name="items">Format arguments.</param>
-		public static void Err(string text, params object[] items)
-			=> NativeAPI.log_write(LogLevel.Error, string.Format(text, items));
 
 		/// <summary>Writes a formatted line to the log using a
 		/// LogLevel.Error severity level!</summary>


### PR DESCRIPTION
This removes overloads for `Log.Write` and family that provided formatting functionality. These functions just increase API complexity and surface when C#'s built-in string interpolators are more than enough.