### PR TITLE
fix: debug UWP C# projects

### DIFF
--- a/Examples/StereoKitTest/StereoKitTest_UWP/StereoKitTest_UWP.csproj
+++ b/Examples/StereoKitTest/StereoKitTest_UWP/StereoKitTest_UWP.csproj
@@ -107,12 +107,10 @@
     <SKCMakePreset Condition="'$(Platform)' == 'ARM'"  >Uwp_Arm32_$(Configuration)</SKCMakePreset>
     <SKCMakePreset Condition="'$(Platform)' == 'ARM64'">Uwp_Arm64_$(Configuration)</SKCMakePreset>
     <SKCMakePreset Condition="'$(Platform)' == 'x64'"  >Uwp_x64_$(Configuration)</SKCMakePreset>
-    <!--Unlike the other projects, this seems to invoke from the bin
-        folder, and $(ProjectDir) doesn't work.-->
-    <PreBuildEvent>cd ..\..\..\ &amp; cmake --preset $(SKCMakePreset) &amp; cmake --build --preset $(SKCMakePreset)</PreBuildEvent>
+    <PreBuildEvent>cd $(ProjectDir)..\..\..\ &amp; cmake --preset $(SKCMakePreset) &amp; cmake --build --preset $(SKCMakePreset)</PreBuildEvent>
   </PropertyGroup>
   <Target Name="SKTestRebuildUWP" AfterTargets="Clean">
-    <RemoveDir Directories="..\..\..\bin\intermediate\UWP_$(Platform)_$(Configuration)" />
+    <RemoveDir Directories="$(ProjectDir)..\..\..\bin\intermediate\UWP_$(Platform)_$(Configuration)" />
   </Target>
   <Target Name="SKCheckBuildFiles" BeforeTargets="CoreBuild" AfterTargets="PreBuild">
     <Message Importance="high" Text="=========$(Platform)" />

--- a/Examples/StereoKitTest/StereoKitTest_UWP/StereoKitTest_UWP.csproj
+++ b/Examples/StereoKitTest/StereoKitTest_UWP/StereoKitTest_UWP.csproj
@@ -12,7 +12,7 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
-    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.18362.0</TargetPlatformVersion>
+    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.19041.0</TargetPlatformVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -93,10 +93,6 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\..\StereoKitC\StereoKitC_UWP\StereoKitC_UWP.vcxproj">
-      <Project>{45af7827-11ca-4691-a063-8c78fb0be1ec}</Project>
-      <Name>StereoKitC_UWP</Name>
-    </ProjectReference>
     <ProjectReference Include="..\..\..\StereoKit\StereoKit.csproj">
       <Project>{0152979d-5d5e-4d18-9ef7-7261581b2bc6}</Project>
       <Name>StereoKit</Name>
@@ -106,11 +102,26 @@
     <VisualStudioVersion>14.0</VisualStudioVersion>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
+  <!-- Make sure the UWP binaries are built and included. -->
+  <PropertyGroup>
+    <SKCMakePreset Condition="'$(Platform)' == 'ARM'"  >Uwp_Arm32_$(Configuration)</SKCMakePreset>
+    <SKCMakePreset Condition="'$(Platform)' == 'ARM64'">Uwp_Arm64_$(Configuration)</SKCMakePreset>
+    <SKCMakePreset Condition="'$(Platform)' == 'x64'"  >Uwp_x64_$(Configuration)</SKCMakePreset>
+    <!--Unlike the other projects, this seems to invoke from the bin
+        folder, and $(ProjectDir) doesn't work.-->
+    <PreBuildEvent>cd ..\..\..\ &amp; cmake --preset $(SKCMakePreset) &amp; cmake --build --preset $(SKCMakePreset)</PreBuildEvent>
+  </PropertyGroup>
+  <Target Name="SKTestRebuildUWP" AfterTargets="Clean">
+    <RemoveDir Directories="..\..\..\bin\intermediate\UWP_$(Platform)_$(Configuration)" />
   </Target>
-  <Target Name="AfterBuild"> 
+  <Target Name="SKCheckBuildFiles" BeforeTargets="CoreBuild" AfterTargets="PreBuild">
+    <Message Importance="high" Text="=========$(Platform)" />
+    <Error Condition="!Exists('$(ProjectDir)..\..\..\bin\distribute\bin\UWP\$(Platform)\$(Configuration)\StereoKitC.dll')" Text="StereoKitC was not properly built! Binary files are missing." />
   </Target>
-  -->
+  <ItemGroup>
+    <None Visible="false" Include="$(ProjectDir)..\..\..\bin\distribute\bin\UWP\$(Platform)\$(Configuration)\StereoKitC.dll" CopyToOutputDirectory="PreserveNewest" />
+    <None Visible="false" Include="$(ProjectDir)..\..\..\bin\distribute\bin\UWP\$(Platform)\$(Configuration)\StereoKitC.pdb" CopyToOutputDirectory="PreserveNewest" />
+    <!-- Needed for ucrtbased.dll when running a debug build. -->
+    <SDKReference Condition="'$(Configuration)' == 'Debug'" Include="Microsoft.VCLibs, Version=14.0" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
The UWP Debug configuration of StereoKitC could not be loaded due to a missing dependency: `ucrtbased.dll`. Similar to this (almost ancient?) [forum](https://forums.hololens.com/discussion/1448/dllnotfoundexception-when-c-code-tries-to-pinvoke-a-native-lib), it occurred for the ARM, ARM64, & x64 (.NET Native only) libraries.

I also added in the CMake build for the UWP test project! Would you want to remove/refactor the StereoKitC_UWP & StereoKitCTest_UWP projects in the solution as well?