### PR TITLE
Fix for hand mesh corrupting when switching between the hand mesh EXT.

### DIFF
--- a/Examples/StereoKitTest/Demos/DemoControllers.cs
+++ b/Examples/StereoKitTest/Demos/DemoControllers.cs
@@ -10,6 +10,9 @@ class DemoControllers : ITest
 	string title       = "Controllers";
 	string description = "While StereoKit prioritizes hand input, sometimes a controller has more precision! StereoKit provides access to any controllers via the Input.Controller function. This is a debug visualization of the controller data provided there.\n\nStereoKit will simulate hands if only controllers are present, but it will not simulate controllers if only hands are present.";
 
+	Handed activeHand = Handed.Right;
+	Pose windowPose = Demo.contentPose.Pose;
+
 	public void Initialize()
 	{
 		Default.MaterialHand[MatParamName.ColorTint] = new Color(1,1,1,0.4f);
@@ -24,6 +27,14 @@ class DemoControllers : ITest
 	{
 		ShowController(Handed.Right);
 		ShowController(Handed.Left);
+
+		UI.WindowBegin("Controller Info", ref windowPose, new Vec2(0.3f,0));
+		if (UI.Radio("Left",  activeHand == Handed.Left )) activeHand = Handed.Left;
+		UI.SameLine();
+		if (UI.Radio("Right", activeHand == Handed.Right)) activeHand = Handed.Right;
+
+		ShowControllerUI(activeHand);
+		UI.WindowEnd();
 
 		Demo.ShowSummary(title, description, new Bounds(.2f, .1f, 0));
 	}
@@ -76,4 +87,29 @@ class DemoControllers : ITest
 		Default.MeshCube.Draw(Default.Material, c.aim.ToMatrix(new Vec3(1,1,4) * U.cm), Color.HSV(0,0.5f,0.8f).ToLinear());
 	}
 	/// :End:
+
+	static void LineItem(string label, string content)
+	{
+		UI.Label(label, new Vec2(UI.LineHeight * 3, 0));
+		UI.SameLine();
+		UI.Label(content);
+	}
+	void ShowControllerUI(Handed hand)
+	{
+		Controller controller = Input.Controller(hand);
+
+		LineItem("Pose",        controller.pose.ToString());
+		LineItem("Tracked",     controller.IsTracked.ToString());
+		LineItem("Tracked Pos", controller.trackedPos.ToString());
+		LineItem("Tracked Rot", controller.trackedRot.ToString());
+
+		LineItem("Palm",        controller.palm.ToString());
+		LineItem("Aim",         controller.aim.ToString());
+		LineItem("Stick",       controller.stick.ToString());
+		LineItem("Stick Click", controller.stickClick.IsActive().ToString());
+		LineItem("Trigger",     controller.trigger.ToString());
+		LineItem("Grip",        controller.grip.ToString());
+		LineItem("X1",          controller.x1.ToString());
+		LineItem("X2",          controller.x2.ToString());
+	}
 }

--- a/StereoKitC/hands/input_hand.cpp
+++ b/StereoKitC/hands/input_hand.cpp
@@ -334,7 +334,6 @@ void input_hand_update_poses(bool update_visuals) {
 			// Update hand meshes, and draw 'em
 			bool tracked = hand_state[i].info.tracked_state & button_state_active;
 			if (hand_state[i].visible && hand_state[i].material != nullptr && tracked && sk_app_focus() == app_focus_active && hand_active_mesh[i] != nullptr) {
-				log_infof("Rendering hand mesh %d", (int32_t)time_frame());
 				render_add_mesh(hand_active_mesh[i]->mesh, hand_state[i].material, hand_active_mesh[i]->root_transform, hand_state[i].info.pinch_state & button_state_active ? color128{1.5f, 1.5f, 1.5f, 1} : color128{1,1,1,1});
 			}
 		}
@@ -778,7 +777,6 @@ void input_hand_update_mesh(handed_ hand) {
 	// And update the mesh vertices!
 	mesh_set_verts(data.mesh, data.verts, data.vert_count);
 
-	log_infof("Set fallback hand! %d", (int32_t)time_frame());
 	input_hand_set_mesh_data(hand, &hand_fallback_mesh[hand]);
 }
 

