### PR TITLE
Texture meta state fix

### DIFF
--- a/Examples/StereoKitTest/Tests/TestFromThread.cs
+++ b/Examples/StereoKitTest/Tests/TestFromThread.cs
@@ -1,8 +1,9 @@
-﻿using StereoKit;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿// SPDX-License-Identifier: MIT
+// The authors below grant copyright rights under the MIT license:
+// Copyright (c) 2019-2024 Nick Klingensmith
+// Copyright (c) 2024 Qualcomm Technologies, Inc.
+
+using StereoKit;
 using System.Threading.Tasks;
 
 class TestFromThread : ITest
@@ -28,7 +29,7 @@ class TestFromThread : ITest
 		{
 			// Load the shader via memory to force load a unique new shader
 			// with a brand new id.
-			Shader uniqueshader = Shader.FromMemory(Platform.ReadFileBytes("Assets/Shaders/floor_shader.hlsl.sks"));
+			Shader uniqueshader = Shader.FromMemory(Platform.ReadFileBytes("Shaders/floor_shader.hlsl.sks"));
 			uniqueShaderMat = new Material(uniqueshader);
 			material        = Material.Default.Copy();
 			mesh            = Mesh.GenerateSphere(1);

--- a/Examples/StereoKitTest/Tests/TestTextureFallback.cs
+++ b/Examples/StereoKitTest/Tests/TestTextureFallback.cs
@@ -1,0 +1,51 @@
+﻿// SPDX-License-Identifier: MIT
+// The authors below grant copyright rights under the MIT license:
+// Copyright (c) 2024 Nick Klingensmith
+// Copyright (c) 2024 Qualcomm Technologies, Inc.
+
+using StereoKit;
+using System.Collections.Generic;
+
+class TestTextureFallback : ITest
+{
+	List<Material> materials = new List<Material>();
+
+	public void Initialize()
+	{
+		// A blank texture with no data will always just use the loading
+		// fallback texture.
+		Material emptyMat = Material.Unlit.Copy();
+		emptyMat[MatParamName.DiffuseTex] = new Tex();
+		materials.Add(emptyMat);
+
+		// We can override the fallback texture per-material, in case the
+		// global fallback texture doesn't work well.
+		Material fallbackMat = Material.Unlit.Copy();
+		Tex fallbackTex = new Tex();
+		fallbackTex.FallbackOverride = Tex.GenColor(new Color(1,0,1,1), 2, 2);
+		fallbackMat[MatParamName.DiffuseTex] = fallbackTex;
+		materials.Add(fallbackMat);
+
+		// Textures that encounter an error while loading will use the global
+		// error texture.
+		Log.Info("Expected texture load failure:");
+		Material errorMat = Material.Unlit.Copy();
+		errorMat[MatParamName.DiffuseTex] = Tex.FromFile("file_that_doesnt_exist.png");
+		materials.Add(errorMat);
+
+	}
+
+	public void Shutdown()
+	{
+	}
+
+	public void Step()
+	{
+		for (int i = 0; i < materials.Count; i++)
+		{
+			float x = (i - (materials.Count-1)/2.0f) * 0.3f;
+			Mesh.Quad.Draw(materials[i], Matrix.TRS(new Vec3(x,0,-0.5f), V.XYZ(0,180,0), 0.2f));
+		}
+		Tests.Screenshot("Tests/FallbackTextures.jpg", 400,200, new Vec3(0, 0, -0.25f), new Vec3(0, 0, -0.5f));
+	}
+}

--- a/StereoKitC/asset_types/assets.cpp
+++ b/StereoKitC/asset_types/assets.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // The authors below grant copyright rights under the MIT license:
-// Copyright (c) 2019-2023 Nick Klingensmith
-// Copyright (c) 2023 Qualcomm Technologies, Inc.
+// Copyright (c) 2019-2024 Nick Klingensmith
+// Copyright (c) 2023-2024 Qualcomm Technologies, Inc.
 
 #include "assets.h"
 #include "../_stereokit.h"
@@ -762,7 +762,10 @@ int32_t asset_thread(void *thread_inst_obj) {
 ///////////////////////////////////////////
 
 void assets_block_until(asset_header_t *asset, asset_state_ state) {
-	if (asset->state >= state || asset->state < 0)
+	// If we're past the required state already, drop out. asset_state_none and
+	// below (error states) means no loading is happening, so blocking will
+	// only put us in an infinite loop.
+	if (asset->state >= state || asset->state <= asset_state_none)
 		return;
 
 	ft_id_t curr_id = ft_id_current();

--- a/StereoKitC/asset_types/texture.cpp
+++ b/StereoKitC/asset_types/texture.cpp
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: MIT
+// The authors below grant copyright rights under the MIT license:
+// Copyright (c) 2019-2024 Nick Klingensmith
+// Copyright (c) 2024 Qualcomm Technologies, Inc.
+
 #include "../stereokit.h"
 #include "../platforms/platform.h"
 #include "../libraries/ferr_hash.h"
@@ -500,7 +505,7 @@ tex_t tex_create(tex_type_ type, tex_format_ format) {
 	result->address_mode = tex_address_wrap;
 	result->sample_mode  = tex_sample_linear;
 	result->anisotropy   = 4;
-	result->header.state = asset_state_loaded_meta;
+	result->header.state = asset_state_none;
 
 	tex_set_fallback(result, tex_loading_texture);
 


### PR DESCRIPTION
Tex objects were incorrectly providing metadata without blocking for asset load. The "default" asset state of the texture indicated metadata was present, even when it wasn't really.

Changing this meant reading blank textures would block indefinitely, so this was also changed. Blank textures now just return 0.

Also added some tests related to this.