### PR TITLE
Fix interactor pose jump on untracked.

### DIFF
--- a/StereoKitC/hands/hand_override.cpp
+++ b/StereoKitC/hands/hand_override.cpp
@@ -38,7 +38,7 @@ void hand_override_shutdown() {
 
 void hand_override_update_frame() {
 	for (int32_t h = 0; h < handed_max; h++) {
-		hand_t *inp_hand = (hand_t*)input_hand((handed_)h);
+		hand_t *inp_hand = input_hand_ref((handed_)h);
 		inp_hand->tracked_state = button_make_state(inp_hand->tracked_state & button_state_active, override_hand[h]);
 
 		if (!override_hand[h]) continue;

--- a/StereoKitC/hands/hand_oxr_articulated.cpp
+++ b/StereoKitC/hands/hand_oxr_articulated.cpp
@@ -221,8 +221,11 @@ void hand_oxra_update_joints() {
 		inp_hand->wrist = pose_t{ oxra_hand_joints[h][XR_HAND_JOINT_WRIST_EXT].position,                oxra_hand_joints[h][XR_HAND_JOINT_WRIST_EXT].orientation };
 		
 		// Update the aim values
-		inp_hand->aim.position    = oxra_hand_joints[h][XR_HAND_JOINT_INDEX_PROXIMAL_EXT].position;
-		inp_hand->aim.orientation = quat_lookat_up(shoulders[h], inp_hand->aim.position, inp_hand->palm.orientation * vec3_up);
+		inp_hand->aim.position = oxra_hand_joints[h][XR_HAND_JOINT_INDEX_PROXIMAL_EXT].position;
+
+		vec3 dir   = inp_hand->aim.position - shoulders[h];
+		vec3 right = oxra_hand_joints[h][XR_HAND_JOINT_LITTLE_PROXIMAL_EXT].position - inp_hand->aim.position;
+		inp_hand->aim.orientation = quat_lookat_up(vec3_zero, dir, vec3_cross(dir, right));
 	}
 
 	if (!hands_active) {

--- a/StereoKitC/hands/hand_oxr_articulated.cpp
+++ b/StereoKitC/hands/hand_oxr_articulated.cpp
@@ -187,7 +187,7 @@ void hand_oxra_update_joints() {
 			(locations.jointLocations[10].locationFlags & XR_SPACE_LOCATION_POSITION_VALID_BIT) > 0 ||
 			(locations.jointLocations[0 ].locationFlags & XR_SPACE_LOCATION_POSITION_VALID_BIT) > 0 ||
 			(locations.jointLocations[1 ].locationFlags & XR_SPACE_LOCATION_POSITION_VALID_BIT) > 0;
-		hand_t *inp_hand = (hand_t*)input_hand((handed_)h);
+		hand_t *inp_hand = input_hand_ref((handed_)h);
 		inp_hand->tracked_state = button_make_state((inp_hand->tracked_state & button_state_active) > 0, valid_joints);
 
 		// If both hands aren't active at all, we'll want to to switch back
@@ -235,7 +235,7 @@ void hand_oxra_update_joints() {
 
 void hand_oxra_update_states() {
 	for (int32_t h = 0; h < handed_max; h++) {
-		hand_t* inp_hand = (hand_t*)input_hand((handed_)h);
+		hand_t* inp_hand = input_hand_ref((handed_)h);
 
 		// Pinch values from the hand interaction profile typically have deep
 		// knowledge about the hands, beyond what can be gleaned from the joint
@@ -280,10 +280,11 @@ void hand_oxra_update_states() {
 ///////////////////////////////////////////
 
 void hand_oxra_update_inactive() {
-	oxra_mesh_dirty[0] = true;
-	oxra_mesh_dirty[1] = true;
 
 	if (hand_oxra_is_tracked()) {
+		oxra_mesh_dirty[0] = true;
+		oxra_mesh_dirty[1] = true;
+
 		oxra_hand_active = true;
 		input_hand_refresh_system();
 	}

--- a/StereoKitC/hands/hand_oxr_controller.cpp
+++ b/StereoKitC/hands/hand_oxr_controller.cpp
@@ -23,7 +23,7 @@ namespace sk {
 ///////////////////////////////////////////
 
 bool hand_oxrc_available() {
-	return sk_active_display_mode() == display_mode_mixedreality 
+	return sk_active_display_mode() == display_mode_mixedreality
 		&& xr_session != XR_NULL_HANDLE;
 }
 
@@ -42,14 +42,15 @@ void hand_oxrc_shutdown() {
 void hand_oxrc_update_pose(bool animate) {
 	for (uint32_t hand_id = 0; hand_id < handed_max; hand_id++) {
 		const controller_t *controller = input_controller ((handed_)hand_id);
-		const hand_t       *hand       = input_hand       ((handed_)hand_id);
+		hand_t             *hand       = input_hand_ref   ((handed_)hand_id);
 		pointer_t          *pointer    = input_get_pointer(input_hand_pointer_id[hand_id]);
 		// Update the hand point pose
 		pointer->tracked = controller->tracked;
-		if (pointer->tracked > 0) {
-			pointer->ray.pos     = controller->aim.position;
-			pointer->ray.dir     = controller->aim.orientation * vec3_forward;
-			pointer->orientation = controller->aim.orientation;
+		if ((controller->tracked & button_state_active) > 0) {
+			hand->aim            = controller->aim;
+			pointer->ray.pos     = hand->aim.position;
+			pointer->ray.dir     = hand->aim.orientation * vec3_forward;
+			pointer->orientation = hand->aim.orientation;
 		}
 
 		// Simulate the hand based on the state of the controller
@@ -71,7 +72,7 @@ void hand_oxrc_update_frame() {
 	// Now we'll get the current states of our actions, and store them for later use
 	for (uint32_t hand_id = 0; hand_id < handed_max; hand_id++) {
 		const controller_t *controller = input_controller ((handed_)hand_id);
-		hand_t             *hand       = (hand_t*)input_hand((handed_)hand_id);
+		hand_t             *hand       = input_hand_ref((handed_)hand_id);
 		pointer_t          *pointer    = input_get_pointer(input_hand_pointer_id[hand_id]);
 		bool                tracked    = controller->tracked & button_state_active;
 
@@ -79,8 +80,7 @@ void hand_oxrc_update_frame() {
 		hand->grip_state       = button_make_state((hand->grip_state  & button_state_active) > 0, controller->grip    >= 0.5f);
 		hand->pinch_activation = fminf(1,controller->trigger/0.5f);
 		hand->grip_activation  = fminf(1,controller->grip   /0.5f);
-		hand->aim_ready = controller->tracked;
-		hand->aim       = controller->aim;
+		hand->aim_ready        = controller->tracked;
 
 		// Get event poses, and fire our own events for them
 		pointer->state = button_make_state(pointer->state & button_state_active, controller->trigger > 0.5f);

--- a/StereoKitC/hands/input_hand.cpp
+++ b/StereoKitC/hands/input_hand.cpp
@@ -130,6 +130,12 @@ const hand_t *input_hand(handed_ hand) {
 
 ///////////////////////////////////////////
 
+hand_t* input_hand_ref(handed_ hand) {
+	return &hand_state[hand].info;
+}
+
+///////////////////////////////////////////
+
 hand_source_ input_hand_source(handed_) {
 	return hand_sources[hand_system].source;
 }

--- a/StereoKitC/hands/input_hand.h
+++ b/StereoKitC/hands/input_hand.h
@@ -48,6 +48,7 @@ void input_hand_shutdown();
 void input_hand_update  ();
 
 hand_system_  input_hand_get_system        ();
+hand_t*       input_hand_ref               (handed_ hand);
 void          input_hand_refresh_system    ();
 void          input_hand_update_poses      ();
 bool          input_hand_get_visible       (handed_ hand);

--- a/StereoKitC/shaders_builtin/shader_builtin_lightmap.hlsl
+++ b/StereoKitC/shaders_builtin/shader_builtin_lightmap.hlsl
@@ -1,8 +1,8 @@
 #include "stereokit.hlsli"
 
-//--tex_trans   = 0,0,1,1
-//--diffuse     = white
-//--occlusion   = white
+//--tex_trans = 0,0,1,1
+//--diffuse   = white
+//--lightmap  = white
 
 float4       tex_trans;
 Texture2D    diffuse    : register(t0);

--- a/StereoKitC/ui/ui_core.cpp
+++ b/StereoKitC/ui/ui_core.cpp
@@ -635,14 +635,17 @@ int32_t interactor_create(interactor_type_ type, interactor_event_ events, inter
 void interactor_update(int32_t interactor, vec3 capsule_start, vec3 capsule_end, float capsule_radius, vec3 motion_pos, quat motion_orientation, vec3 motion_anchor, button_state_ active, button_state_ tracked) {
 	if (interactor < 0 || interactor >= skui_interactors.count) return;
 	interactor_t *actor = &skui_interactors[interactor];
-	actor->capsule_start_world = actor->capsule_start = capsule_start;
-	actor->capsule_end_world   = actor->capsule_end   = capsule_end;
-	actor->capsule_radius      = capsule_radius;
-	actor->position            = motion_pos;
-	actor->orientation         = motion_orientation;
-	actor->motion_anchor       = motion_anchor;
 	actor->tracked             = tracked;
 	actor->pinch_state         = active;
+
+	if (tracked & button_state_active) {
+		actor->capsule_start_world = actor->capsule_start = capsule_start;
+		actor->capsule_end_world   = actor->capsule_end   = capsule_end;
+		actor->capsule_radius      = capsule_radius;
+		actor->position            = motion_pos;
+		actor->orientation         = motion_orientation;
+		actor->motion_anchor       = motion_anchor;
+	}
 
 	// Don't let the hand trigger things while popping in and out of
 	// tracking

--- a/StereoKitC/xr_backends/openxr.cpp
+++ b/StereoKitC/xr_backends/openxr.cpp
@@ -523,6 +523,13 @@ bool openxr_init() {
 	}
 #endif
 
+	// Snapdragon Spaces advertises the palm pose extension, but provides bad
+	// data for it. Only enable it if it's explicitly requested.
+	if (strstr(device_get_runtime(), "Snapdragon") != nullptr && xr_exts_user.index_where([](const char* const& ext) {return strcmp(ext, "XR_EXT_palm_pose") == 0; }) < 0) {
+		xr_ext_available.EXT_palm_pose = false;
+		log_diag("Rejecting Snapdragon's XR_EXT_palm_pose due to implementation issues.");
+	}
+
 	device_data.has_hand_tracking = xr_has_articulated_hands;
 	device_data.tracking          = device_tracking_none;
 	if      (properties.trackingProperties.positionTracking)    device_data.tracking = device_tracking_6dof;


### PR DESCRIPTION
When hand tracking becomes untracked, SK switches to controllers. The interactor system was updating interactor poses with controller data in this case, even when controllers were untracked as well. This would result in a position and orientation change of the interactor when this happened, causing undesirable behavior with in-progress manipulations.

This also improved the orientation of far hand interactors, and removes the palm pose extension on Snapdragon systems. Palm pose on Snapdragon seems partially implemented, and provides only an identity pose, which messes up SK's hand simulation data for controllers.