--- a/StereoKitC/hands/input_hand.cpp
+++ b/StereoKitC/hands/input_hand.cpp
@@ -35,7 +35,7 @@ struct hand_state_t {
 	pose_t      pose_blend[5][5];
 	pose_t      pose_prev[5][5];
 	material_t  material;
-	hand_mesh_t mesh;
+	mesh_t      active_mesh;
 	vec3        pinch_pt_relative;
 	bool        visible;
 	bool        enabled;
@@ -115,6 +115,8 @@ hand_system_t hand_sources[] = { // In order of priority
 };
 int32_t             hand_system = -1;
 hand_state_t        hand_state[2] = {};
+hand_mesh_t         hand_fallback_mesh[2];
+hand_mesh_t*        hand_active_mesh[2];
 float               hand_size_update = 0;
 int32_t             input_hand_pointer_id[handed_max] = {-1, -1};
 array_t<hand_sim_t> hand_sim_poses   = {};
@@ -278,9 +280,9 @@ void input_hand_shutdown() {
 
 	for (int32_t i = 0; i < handed_max; i++) {
 		material_release(hand_state[i].material);
-		mesh_release    (hand_state[i].mesh.mesh);
-		sk_free(hand_state[i].mesh.inds);
-		sk_free(hand_state[i].mesh.verts);
+		mesh_release    (hand_fallback_mesh[i].mesh);
+		sk_free(hand_fallback_mesh[i].inds);
+		sk_free(hand_fallback_mesh[i].verts);
 	}
 	hand_sim_poses.free();
 }
@@ -331,8 +333,9 @@ void input_hand_update_poses(bool update_visuals) {
 		for (int32_t i = 0; i < handed_max; i++) {
 			// Update hand meshes, and draw 'em
 			bool tracked = hand_state[i].info.tracked_state & button_state_active;
-			if (hand_state[i].visible && hand_state[i].material != nullptr && tracked && sk_app_focus() == app_focus_active) {
-				render_add_mesh(hand_state[i].mesh.mesh, hand_state[i].material, hand_state[i].mesh.root_transform, hand_state[i].info.pinch_state & button_state_active ? color128{1.5f, 1.5f, 1.5f, 1} : color128{1,1,1,1});
+			if (hand_state[i].visible && hand_state[i].material != nullptr && tracked && sk_app_focus() == app_focus_active && hand_active_mesh[i] != nullptr) {
+				log_infof("Rendering hand mesh %d", (int32_t)time_frame());
+				render_add_mesh(hand_active_mesh[i]->mesh, hand_state[i].material, hand_active_mesh[i]->root_transform, hand_state[i].info.pinch_state & button_state_active ? color128{1.5f, 1.5f, 1.5f, 1} : color128{1,1,1,1});
 			}
 		}
 	}
@@ -414,8 +417,8 @@ hand_joint_t *input_hand_get_pose_buffer(handed_ hand) {
 
 ///////////////////////////////////////////
 
-hand_mesh_t *input_hand_mesh_data(handed_ handedness) {
-	return &hand_state[handedness].mesh;
+void input_hand_set_mesh_data(handed_ handedness, hand_mesh_t *mesh_data) {
+	hand_active_mesh[handedness] = mesh_data;
 }
 
 ///////////////////////////////////////////
@@ -616,7 +619,7 @@ const vec3 sincos_norm[] = {
 const float texcoord_v[SK_FINGERJOINTS + 1] = { 1, 1-0.44f, 1-0.69f, 1-0.85f, 1-0.96f, 1-0.99f };
 
 void input_hand_update_mesh(handed_ hand) {
-	hand_mesh_t &data = hand_state[hand].mesh;
+	hand_mesh_t &data = hand_fallback_mesh[hand];
 
 	const int32_t ring_count  = _countof(sincos);
 	const int32_t slice_count = SK_FINGERJOINTS + 1;
@@ -774,6 +777,9 @@ void input_hand_update_mesh(handed_ hand) {
 
 	// And update the mesh vertices!
 	mesh_set_verts(data.mesh, data.verts, data.vert_count);
+
+	log_infof("Set fallback hand! %d", (int32_t)time_frame());
+	input_hand_set_mesh_data(hand, &hand_fallback_mesh[hand]);
 }
 
 ///////////////////////////////////////////

--- a/StereoKitC/hands/input_hand.h
+++ b/StereoKitC/hands/input_hand.h
@@ -47,7 +47,7 @@ void          input_hand_update_meshes  ();
 void          input_hand_update_poses   (bool update_visuals);
 bool          input_hand_get_visible    (handed_ hand);
 hand_joint_t* input_hand_get_pose_buffer(handed_ hand);
-hand_mesh_t*  input_hand_mesh_data      (handed_ handedness);
+void          input_hand_set_mesh_data  (handed_ handedness, hand_mesh_t* mesh_data);
 void          input_hand_sim            (handed_ handedness, bool center_on_finger,  vec3 hand_pos, quat orientation, bool tracked);
 void          input_hand_sim_poses      (handed_ handedness, bool mouse_adjustments, vec3 hand_pos, quat orientation);
 void          input_hand_state_update   (handed_ handedness);


### PR DESCRIPTION
Switching between StereoKit's fallback hand mesh and the hand mesh extension would cause the mesh to get corrupted! This fixes that issue, and adds a window that allows you to inspect all available controller data.