### PR TITLE
Ensure we call Shutdown() when successfully removing a stepper

### DIFF
--- a/StereoKit/Framework/Steppers.cs
+++ b/StereoKit/Framework/Steppers.cs
@@ -92,7 +92,7 @@ namespace StereoKit.Framework
 						break;
 					case ActionType.Remove:
 						bool result = false;
-						lock (_stepperLock) _steppers.Remove(action.stepper);
+						lock (_stepperLock) result = _steppers.Remove(action.stepper);
 						if (result) action.stepper.Shutdown();
 						break;
 				}


### PR DESCRIPTION
In #949, result wasn't being set to anything other than `false`. This fixes that!