### PR TITLE
Add support for `XR_KHR_android_thread_settings`

### DIFF
--- a/StereoKitC/xr_backends/openxr.cpp
+++ b/StereoKitC/xr_backends/openxr.cpp
@@ -584,7 +584,7 @@ bool openxr_init() {
 	// spaces, reference spaces are sometimes invalid before session start. We
 	// need to submit blank frames in order to get past the READY state.
 	while (xr_session_state == XR_SESSION_STATE_IDLE || xr_session_state == XR_SESSION_STATE_UNKNOWN) {
-		platform_sleep(9);
+		platform_sleep(33);
 		if (!openxr_poll_events()) { log_infof("Exit event during initialization"); openxr_cleanup(); return false; }
 	}
 	// Blank frames should only be submitted when the session is READY
@@ -918,10 +918,8 @@ void openxr_step_begin() {
 void openxr_step_end() {
 	anchors_step_end();
 
-	if (xr_running)
-		openxr_render_frame();
-	else
-		platform_sleep(9);
+	if (xr_running) { openxr_render_frame(); }
+	else            { platform_sleep(33);    }
 
 	xr_extension_structs_clear();
 	render_clear();

--- a/StereoKitC/xr_backends/openxr_extensions.h
+++ b/StereoKitC/xr_backends/openxr_extensions.h
@@ -153,7 +153,8 @@ namespace sk {
 
 // Android platform only
 #define FOR_EACH_EXT_ANDROID(_) \
-	_(KHR_android_create_instance, EXT_AVAILABLE_ANDROID)
+	_(KHR_android_create_instance, EXT_AVAILABLE_ANDROID) \
+	_(KHR_android_thread_settings, EXT_AVAILABLE_ANDROID)
 
 // Linux platform only
 #define FOR_EACH_EXT_LINUX(_) \
@@ -208,6 +209,11 @@ namespace sk {
 	_(xrTryGetPerceptionAnchorFromSpatialAnchorMSFT) \
 	_(xrGetAudioOutputDeviceGuidOculus)              \
 	_(xrGetAudioInputDeviceGuidOculus)
+#elif defined(SK_OS_ANDROID)
+#define FOR_EACH_PLATFORM_FUNCTION(_)  \
+	_(xrConvertTimespecTimeToTimeKHR ) \
+	_(xrConvertTimeToTimespecTimeKHR ) \
+	_(xrSetAndroidApplicationThreadKHR)
 #else
 #define FOR_EACH_PLATFORM_FUNCTION(_)  \
 	_(xrConvertTimespecTimeToTimeKHR ) \

--- a/StereoKitC/xr_backends/openxr_view.cpp
+++ b/StereoKitC/xr_backends/openxr_view.cpp
@@ -735,10 +735,6 @@ bool openxr_render_frame() {
 	// Timing also needs some work, may be best as some sort of anchor system
 	xr_time = frame_state.predictedDisplayTime;
 
-	// Execute any code that's dependent on the predicted time, such as
-	// updating the location of controller models.
-	input_step_late();
-
 	// If there's nothing to render, we may want to totally skip all projection
 	// layers entirely.
 	bool render_displays =
@@ -794,6 +790,14 @@ bool openxr_render_frame() {
 			backend_openxr_end_frame_chain(&end_second, sizeof(end_second));
 		}
 	}
+
+	// Execute any code that's dependent on the predicted time, such as
+	// updating the location of controller models.
+	// 
+	// Input can be costly to look at on some systems, so this happens _after_
+	// swapchains are acquired, so they're in close time proximity to
+	// xrWaitFrame. Theoretically better?
+	input_step_late();
 
 	render_pipeline_draw();
 


### PR DESCRIPTION
Also:

- Keep swapchain acquisition closer to `xrWaitFrame`.
- Longer sleep (30fps) when no OpenXR session is present.