### PR TITLE
Window focus delay

### DIFF
--- a/StereoKitC/ui/stereokit_ui.cpp
+++ b/StereoKitC/ui/stereokit_ui.cpp
@@ -939,13 +939,17 @@ void ui_window_end() {
 	vec3 size  = { win->prev_size.x, win->prev_size.y, skui_settings.depth };
 
 	// Focus animation
+	const float delay = 0.2f;
 	button_state_ focus_state = ui_id_focus_state(win->hash);
-	if (focus_state & button_state_just_active)   ui_anim_start(win->hash, 0);
-	if (focus_state & button_state_just_inactive) ui_anim_start(win->hash, 1);
+	if (focus_state & button_state_just_active) ui_anim_start(win->hash, 0);
+	if (focus_state & button_state_just_inactive) {
+		if (ui_anim_elapsed_total(win->hash, 0) > delay) ui_anim_start(win->hash, 1);
+		ui_anim_cancel(win->hash, 0);
+	}
 
 	float focus = ui_id_focused(win->hash) & button_state_active ? 1.0f : 0.0f;
-	if (ui_anim_has(win->hash, 0, skui_anim_focus_duration)) {
-		focus = math_ease_smooth(0, 1, ui_anim_elapsed(win->hash, 0, skui_anim_focus_duration));
+	if (ui_anim_has(win->hash, 0, delay + skui_anim_focus_duration)) {
+		focus = math_ease_smooth(0, 1, math_clamp((ui_anim_elapsed_total(win->hash, 0)-delay)/ skui_anim_focus_duration, 0, 1));
 	} else if (ui_anim_has(win->hash, 1, skui_anim_focus_duration)) {
 		focus = math_ease_smooth(1, 0, ui_anim_elapsed(win->hash, 1, skui_anim_focus_duration));
 	}

--- a/StereoKitC/ui/ui_theming.cpp
+++ b/StereoKitC/ui/ui_theming.cpp
@@ -647,6 +647,15 @@ void ui_anim_start(id_hash_t id, int32_t channel) {
 
 ///////////////////////////////////////////
 
+void ui_anim_cancel(id_hash_t id, int32_t channel) {
+	if (skui_anim_id[channel] == id) {
+		skui_anim_id[channel] = 0;
+		skui_anim_time[channel] = 0;
+	}
+}
+
+///////////////////////////////////////////
+
 bool ui_anim_has(id_hash_t id, int32_t channel, float duration) {
 	if (id == skui_anim_id[channel]) {
 		if ((time_totalf_unscaled() - skui_anim_time[channel]) < duration)
@@ -660,6 +669,12 @@ bool ui_anim_has(id_hash_t id, int32_t channel, float duration) {
 
 float ui_anim_elapsed(id_hash_t id, int32_t channel, float duration, float max) {
 	return skui_anim_id[channel] == id ? fminf(max, (time_totalf_unscaled() - skui_anim_time[channel]) / duration) : 0;
+}
+
+///////////////////////////////////////////
+
+float ui_anim_elapsed_total(id_hash_t id, int32_t channel) {
+	return skui_anim_id[channel] == id ? (time_totalf_unscaled() - skui_anim_time[channel]) : 0;
 }
 
 ///////////////////////////////////////////

--- a/StereoKitC/ui/ui_theming.h
+++ b/StereoKitC/ui/ui_theming.h
@@ -28,8 +28,10 @@ void     ui_play_sound_on    (ui_vis_ element_visual, vec3 at);
 void     ui_play_sound_off   (ui_vis_ element_visual, vec3 at);
 void     ui_draw_cube        (vec3 start, vec3 size, ui_color_ color, float focus);
 
-void     ui_anim_start       (id_hash_t id, int32_t channel);
-bool     ui_anim_has         (id_hash_t id, int32_t channel, float duration);
-float    ui_anim_elapsed     (id_hash_t id, int32_t channel, float duration = 1, float max = 1);
+void     ui_anim_start        (id_hash_t id, int32_t channel);
+void     ui_anim_cancel       (id_hash_t id, int32_t channel);
+bool     ui_anim_has          (id_hash_t id, int32_t channel, float duration);
+float    ui_anim_elapsed      (id_hash_t id, int32_t channel, float duration = 1, float max = 1);
+float    ui_anim_elapsed_total(id_hash_t id, int32_t channel);
 
 }


### PR DESCRIPTION
Add a 200ms delay before showing window focus, helps cut down on "flashing" when focus travels between elements.