### PR TITLE
Support for GLTF's KHR_texture_transform. 

### DIFF
--- a/Examples/StereoKitTest/Demos/DemoMaterial.cs
+++ b/Examples/StereoKitTest/Demos/DemoMaterial.cs
@@ -147,9 +147,9 @@ class DemoMaterial : ITest
 		/// :End:
 
 		matParameters = Material.Default.Copy();
-		matParameters[MatParamName.DiffuseTex] = Tex.FromFile("floor.png");
-		matParameters[MatParamName.ColorTint ] = Color.HSV(0.6f, 0.7f, 1f);
-		matParameters[MatParamName.TexScale  ] = 2.0f;
+		matParameters[MatParamName.DiffuseTex  ] = Tex.FromFile("floor.png");
+		matParameters[MatParamName.ColorTint   ] = Color.HSV(0.6f, 0.7f, 1f);
+		matParameters[MatParamName.TexTransform] = new Vec4(0,0,2,2);
 	}
 
 	int showCount;

--- a/Examples/StereoKitTest/Demos/DemoTextures.cs
+++ b/Examples/StereoKitTest/Demos/DemoTextures.cs
@@ -75,8 +75,8 @@ class DemoTextures : ITest
 		/// shader parameters really quickly! You can do this with strings
 		/// representing shader parameter names, or use the MatParamName
 		/// enum for compile safety.
-		exampleMaterial[MatParamName.DiffuseTex] = gridTex;
-		exampleMaterial[MatParamName.TexScale  ] = 2.0f;
+		exampleMaterial[MatParamName.DiffuseTex  ] = gridTex;
+		exampleMaterial[MatParamName.TexTransform] = new Vec4(0,0,2,2);
 		/// :End:
 	}
 

--- a/StereoKit/Assets/Material.cs
+++ b/StereoKit/Assets/Material.cs
@@ -71,7 +71,14 @@ namespace StereoKit
 		/// This is great for tiling textures!
 		/// 
 		/// This represents the float param 'tex_scale'.</summary>
+		[Obsolete("No longer present, use TexTransform instead.")]
 		TexScale,
+		/// <summary>Not necessarily present in all shaders, this transforms
+		/// the UV coordinates of the mesh, so that the texture can repeat and
+		/// scroll. XY components are offset, and ZW components are scale.
+		/// 
+		/// This represents the float param 'tex_trans'.</summary>
+		TexTransform,
 		/// <summary>In clip shaders, this is the cutoff value below which
 		/// pixels are discarded. Typically, the diffuse/albedo's alpha
 		/// component is sampled for comparison here.
@@ -299,7 +306,7 @@ namespace StereoKit
 				case MatParamName.NormalTex:       return "normal";
 				case MatParamName.OcclusionTex:    return "occlusion";
 				case MatParamName.RoughnessAmount: return "roughness";
-				case MatParamName.TexScale:        return "tex_scale";
+				case MatParamName.TexTransform:    return "tex_trans";
 				case MatParamName.ClipCutoff:      return "cutoff";
 				default: Log.Err($"Unimplemented Material Parameter Name! {parameter}"); return "";
 			}

--- a/StereoKitC/shaders_builtin/shader_builtin_default.hlsl
+++ b/StereoKitC/shaders_builtin/shader_builtin_default.hlsl
@@ -1,13 +1,11 @@
 #include "stereokit.hlsli"
 
-//--name = sk/default
-
 //--color:color = 1,1,1,1
-//--tex_scale   = 1
+//--tex_trans   = 0,0,1,1
 //--diffuse     = white
 
 float4       color;
-float        tex_scale;
+float4       tex_trans;
 Texture2D    diffuse   : register(t0);
 SamplerState diffuse_s : register(s0);
 
