### PR TITLE
Interaction improvements

### DIFF
--- a/Examples/StereoKitTest/DebugToolWindow.cs
+++ b/Examples/StereoKitTest/DebugToolWindow.cs
@@ -107,7 +107,7 @@ class DebugToolWindow : IStepper
 		itemToolsSkeleton = new HandMenuItem("Skeleton",     Sprite.ToggleOff, () => skeleton = ToggleTool(skeleton) );
 		itemToolsTheme    = new HandMenuItem("Theme Editor", Sprite.ToggleOff, () => theme    = ToggleTool(theme) );
 		itemToolsCamera   = new HandMenuItem("Camera",       Sprite.ToggleOff, () => camera   = ToggleTool(camera, () => new RenderCamera(UI.PopupPose(), 1000, 1000)) );
-		itemToolsRuler    = new HandMenuItem("Ruler",        Sprite.ToggleOff, () => showRuler = !showRuler );
+		itemToolsRuler    = new HandMenuItem("Ruler",        Sprite.ToggleOff, () => {showRuler = !showRuler; rulerPose = UI.PopupPose();} );
 		itemRecordHead    = new HandMenuItem("Record Head",  Sprite.ToggleOff, () => ToggleRecordHead() );
 		itemRecordHand    = new HandMenuItem("Record Hand",  Sprite.ToggleOff, () => ToggleRecordHand() );
 
@@ -124,6 +124,7 @@ class DebugToolWindow : IStepper
 				itemToolsSkeleton,
 				itemToolsTheme,
 				itemToolsCamera,