@@ -34,7 +32,7 @@ psIn vs(vsIn input, uint id : SV_InstanceID) {
 
 	float3 normal = normalize(mul(input.norm, (float3x3)sk_inst[id].world));
 
-	o.uv         = input.uv * tex_scale;
+	o.uv         = (input.uv * tex_trans.zw) + tex_trans.xy;
 	o.color      = color * input.col * sk_inst[id].color;
 	o.color.rgb *= sk_lighting(normal);
 	return o;

--- a/StereoKitC/shaders_builtin/shader_builtin_pbr.hlsl
+++ b/StereoKitC/shaders_builtin/shader_builtin_pbr.hlsl
@@ -1,17 +1,16 @@
 #include <stereokit.hlsli>
 #include <stereokit_pbr.hlsli>
 
-//--name = sk/default_pbr
 //--color:color           = 1,1,1,1
 //--emission_factor:color = 0,0,0,0
 //--metallic              = 0
 //--roughness             = 1
-//--tex_scale             = 1
+//--tex_trans             = 0,0,1,1
 float4 color;
 float4 emission_factor;
+float4 tex_trans;
 float  metallic;
 float  roughness;
-float  tex_scale;
 
 //--diffuse   = white
 //--emission  = white
@@ -52,7 +51,7 @@ psIn vs(vsIn input, uint id : SV_InstanceID) {
 	o.pos   = mul(float4(o.world,  1), sk_viewproj[o.view_id]);
 
 	o.normal     = normalize(mul(float4(input.norm, 0), sk_inst[id].world).xyz);
-	o.uv         = input.uv * tex_scale;
+	o.uv         = (input.uv * tex_trans.zw) + tex_trans.xy;
 	o.color      = input.color * sk_inst[id].color * color;
 	o.irradiance = sk_lighting(o.normal);
 	o.view_dir   = sk_camera_pos[o.view_id].xyz - o.world;

--- a/StereoKitC/shaders_builtin/shader_builtin_pbr_clip.hlsl
+++ b/StereoKitC/shaders_builtin/shader_builtin_pbr_clip.hlsl
@@ -1,18 +1,17 @@
 #include <stereokit.hlsli>
 #include <stereokit_pbr.hlsli>
 
-//--name = sk/default_pbr_clip
 //--color:color           = 1,1,1,1
 //--emission_factor:color = 0,0,0,0
+//--tex_trans             = 0,0,1,1
 //--metallic              = 0
 //--roughness             = 1
-//--tex_scale             = 1
 //--cutoff                = 0.5
 float4 color;
 float4 emission_factor;
+float4 tex_trans;
 float  metallic;
 float  roughness;
-float  tex_scale;
 float  cutoff;
 
 //--diffuse   = white
@@ -54,7 +53,7 @@ psIn vs(vsIn input, uint id : SV_InstanceID) {
 	o.pos   = mul(float4(o.world,  1), sk_viewproj[o.view_id]);
 
 	o.normal     = normalize(mul(float4(input.norm, 0), sk_inst[id].world).xyz);
-	o.uv         = input.uv * tex_scale;
+	o.uv         = (input.uv * tex_trans.zw) + tex_trans.xy;
 	o.color      = input.color * sk_inst[id].color * color;
 	o.irradiance = sk_lighting(o.normal);
 	o.view_dir   = sk_camera_pos[o.view_id].xyz - o.world;

--- a/StereoKitC/shaders_builtin/shader_builtin_unlit.hlsl
+++ b/StereoKitC/shaders_builtin/shader_builtin_unlit.hlsl
@@ -1,12 +1,11 @@
 #include "stereokit.hlsli"
 
-//--name = sk/unlit
 //--color:color = 1, 1, 1, 1
-//--tex_scale   = 1
+//--tex_trans   = 0,0,1,1
 //--diffuse     = white
 
 float4       color;
-float        tex_scale;
+float4       tex_trans;
 Texture2D    diffuse   : register(t0);
 SamplerState diffuse_s : register(s0);
 
@@ -31,7 +30,7 @@ psIn vs(vsIn input, uint id : SV_InstanceID) {
 	float3 world = mul(float4(input.pos.xyz, 1), sk_inst[id].world).xyz;
 	o.pos        = mul(float4(world,         1), sk_viewproj[o.view_id]);
 
-	o.uv    = input.uv * tex_scale;
+	o.uv    = (input.uv * tex_trans.zw) + tex_trans.xy;
 	o.color = input.col * color * sk_inst[id].color;
 	return o;
 }

--- a/StereoKitC/shaders_builtin/shader_builtin_unlit_clip.hlsl
+++ b/StereoKitC/shaders_builtin/shader_builtin_unlit_clip.hlsl
@@ -1,10 +1,12 @@
 #include "stereokit.hlsli"
 
-//--name = sk/unlit_clip
 //--color:color = 1, 1, 1, 1
+//--tex_trans   = 0,0,1,1
 //--diffuse     = white
 //--cutoff      = 0.01
+
 float4       color;
+float4       tex_trans;
 float        cutoff;
 Texture2D    diffuse   : register(t0);
 SamplerState diffuse_s : register(s0);
@@ -30,7 +32,7 @@ psIn vs(vsIn input, uint id : SV_InstanceID) {
 	float3 world = mul(float4(input.pos.xyz, 1), sk_inst[id].world).xyz;
 	o.pos        = mul(float4(world,         1), sk_viewproj[o.view_id]);
 
-	o.uv    = input.uv;
+	o.uv    = (input.uv * tex_trans.zw) + tex_trans.xy;
 	o.color = input.col * color * sk_inst[id].color;
 	return o;
 }


### PR DESCRIPTION
- GLTF support now includes `KHR_texture_transform`, without the rotation feature.
- Add support for axis independent scaling and translation of texture coordinates in most shaders.
- Deprecate `MatParamName.TexScale` in favor of `TexTransform`.
- `gltfpack` now works without needing the `-noq` flag.