+				itemToolsRuler,
 				new HandMenuItem("Back", null, null, HandMenuAction.Back)
 				),
 			new HandRadialLayer("Print",

--- a/Examples/StereoKitTest/Tools/ThemeEditor.cs
+++ b/Examples/StereoKitTest/Tools/ThemeEditor.cs
@@ -82,7 +82,7 @@ UI.SetThemeColor(UIColor.Text,       new Color({text.r      :0.000}f,{text.g    
 			initial      = Theme.FromCurrent();
 			active       = initial.Clone();
 			applied      = initial.Clone();
-			settingsPose = UI.PopupPose();
+			settingsPose = UI.PopupPose(new Vec3(0,0.1f,0));
 			return true;
 		}
 

--- a/StereoKitC/hands/hand_oxr_articulated.cpp
+++ b/StereoKitC/hands/hand_oxr_articulated.cpp
@@ -246,10 +246,13 @@ void hand_oxra_update_joints() {
 		// "ready pose" (facing the same general direction as the user). It
 		// should remain tracked if it was activated, even if it's no longer in
 		// a ready pose.
+		const float near_dist  = 0.2f;
+		const float hand_angle = 0.25f; // ~150 degrees
 		bool was_tracked  = (pointer ->tracked       & button_state_active) > 0;
 		bool is_active    = (pointer ->state         & button_state_active) > 0;
 		bool hand_tracked = (inp_hand->tracked_state & button_state_active) > 0;
-		bool is_facing    = vec3_dot(vec3_normalize(pointer->ray.pos - input_head()->position), inp_hand->palm.orientation * vec3_forward) > 0.25f;
+		bool is_facing    = vec3_dot(vec3_normalize(pointer->ray.pos - head->position), inp_hand->palm.orientation * vec3_forward) > hand_angle;
+		bool is_far       = vec2_distance_sq({pointer->ray.pos.x, pointer->ray.pos.z}, {head->position.x, head->position.z}) > (near_dist*near_dist);
 		pointer->tracked = button_make_state(was_tracked, hand_tracked && (is_active || is_facing));
 	}
 

--- a/StereoKitC/tools/virtual_keyboard.cpp
+++ b/StereoKitC/tools/virtual_keyboard.cpp
@@ -190,7 +190,7 @@ void virtualkeyboard_open(bool32_t open, text_context_ type) {
 
 	// Position the keyboard in front of the user if this just opened
 	if (open && !local.open) {
-		local.pose = matrix_transform_pose(matrix_invert(render_get_cam_root()), ui_popup_pose({0,-0.1f,0}));
+		local.pose = matrix_transform_pose(matrix_invert(render_get_cam_root()), ui_popup_pose({0,0,0}));
 	}
 
 	// Reset the keyboard to its default state

--- a/StereoKitC/ui/stereokit_ui.cpp
+++ b/StereoKitC/ui/stereokit_ui.cpp
@@ -805,7 +805,7 @@ bool32_t ui_slider_at_g(bool vertical, const C *id_text, float &value, float min
 	vec2 vmin, vmax, vstep, vval;
 	if (vertical) { vmin = { 0,min }; vmax = { 0,max }; vstep = { 0,step }; vval = { 0,value }; }
 	else          { vmin = { min,0 }; vmax = { max,0 }; vstep = { step,0 }; vval = { value,0 }; }
-	ui_slider_behavior(id, &vval, vmin, vmax, vstep, window_relative_pos, size, button_size, confirm_method, &button_center, &finger_offset, &focus_state, &active_state, &interactor);
+	ui_slider_behavior(id, &vval, vmin, vmax, vstep, window_relative_pos, size, button_size, button_size + vec2{skui_settings.padding, skui_settings.padding}*2, confirm_method, & button_center, & finger_offset, & focus_state, & active_state, & interactor);
 	value = vertical ? vval.y : vval.x;
 
 	if (active_state & button_state_just_active)

--- a/StereoKitC/ui/ui_core.cpp
+++ b/StereoKitC/ui/ui_core.cpp
@@ -126,7 +126,7 @@ void ui_show_ray(int32_t interactor, float skip, bool hide_inactive, float *ref_
 		float curve = math_lerp(
 			sinf(pct_i * pct_i * 3.14159f),
 			fminf(1,sinf(pct * pct * 3.14159f)*1.5f), active);
-		float width = (0.0015f + curve * 0.002f) * visibility;
+		float width = (0.002f + curve * 0.003f) * visibility;
 		pts[i] = line_point_t{ actor->position + vec3_lerp(uncentered_dir*d, centered_dir*d, blend), width, color32{ 255,255,255,(uint8_t)(curve*alpha*255) } };
 	}
 	line_add_listv(pts, ct);

--- a/StereoKitC/ui/ui_core.cpp
+++ b/StereoKitC/ui/ui_core.cpp
@@ -480,7 +480,7 @@ bool32_t _ui_handle_begin(id_hash_t id, pose_t &handle_pose, bounds_t handle_bou
 				hand_attention_dist += 0.1f; // penalty to prefer non-handle elements
 
 				if (actor->pinch_state & button_state_just_active && actor->focused_prev == id) {
-					ui_play_sound_on(ui_vis_handle, actor->capsule_end_world);
+					ui_play_sound_on(ui_vis_handle, hierarchy_to_world_point(at));
 
 					actor->active = id;
 					actor->interaction_start_position      = actor->position;
@@ -568,7 +568,7 @@ bool32_t _ui_handle_begin(id_hash_t id, pose_t &handle_pose, bounds_t handle_bou
 
 					if (actor->pinch_state & button_state_just_inactive) {
 						actor->active = 0;
-						ui_play_sound_off(ui_vis_handle, actor->capsule_end_world);
+						ui_play_sound_off(ui_vis_handle, hierarchy_to_world_point(actor->interaction_pt_pivot));
 					}
 					ui_pop_surface();
 					ui_push_surface(handle_pose);

--- a/StereoKitC/ui/ui_core.cpp
+++ b/StereoKitC/ui/ui_core.cpp
@@ -945,23 +945,28 @@ button_state_ ui_last_element_hand_focused(handed_ hand) {
 ///////////////////////////////////////////
 
 button_state_ ui_last_element_active() {
-	// TODO: needs interactor work
-	return button_make_state(
-		skui_interactors[handed_left].active_prev == skui_last_element || skui_interactors[handed_right].active_prev == skui_last_element,
-		skui_interactors[handed_left].active      == skui_last_element || skui_interactors[handed_right].active      == skui_last_element);
+	bool was_active = false;
+	bool is_active  = false;
+	for (int32_t i = 0; i < skui_interactors.count; i++) {
+		was_active = was_active || (skui_interactors[i].active_prev == skui_last_element);
+		is_active  = is_active  || (skui_interactors[i].active      == skui_last_element);
+	}
+	return button_make_state(was_active, is_active);
 }
 
 ///////////////////////////////////////////
 
 button_state_ ui_last_element_focused() {
-	// TODO: needs interactor work
-
-	// Because focus can change at any point during the frame, we'll check
-	// against the last two frame's focus ids, which are set in stone after the
-	// frame ends.
-	return button_make_state(
-		skui_interactors[handed_left].focused_prev_prev == skui_last_element || skui_interactors[handed_right].focused_prev_prev == skui_last_element,
-		skui_interactors[handed_left].focused_prev      == skui_last_element || skui_interactors[handed_right].focused_prev      == skui_last_element);
+	bool was_focused = false;
+	bool is_focused  = false;
+	for (int32_t i = 0; i < skui_interactors.count; i++) {
+		// Because focus can change at any point during the frame, we'll check
+		// against the last two frame's focus ids, which are set in stone after the
+		// frame ends.
+		was_focused = was_focused || (skui_interactors[i].focused_prev_prev == skui_last_element);
+		is_focused  = is_focused  || (skui_interactors[i].focused_prev      == skui_last_element);
+	}
+	return button_make_state(was_focused, is_focused);
 }
 
 ///////////////////////////////////////////

--- a/StereoKitC/ui/ui_core.cpp
+++ b/StereoKitC/ui/ui_core.cpp
@@ -54,14 +54,14 @@ void ui_core_init() {
 
 	skui_id_stack.add({ HASH_FNV64_START });
 
-	skui_hand_interactors[0] = interactor_create(interactor_type_point, interactor_event_poke);
-	skui_hand_interactors[1] = interactor_create(interactor_type_point, interactor_event_pinch);
-	skui_hand_interactors[2] = interactor_create(interactor_type_line,  (interactor_event_)(interactor_event_poke | interactor_event_pinch));
-	skui_hand_interactors[3] = interactor_create(interactor_type_point, interactor_event_poke);
-	skui_hand_interactors[4] = interactor_create(interactor_type_point,  interactor_event_pinch);
-	skui_hand_interactors[5] = interactor_create(interactor_type_line,  (interactor_event_)(interactor_event_poke | interactor_event_pinch));
+	skui_hand_interactors[0] = interactor_create(interactor_type_point, interactor_event_poke,  interactor_activate_position);
+	skui_hand_interactors[1] = interactor_create(interactor_type_point, interactor_event_pinch, interactor_activate_state);
+	skui_hand_interactors[2] = interactor_create(interactor_type_line,  (interactor_event_)(interactor_event_poke | interactor_event_pinch), interactor_activate_state);
+	skui_hand_interactors[3] = interactor_create(interactor_type_point, interactor_event_poke,  interactor_activate_position);
+	skui_hand_interactors[4] = interactor_create(interactor_type_point, interactor_event_pinch, interactor_activate_state);
+	skui_hand_interactors[5] = interactor_create(interactor_type_line,  (interactor_event_)(interactor_event_poke | interactor_event_pinch), interactor_activate_state);
 
-	skui_mouse_interactor    = interactor_create(interactor_type_line,  (interactor_event_)(interactor_event_poke | interactor_event_pinch));
+	skui_mouse_interactor    = interactor_create(interactor_type_line,  (interactor_event_)(interactor_event_poke | interactor_event_pinch), interactor_activate_state);
 
 	skui_input_mode = device_display_get_type() == display_type_flatscreen
 		? 2  // Mouse
@@ -182,6 +182,8 @@ void ui_core_controllers_step() {
 		const controller_t *ctrl = input_controller((handed_)i);
 
 		// controller ray
+
+		interactor_min_distance_set(skui_hand_interactors[i*3 + 2], -100000);
 		interactor_update(skui_hand_interactors[i*3 + 2],
 			ctrl->aim.position, ctrl->aim.position + ctrl->aim.orientation*vec3_forward * 100, 0.005f,
 			ctrl->aim.position, ctrl->aim.orientation, input_head()->position,
@@ -289,7 +291,7 @@ button_state_ ui_volume_at_g(const C *id, bounds_t bounds, ui_confirm_ interact_
 
 	interactor_t *actor = interactor_get(interactor);
 	if (actor != nullptr) {
-		result = interactor_set_active(actor, id_hash, actor->type == interactor_type_point
+		result = interactor_set_active(actor, id_hash, actor->activation == interactor_activate_position
 			? (bool32_t)((focus              & button_state_active) != 0)
 			: (bool32_t)((actor->pinch_state & button_state_active) != 0));
 	}
@@ -324,7 +326,7 @@ void ui_button_behavior_depth(vec3 window_relative_pos, vec2 size, id_hash_t id,
 	out_finger_offset = button_depth;
 	if (out_focus_state & button_state_active) {
 		bool pressed;
-		if (actor->type == interactor_type_point) {
+		if (actor->activation == interactor_activate_position) {
 			out_finger_offset = -(interaction_at.z + actor->capsule_radius) - window_relative_pos.z;
 			pressed = out_finger_offset < button_activation_depth;
 		} else {
@@ -346,7 +348,7 @@ void ui_button_behavior_depth(vec3 window_relative_pos, vec2 size, id_hash_t id,
 
 ///////////////////////////////////////////
 
-void ui_slider_behavior(id_hash_t id, vec2* value, vec2 min, vec2 max, vec2 step, vec3 window_relative_pos, vec2 size, vec2 button_size, ui_confirm_ confirm_method, vec2 *out_button_center, float *out_finger_offset, button_state_ *out_focus_state, button_state_ *out_active_state, int32_t *out_interactor) {
+void ui_slider_behavior(id_hash_t id, vec2* value, vec2 min, vec2 max, vec2 step, vec3 window_relative_pos, vec2 size, vec2 button_size_visual, vec2 button_size_interact, ui_confirm_ confirm_method, vec2 *out_button_center, float *out_finger_offset, button_state_ *out_focus_state, button_state_ *out_active_state, int32_t *out_interactor) {
 	const float snap_scale = 1;
 	const float snap_dist  = 7*cm2m;
 
@@ -361,12 +363,12 @@ void ui_slider_behavior(id_hash_t id, vec2* value, vec2 min, vec2 max, vec2 step
 	*out_interactor    = -1;
 	*out_finger_offset = button_depth;
 	*out_button_center = {
-		window_relative_pos.x - (percent.x * (size.x - button_size.x) + button_size.x/2.0f),
-		window_relative_pos.y - (percent.y * (size.y - button_size.y) + button_size.y/2.0f) };
+		window_relative_pos.x - (percent.x * (size.x - button_size_visual.x) + button_size_visual.x/2.0f),
+		window_relative_pos.y - (percent.y * (size.y - button_size_visual.y) + button_size_visual.y/2.0f) };
 
 	vec2 finger_at = {};
 	interactor_t* actor = nullptr;
-	vec3 activation_size  = vec3{ button_size.x, button_size.y, button_depth };
+	vec3 activation_size  = vec3{ button_size_interact.x, button_size_interact.y, button_depth };
 	vec3 activation_start = { out_button_center->x+activation_size.x/2.0f, out_button_center->y+activation_size.y/2.0f, window_relative_pos.z };
 	if (confirm_method == ui_confirm_push) {
 		ui_button_behavior_depth(activation_start, { activation_size.x, activation_size.y }, id, button_depth, button_depth / 2, *out_finger_offset, *out_active_state, *out_focus_state, out_interactor);
@@ -374,6 +376,8 @@ void ui_slider_behavior(id_hash_t id, vec2* value, vec2 min, vec2 max, vec2 step
 		actor = interactor_get(*out_interactor);
 		
 	} else if (confirm_method == ui_confirm_pinch || confirm_method == ui_confirm_variable_pinch) {
+		activation_start.z += skui_settings.depth;
+		activation_size.z  += skui_settings.depth;
 		ui_box_interaction_1h(id, interactor_event_pinch,
 			activation_start, activation_size,
 			activation_start, activation_size,
@@ -384,6 +388,7 @@ void ui_slider_behavior(id_hash_t id, vec2* value, vec2 min, vec2 max, vec2 step
 		actor = interactor_get(*out_interactor);
 		if (actor != nullptr) {
 			*out_active_state = interactor_set_active(actor, id, actor->pinch_state & button_state_active);
+			line_add(actor->capsule_start_world, actor->capsule_end_world, color32{255,255,255,255}, color32{255,255,255,255}, 0.0025f);
 		}
 	}
 
@@ -404,8 +409,8 @@ void ui_slider_behavior(id_hash_t id, vec2* value, vec2 min, vec2 max, vec2 step
 	vec2 new_percent = percent;
 	if ((*out_active_state) & button_state_active) {
 		vec2 pos_in_slider = {
-			(float)fmin(1, fmax(0, ((window_relative_pos.x-button_size.x/2)-finger_at.x) / (size.x-button_size.x))),
-			(float)fmin(1, fmax(0, ((window_relative_pos.y-button_size.y/2)-finger_at.y) / (size.y-button_size.y)))};
+			(float)fmin(1, fmax(0, ((window_relative_pos.x-button_size_visual.x/2)-finger_at.x) / (size.x-button_size_visual.x))),
+			(float)fmin(1, fmax(0, ((window_relative_pos.y-button_size_visual.y/2)-finger_at.y) / (size.y-button_size_visual.y)))};
 		vec2 new_val = min + pos_in_slider*range;
 		if (step.x != 0) new_val.x = min.x + ((int)(((new_val.x - min.x) / step.x) + 0.5f)) * step.x;
 		if (step.y != 0) new_val.y = min.y + ((int)(((new_val.y - min.x) / step.y) + 0.5f)) * step.y;
@@ -414,8 +419,8 @@ void ui_slider_behavior(id_hash_t id, vec2* value, vec2 min, vec2 max, vec2 step
 			range.x == 0 ? 0.5f : (new_val.x - min.x) / range.x,
 			range.y == 0 ? 0.5f : (new_val.y - min.y) / range.y };
 		*out_button_center = {
-			window_relative_pos.x - (new_percent.x * (size.x - button_size.x) + button_size.x/2.0f),
-			window_relative_pos.y - (new_percent.y * (size.y - button_size.y) + button_size.y/2.0f) };
+			window_relative_pos.x - (new_percent.x * (size.x - button_size_visual.x) + button_size_visual.x/2.0f),
+			window_relative_pos.y - (new_percent.y * (size.y - button_size_visual.y) + button_size_visual.y/2.0f) };
 
 		// Play tick sound as the value updates
 		if (value->x != new_val.x || value->y != new_val.y) {
@@ -604,10 +609,11 @@ void ui_handle_end() {
 
 ///////////////////////////////////////////
 
-int32_t interactor_create(interactor_type_ type, interactor_event_ events) {
+int32_t interactor_create(interactor_type_ type, interactor_event_ events, interactor_activate_ activation) {
 	interactor_t result = {};
 	result.type   = type;
 	result.events = events;
+	result.activation = activation;
 	result.min_distance = -1000000;
 	return skui_interactors.add(result);
 }
@@ -699,19 +705,19 @@ void interactor_plate_1h(id_hash_t id, interactor_event_ event_mask, vec3 plate_
 		// volume to account for vertical or horizontal movement during a press,
 		// such as the downward motion often accompanying a 'poke' motion.
 
-		float    surface_offset = actor->type == interactor_type_point ? actor->capsule_radius*2 : 0;
+		float    surface_offset = actor->activation == interactor_activate_position ? actor->capsule_radius*2 : 0;
 
 		bool     was_focused = actor->focused_prev == id;
 		bool     was_active  = actor->active_prev  == id;
 		float    depth  = fmaxf(0.0001f, 8 * plate_size.z);
-		bounds_t bounds = was_focused && actor->type == interactor_type_point
+		bounds_t bounds = was_focused && actor->activation == interactor_activate_position
 			? size_box({ plate_start.x, plate_start.y, (plate_start.z + depth) - surface_offset }, { plate_size.x, plate_size.y, depth })
 			: size_box({ plate_start.x, plate_start.y, plate_start.z           - surface_offset }, { plate_size.x, plate_size.y, 0.0001f });
 
 		float         priority = 0;
 		vec3          interact_at;
 		bool          in_box   = interactor_check_box(actor, bounds, &interact_at, &priority);
-		button_state_ focus    = interactor_set_focus(actor, id, in_box || (actor->type != interactor_type_point && was_active), priority, plate_start-vec3{plate_size.x/2, plate_size.y/2, 0});
+		button_state_ focus    = interactor_set_focus(actor, id, in_box || (actor->activation == interactor_activate_state && was_active), priority, plate_start-vec3{plate_size.x/2, plate_size.y/2, 0});
 		if (focus != button_state_inactive) {
 			*out_interactor           = i;
 			*out_focus_state          = focus;
@@ -750,8 +756,7 @@ void ui_box_interaction_1h(id_hash_t id, interactor_event_ event_mask, vec3 box_
 		vec3  at;
 		float priority;
 		bool  in_box = interactor_check_box(actor, bounds, &at, &priority);
-
-		button_state_ focus = interactor_set_focus(actor, id, in_box || (actor->type != interactor_type_point && was_active), priority, bounds.center);
+		button_state_ focus = interactor_set_focus(actor, id, in_box || (actor->activation == interactor_activate_state && was_active), priority, bounds.center);
 		if (focus != button_state_inactive) {
 			*out_interactor  = i;
 			*out_focus_state = focus;
@@ -798,7 +803,7 @@ button_state_ interactor_set_focus(interactor_t* interactor, id_hash_t for_el_id
 	bool is_focused  = false;
 
 	if (focused && priority <= interactor->focus_priority) {
-		if (priority >= interactor->min_distance) {
+		if (priority >= interactor->min_distance || interactor->active_prev == for_el_id) {
 			is_focused = focused;
 			interactor->focused = for_el_id;
 		} else {

--- a/StereoKitC/ui/ui_core.h
+++ b/StereoKitC/ui/ui_core.h
@@ -62,6 +62,7 @@ struct interactor_t {
 	id_hash_t focused_prev;
 	id_hash_t focused;
 	float     focus_priority;
+	float     focus_distance;
 	id_hash_t active_prev_prev;
 	id_hash_t active_prev;
 	id_hash_t active;
@@ -87,7 +88,7 @@ bool32_t         ui_keyboard_focus_lost     (id_hash_t focused_id);
 
 int32_t          interactor_last_focused    (                                id_hash_t for_el_id);
 bool32_t         interactor_is_preoccupied  (const interactor_t* interactor, id_hash_t for_el_id, interactor_event_ event_mask, bool32_t include_focused);
-button_state_    interactor_set_focus       (      interactor_t* interactor, id_hash_t for_el_id, bool32_t focused, float priority, vec3 element_center_local);
+button_state_    interactor_set_focus       (      interactor_t* interactor, id_hash_t for_el_id, bool32_t focused, float priority, float distance, vec3 element_center_local);
 button_state_    interactor_set_active      (      interactor_t* interactor, id_hash_t for_el_id, bool32_t active);
 bool32_t         interactor_check_box       (const interactor_t* interactor, bounds_t box, vec3* out_at, float* out_priority);
 

--- a/StereoKitC/ui/ui_core.h
+++ b/StereoKitC/ui/ui_core.h
@@ -14,10 +14,16 @@ enum interactor_event_ {
 	interactor_event_pinch = 1 << 3
 };
 
+enum interactor_activate_ {
+	interactor_activate_state = 0,
+	interactor_activate_position = 1,
+};
+
 struct interactor_t {
 	// What type of interactions does this provide
-	interactor_event_ events;
-	interactor_type_  type;
+	interactor_event_    events;
+	interactor_activate_ activation;
+	interactor_type_     type;
 
 	vec3      capsule_end;
 	vec3      capsule_end_world;
@@ -70,7 +76,7 @@ void             ui_core_shutdown           ();
 void             ui_box_interaction_1h      (id_hash_t id, interactor_event_ event_mask, vec3 box_unfocused_start, vec3 box_unfocused_size, vec3 box_focused_start, vec3 box_focused_size, button_state_* out_focus_state, int32_t* out_interactor);
 void             interactor_plate_1h        (id_hash_t id, interactor_event_ event_mask, vec3 plate_start, vec3 plate_size, button_state_* out_focus_state, int32_t* out_interactor, vec3* out_interaction_at_local);
 bool32_t         _ui_handle_begin           (id_hash_t id, pose_t& handle_pose, bounds_t handle_bounds, bool32_t draw, ui_move_ move_type, ui_gesture_ allowed_gestures);
-void             ui_slider_behavior         (id_hash_t id, vec2* value, vec2 min, vec2 max, vec2 step, vec3 window_relative_pos, vec2 size, vec2 button_size, ui_confirm_ confirm_method, vec2* out_button_center, float* out_finger_offset, button_state_* out_focus_state, button_state_* out_active_state, int32_t* out_interactor);
+void             ui_slider_behavior         (id_hash_t id, vec2* value, vec2 min, vec2 max, vec2 step, vec3 window_relative_pos, vec2 size, vec2 button_size_visual, vec2 button_size_interact, ui_confirm_ confirm_method, vec2* out_button_center, float* out_finger_offset, button_state_* out_focus_state, button_state_* out_active_state, int32_t* out_interactor);
 
 bool32_t         ui_id_focused              (id_hash_t id);
 button_state_    ui_id_focus_state          (id_hash_t id);
@@ -85,7 +91,7 @@ button_state_    interactor_set_focus       (      interactor_t* interactor, id_
 button_state_    interactor_set_active      (      interactor_t* interactor, id_hash_t for_el_id, bool32_t active);
 bool32_t         interactor_check_box       (const interactor_t* interactor, bounds_t box, vec3* out_at, float* out_priority);
 
-int32_t          interactor_create          (interactor_type_ type, interactor_event_ events);
+int32_t          interactor_create          (interactor_type_ type, interactor_event_ events, interactor_activate_ activation);
 void             interactor_update          (int32_t interactor, vec3 capsule_start, vec3 capsule_end, float capsule_radius, vec3 motion_pos, quat motion_orientation, vec3 motion_anchor, button_state_ active, button_state_ tracked);
 void             interactor_min_distance_set(int32_t interactor, float min_distance);
 interactor_t*    interactor_get             (int32_t interactor);

--- a/StereoKitC/ui/ui_layout.cpp
+++ b/StereoKitC/ui/ui_layout.cpp
@@ -497,41 +497,48 @@ void ui_panel_end() {
 ///////////////////////////////////////////
 
 pose_t ui_popup_pose(vec3 shift) {
-	vec3 at;
-	if (ui_last_element_active() & button_state_active) {
+	pose_t result;
+	if (ui_last_element_active() & (button_state_active | button_state_just_inactive) ) {
 		// If there was a UI element focused, we'll use that
-		at = hierarchy_to_world_point( ui_layout_last().center );
+		vec3 at  = hierarchy_to_world_point   ( ui_layout_last().center );
+		quat rot = hierarchy_to_world_rotation( quat_identity );
+
+		// For an element attached popup, we can just offset the popup from the
+		// element by a bit. Pretty straightforward!
+		vec3 fwd   = rot * vec3_forward;
+		vec3 up    = rot * vec3_up;
+		vec3 right = rot * vec3_right;
+
+		const float away = 0.1f;  // Away from the panel
+		const float down = 0.05f; // Down from the element;
+		result.position    = at + fwd * away + up * down;
+		result.orientation = quat_from_angles(25, 0, 0) * rot;
 	} else {
-		bool active_left  = input_hand(handed_left )->tracked_state & button_state_active;
-		bool active_right = input_hand(handed_right)->tracked_state & button_state_active;
+		// For an independant popup, we want to position it in front of the
+		// user. We'll place it in arm's reach, but this may be a bit odd for
+		// controller mode, or those using far hand rays.
+		// TODO: consider far interaction placement
 
-		if (active_left && active_right) {
-			// Both hands are active, pick the hand that's the most high
-			// and outstretched.
-			vec3  pl       = input_hand(handed_left )->fingers[1][4].position;
-			vec3  pr       = input_hand(handed_right)->fingers[1][4].position;
-			vec3  head     = input_head()->position;
-			float dist_l   = vec3_distance(pl, head);
-			float dist_r   = vec3_distance(pr, head);
-			float height_l = pl.y - pr.y;
-			float height_r = pr.y - pl.y;
-			at = dist_l + height_l / 2.0f > dist_r + height_r / 2.0f ? pl : pr;
-		} else if (active_left) {
-			at = input_hand(handed_left)->fingers[1][4].position;
-		} else if (active_right) {
-			at = input_hand(handed_right)->fingers[1][4].position;
-		} else {
-			// Head based fallback!
-			at = input_head()->position + input_head()->orientation * vec3_forward * 0.35f;
-		}
+		const float popup_distance = 0.5f; // The XZ distance from the user
+		const float height_blend   = 0.5f; // How much does the user's Y axis rotation affect the popup position
+		const float rotation_blend = 0.4f; // How much does the popup position's Y offset affect the popup orientation
+
+		pose_t head     = *input_head();
+		vec3   head_fwd = head.orientation * vec3_forward;
+		vec3   flat_fwd = vec3_normalize(vec3{ head_fwd.x, 0, head_fwd.z });
+		flat_fwd.y = head_fwd.y * height_blend;
+		result.position    = head.position + flat_fwd * popup_distance;
+
+		vec3 face_dir = vec3_normalize(head.position - result.position);
+		face_dir.y *= rotation_blend;
+		result.orientation = quat_lookat(vec3_zero, face_dir);
+
+		vec3 fwd   = result.orientation * vec3_forward;
+		vec3 up    = result.orientation * vec3_up;
+		vec3 right = result.orientation * vec3_right;
+		result.position += shift.x * right + shift.y * up + shift.z * fwd;
 	}
-
-	vec3 dir = at - input_head()->position;
-	at = input_head()->position + dir * 0.7f;
-
-	return pose_t {
-		at + shift,
-		quat_lookat(vec3_zero, -dir) };
+	return result;
 }
 
 ///////////////////////////////////////////


### PR DESCRIPTION
- Improved popup pose. When invoked by an active element, this attaches as an offset from the element, and when independent of an element, picks a more convenient position in front of the user.
- Fixed window grab noises for far interactions.
- Aim ray now is unavailable when the hand is too close to the body.
- Made aim ray slightly thicker.
- Slider hitboxes are now larger, can be independent from visual indicator size.