### PR TITLE
Multisample AA for XR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ set(SK_MULTITHREAD_BUILD_BY_DEFAULT ON  CACHE BOOL "MSVC only, on by default. Th
 set(SK_BUILD_TESTS                  ON  CACHE BOOL "Build the StereoKitCTest project in addition to the StereoKitC library.")
 set(SK_BUILD_SHARED_LIBS            ON  CACHE BOOL "Should StereoKit build as a shared, or static library?")
 set(SK_DYNAMIC_OPENXR               OFF CACHE BOOL "Dynamic link with the standard OpenXR Loader. Not what you want on desktop, but on Android you may need to dynamic link with other loaders.")
-set(SK_WINDOWS_GL                   ON  CACHE BOOL "Build Windows version using OpenGL as the renderer. This is primarily for debugging GL code while developing on Windows.")
+set(SK_WINDOWS_GL                   OFF CACHE BOOL "Build Windows version using OpenGL as the renderer. This is primarily for debugging GL code while developing on Windows.")
 set(FORCE_COLORED_OUTPUT            OFF CACHE BOOL "Always produce ANSI-colored output (GNU/Clang only).")
 
 ###########################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ set(SK_MULTITHREAD_BUILD_BY_DEFAULT ON  CACHE BOOL "MSVC only, on by default. Th
 set(SK_BUILD_TESTS                  ON  CACHE BOOL "Build the StereoKitCTest project in addition to the StereoKitC library.")
 set(SK_BUILD_SHARED_LIBS            ON  CACHE BOOL "Should StereoKit build as a shared, or static library?")
 set(SK_DYNAMIC_OPENXR               OFF CACHE BOOL "Dynamic link with the standard OpenXR Loader. Not what you want on desktop, but on Android you may need to dynamic link with other loaders.")
+set(SK_WINDOWS_GL                   ON  CACHE BOOL "Build Windows version using OpenGL as the renderer. This is primarily for debugging GL code while developing on Windows.")
 set(FORCE_COLORED_OUTPUT            OFF CACHE BOOL "Always produce ANSI-colored output (GNU/Clang only).")
 
 ###########################################
@@ -135,7 +136,13 @@ elseif (UNIX)
   find_package(Threads REQUIRED)
 
 elseif(WIN32)
-  set(SK_SHADER_TARGETS "x")
+  if (SK_WINDOWS_GL)
+    set(SK_SHADER_TARGETS "g")
+    add_definitions("-DSKG_FORCE_OPENGL")
+    add_definitions("-DSK_GPU_LABELS")
+  else()
+    set(SK_SHADER_TARGETS "x")
+  endif()
   add_definitions("-D_CRT_SECURE_NO_WARNINGS")
   set(WINDOWS_LIBS
     Comdlg32

--- a/StereoKit/Assets/Tex.cs
+++ b/StereoKit/Assets/Tex.cs
@@ -318,7 +318,7 @@ namespace StereoKit
 		/// passed on to StereoKit? If so, StereoKit may delete it when it's
 		/// finished with it. If this is not desired, pass in false.</param>
 		public void SetNativeSurface(IntPtr nativeTexture, TexType type=TexType.Image, long native_fmt=0, int width=0, int height=0, int surface_count=1, bool owned=true)
-			=> NativeAPI.tex_set_surface(_inst, nativeTexture, type, native_fmt, width, height, surface_count, owned);
+			=> NativeAPI.tex_set_surface(_inst, nativeTexture, type, native_fmt, width, height, surface_count, 1, 1, owned);
 
 		/// <summary>This will return the texture's native resource for use
 		/// with external libraries. For D3D, this will be an ID3D11Texture2D*,

--- a/StereoKit/Native/NativeAPI.cs
+++ b/StereoKit/Native/NativeAPI.cs
@@ -194,7 +194,7 @@ namespace StereoKit
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   tex_set_colors          (IntPtr texture, int width, int height, [In] ushort[] data);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   tex_set_colors          (IntPtr texture, int width, int height, [In] float[] data);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   tex_set_mem             (IntPtr texture, [In] byte[] data, UIntPtr data_size, [MarshalAs(UnmanagedType.Bool)] bool srgb_data, [MarshalAs(UnmanagedType.Bool)] bool blocking, int priority);
-		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   tex_set_surface         (IntPtr texture, IntPtr native_surface, TexType type, long native_fmt, int width, int height, int surface_count, [MarshalAs(UnmanagedType.Bool)] bool owned);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   tex_set_surface         (IntPtr texture, IntPtr native_surface, TexType type, long native_fmt, int width, int height, int surface_count, int multisample, int framebuffer_multisample, [MarshalAs(UnmanagedType.Bool)] bool owned);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr tex_get_surface         (IntPtr texture);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr tex_add_zbuffer         (IntPtr texture, TexFormat format = TexFormat.DepthStencil);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   tex_get_data            (IntPtr texture, IntPtr out_data, UIntPtr out_data_size, int mip_level);

--- a/StereoKitC/asset_types/texture.cpp
+++ b/StereoKitC/asset_types/texture.cpp
@@ -699,7 +699,7 @@ tex_t tex_get_zbuffer(tex_t texture) {
 
 ///////////////////////////////////////////
 
-void tex_set_surface(tex_t texture, void *native_surface, tex_type_ type, int64_t native_fmt, int32_t width, int32_t height, int32_t surface_count, bool32_t owned) {
+void tex_set_surface(tex_t texture, void *native_surface, tex_type_ type, int64_t native_fmt, int32_t width, int32_t height, int32_t surface_count, int32_t multisample, int32_t framebuffer_multisample, bool32_t owned) {
 	texture->owned = owned;
 	
 	if (texture->owned && skg_tex_is_valid(&texture->tex))
@@ -712,7 +712,7 @@ void tex_set_surface(tex_t texture, void *native_surface, tex_type_ type, int64_
 
 	texture->type   = type;
 	texture->format = tex_get_tex_format(native_fmt);
-	texture->tex    = native_surface == nullptr ? skg_tex_t{} : skg_tex_create_from_existing(native_surface, skg_type, skg_tex_fmt_from_native(native_fmt), width, height, surface_count);
+	texture->tex    = native_surface == nullptr ? skg_tex_t{} : skg_tex_create_from_existing(native_surface, skg_type, skg_tex_fmt_from_native(native_fmt), width, height, surface_count, multisample, framebuffer_multisample);
 	texture->width  = texture->tex.width;
 	texture->height = texture->tex.height;
 

--- a/StereoKitC/shaders_builtin/shader_builtin_blit.hlsl
+++ b/StereoKitC/shaders_builtin/shader_builtin_blit.hlsl
@@ -1,24 +1,11 @@
-//--name = sk/blit
+#include "stereokit.hlsli"
+
 //--source = white
 
 Texture2D    source   : register(t0);
 SamplerState source_s : register(s0);
 
-cbuffer StereoKitBuffer : register(b1) {
-	float4x4 sk_view       [2];
-	float4x4 sk_proj       [2];
-	float4x4 sk_proj_inv   [2];
-	float4x4 sk_viewproj   [2];
-	float4   sk_lighting_sh[9];
-	float4   sk_camera_pos [2];
-	float4   sk_camera_dir [2];
-	float4   sk_fingertip  [2];
-	float4   sk_cubemap_i;
-	float    sk_time;
-	uint     sk_view_count;
-};
-
-cbuffer TransformBuffer : register(b2) {
+cbuffer TransformBuffer : register(b3) {
 	float sk_width;
 	float sk_height;
 	float sk_pixel_width;
@@ -34,12 +21,14 @@ struct vsIn {
 struct psIn {
 	float4 pos : SV_POSITION;
 	float2 uv  : TEXCOORD0;
+	uint view_id : SV_RenderTargetArrayIndex;
 };
 
-psIn vs(vsIn input) {
+psIn vs(vsIn input, uint id : SV_InstanceID) {
 	psIn o;
-	o.pos = input.pos;
-	o.uv  = input.uv;
+	o.view_id = id % sk_view_count;
+	o.pos     = input.pos;
+	o.uv      = input.uv;
 	return o;
 }
 

--- a/StereoKitC/stereokit.cpp
+++ b/StereoKitC/stereokit.cpp
@@ -101,16 +101,13 @@ bool32_t sk_init(sk_settings_t settings) {
 	if (local.settings.flatscreen_width   == 0      ) local.settings.flatscreen_width   = 1280;
 	if (local.settings.flatscreen_height  == 0      ) local.settings.flatscreen_height  = 720;
 	if (local.settings.render_scaling     == 0      ) local.settings.render_scaling     = 1;
-	if (local.settings.render_multisample == 0      ) local.settings.render_multisample = 1;
+	if (local.settings.render_multisample == 0      ) local.settings.render_multisample = 4;
 	if (local.settings.mode               == app_mode_none) local.settings.mode         = app_mode_xr;
 
 #if defined(SK_OS_ANDROID)
 	// don't allow flatscreen fallback on Android
 	local.settings.no_flatscreen_fallback = true;
 #endif
-
-	render_set_scaling    (local.settings.render_scaling);
-	render_set_multisample(local.settings.render_multisample);
 
 	log_diagf("Initializing StereoKit v%s...", sk_version_name());
 

--- a/StereoKitC/stereokit.h
+++ b/StereoKitC/stereokit.h
@@ -1014,7 +1014,7 @@ SK_API tex_t        tex_create_cubemap_files(const char **in_arr_cube_face_file_
 SK_API void         tex_set_id              (tex_t texture, const char *id);
 SK_API const char*  tex_get_id              (const tex_t texture);
 SK_API void         tex_set_fallback        (tex_t texture, tex_t fallback);
-SK_API void         tex_set_surface         (tex_t texture, void *native_surface, tex_type_ type, int64_t native_fmt, int32_t width, int32_t height, int32_t surface_count, bool32_t owned sk_default(true));
+SK_API void         tex_set_surface         (tex_t texture, void *native_surface, tex_type_ type, int64_t native_fmt, int32_t width, int32_t height, int32_t surface_count, int32_t multisample sk_default(1), int32_t framebuffer_multisample sk_default(1), bool32_t owned sk_default(true));
 SK_API void*        tex_get_surface         (tex_t texture);
 SK_API void         tex_addref              (tex_t texture);
 SK_API void         tex_release             (tex_t texture);

--- a/StereoKitC/systems/render.cpp
+++ b/StereoKitC/systems/render.cpp
@@ -972,7 +972,7 @@ void render_blit_to_bound(material_t material) {
 void render_blit(tex_t to, material_t material) {
 	skg_tex_t *old_target = skg_tex_target_get();
 
-	for (size_t i = 0; i < to->tex.array_count; i++)
+	for (int32_t i = 0; i < to->tex.array_count; i++)
 	{
 		skg_tex_target_bind(&to->tex, i, 0);
 		render_blit_to_bound(material);

--- a/StereoKitC/systems/render.cpp
+++ b/StereoKitC/systems/render.cpp
@@ -141,7 +141,7 @@ const int32_t    render_instance_max     = 819;
 const int32_t    render_skytex_register  = 11;
 const skg_bind_t render_list_global_bind = { 1,  skg_stage_vertex | skg_stage_pixel, skg_register_constant };
 const skg_bind_t render_list_inst_bind   = { 2,  skg_stage_vertex | skg_stage_pixel, skg_register_constant };
-const skg_bind_t render_list_blit_bind   = { 2,  skg_stage_vertex | skg_stage_pixel, skg_register_constant };
+const skg_bind_t render_list_blit_bind   = { 3,  skg_stage_vertex | skg_stage_pixel, skg_register_constant };
 
 ///////////////////////////////////////////
 
@@ -174,8 +174,8 @@ bool render_init() {
 	local.ortho_viewport_height = 1.0f;
 	local.clear_col             = color128{0,0,0,0};
 	local.list_primary          = nullptr;
-	local.scale                 = 1;
-	local.multisample           = 1;
+	local.scale                 = sk_get_settings_ref()->render_scaling;
+	local.multisample           = sk_get_settings_ref()->render_multisample;
 	local.primary_filter        = render_layer_all_first_person;
 	local.capture_filter        = render_layer_all_first_person;
 	local.list_active           = nullptr;
@@ -732,8 +732,8 @@ void render_draw_queue(const matrix *views, const matrix *projections, int32_t e
 	// Copy camera information into the global buffer
 	for (int32_t i = 0; i < view_count; i++) {
 		XMMATRIX view_f, projection_f;
-		math_matrix_to_fast(views      [i], &view_f      );
-		math_matrix_to_fast(projections[i], &projection_f);
+		math_matrix_to_fast(views      [eye_offset+i], &view_f      );
+		math_matrix_to_fast(projections[eye_offset+i], &projection_f);
 
 		XMMATRIX view_inv = XMMatrixInverse(nullptr, view_f      );
 		XMMATRIX proj_inv = XMMatrixInverse(nullptr, projection_f);
@@ -798,14 +798,6 @@ void render_draw_queue(const matrix *views, const matrix *projections, int32_t e
 
 ///////////////////////////////////////////
 
-void render_draw_matrix(const matrix* views, const matrix* projections, int32_t eye_offset, int32_t count, render_layer_ render_filter) {
-	render_check_viewpoints();
-	render_draw_queue(views, projections, eye_offset, count, render_filter);
-	render_check_screenshots();
-}
-
-///////////////////////////////////////////
-
 // The screenshots are produced in FIFO order, meaning the
 // order of screenshot requests by users is preserved.
 void render_check_screenshots() {
@@ -823,10 +815,10 @@ void render_check_screenshots() {
 
 		tex_t render_capture_surface = tex_create(tex_type_image_nomips | tex_type_rendertarget, local.screenshot_list[i].tex_format);
 		tex_set_color_arr(render_capture_surface, w, h, nullptr, 1, nullptr, 8);
-		tex_add_zbuffer(render_capture_surface);
+		tex_add_zbuffer  (render_capture_surface);
 
 		// Setup to render the screenshot
-		skg_tex_target_bind(&render_capture_surface->tex);
+		skg_tex_target_bind(&render_capture_surface->tex, -1, 0);
 
 		// Set up the viewport if we've got one!
 		if (local.screenshot_list[i].viewport.w != 0) {
@@ -857,11 +849,11 @@ void render_check_screenshots() {
 
 		// Render!
 		render_draw_queue(&local.screenshot_list[i].camera, &local.screenshot_list[i].projection, 0, 1, local.screenshot_list[i].layer_filter);
-		skg_tex_target_bind(nullptr);
+		skg_tex_target_bind(nullptr, -1, 0);
 
 		tex_t resolve_tex = tex_create(tex_type_image_nomips, local.screenshot_list[i].tex_format);
 		tex_set_colors(resolve_tex, w, h, nullptr);
-		skg_tex_copy_to(&render_capture_surface->tex, &resolve_tex->tex);
+		skg_tex_copy_to(&render_capture_surface->tex, -1, &resolve_tex->tex, -1);
 		tex_get_data(resolve_tex, buffer, size);
 #if defined(SKG_OPENGL)
 		int32_t line_size = skg_tex_fmt_size(resolve_tex->tex.format) * resolve_tex->tex.width;
@@ -869,9 +861,9 @@ void render_check_screenshots() {
 		for (int32_t y = 0; y < resolve_tex->tex.height / 2; y++) {
 			void* top_line = ((uint8_t*)buffer) + line_size * y;
 			void* bot_line = ((uint8_t*)buffer) + line_size * ((resolve_tex->tex.height - 1) - y);
-			memcpy(tmp, top_line, line_size);
+			memcpy(tmp,      top_line, line_size);
 			memcpy(top_line, bot_line, line_size);
-			memcpy(bot_line, tmp, line_size);
+			memcpy(bot_line, tmp,      line_size);
 		}
 		sk_free(tmp);
 #endif
@@ -884,7 +876,7 @@ void render_check_screenshots() {
 		skg_event_end();
 	}
 	local.screenshot_list.clear();
-	skg_tex_target_bind(old_target);
+	skg_tex_target_bind(old_target, -1, 0);
 }
 
 ///////////////////////////////////////////
@@ -896,7 +888,7 @@ void render_check_viewpoints() {
 	for (int32_t i = 0; i < local.viewpoint_list.count; i++) {
 		skg_event_begin("Viewpoint");
 		// Setup to render the screenshot
-		skg_tex_target_bind(&local.viewpoint_list[i].rendertarget->tex);
+		skg_tex_target_bind(&local.viewpoint_list[i].rendertarget->tex, -1, 0);
 
 		// Clear the viewport
 		if (local.viewpoint_list[i].clear != render_clear_none) {
@@ -922,14 +914,14 @@ void render_check_viewpoints() {
 
 		// Render!
 		render_draw_queue(&local.viewpoint_list[i].camera, &local.viewpoint_list[i].projection, 0, 1, local.viewpoint_list[i].layer_filter);
-		skg_tex_target_bind(nullptr);
+		skg_tex_target_bind(nullptr, -1, 0);
 
 		// Release the reference we added, the user should have their own ref
 		tex_release(local.viewpoint_list[i].rendertarget);
 		skg_event_end();
 	}
 	local.viewpoint_list.clear();
-	skg_tex_target_bind(old_target);
+	skg_tex_target_bind(old_target, -1, 0);
 }
 
 ///////////////////////////////////////////
@@ -980,9 +972,12 @@ void render_blit_to_bound(material_t material) {
 void render_blit(tex_t to, material_t material) {
 	skg_tex_t *old_target = skg_tex_target_get();
 
-	skg_tex_target_bind (&to->tex  );
-	render_blit_to_bound(material  );
-	skg_tex_target_bind (old_target);
+	for (size_t i = 0; i < to->tex.array_count; i++)
+	{
+		skg_tex_target_bind(&to->tex, i, 0);
+		render_blit_to_bound(material);
+	}
+	skg_tex_target_bind(old_target, -1, 0);
 }
 
 ///////////////////////////////////////////

--- a/StereoKitC/systems/render.h
+++ b/StereoKitC/systems/render.h
@@ -28,7 +28,6 @@ matrix        render_get_cam_final        ();
 matrix        render_get_cam_final_inv    ();
 color128      render_get_clear_color_ln   ();
 vec2          render_get_clip             ();
-void          render_draw_matrix          (const matrix *views, const matrix *projs, int32_t eye_offset, int32_t view_count, render_layer_ render_filter);
 void          render_clear                ();
 vec3          render_unproject_pt         (vec3 normalized_screen_pt);
 void          render_update_projection    ();

--- a/StereoKitC/systems/render_pipeline.cpp
+++ b/StereoKitC/systems/render_pipeline.cpp
@@ -221,8 +221,8 @@ void render_pipeline_surface_get_surface_info(pipeline_surface_id surface_id, in
 	int32_t x = array_based_idx % surface->quilt_width;
 
 	*out_array_idx = arr;
-	out_xywh_rect[2] = surface->tex->width  / surface->quilt_width;
-	out_xywh_rect[3] = surface->tex->height / surface->quilt_height;
+	out_xywh_rect[2] = surface->tex ? surface->tex->width  / surface->quilt_width : 0;
+	out_xywh_rect[3] = surface->tex ? surface->tex->height / surface->quilt_height: 0;
 	out_xywh_rect[0] = x * out_xywh_rect[2];
 	out_xywh_rect[1] = y * out_xywh_rect[3];
 }

--- a/StereoKitC/systems/render_pipeline.cpp
+++ b/StereoKitC/systems/render_pipeline.cpp
@@ -13,7 +13,9 @@ struct pipeline_surface_t {
 	tex_format_   color;
 	tex_format_   depth;
 	render_layer_ layer;
-	int32_t       surface_count;
+	int32_t       array_count;
+	int32_t       quilt_width;
+	int32_t       quilt_height;
 	int32_t       multisample;
 	color128      clear_color;
 	tex_t         tex;
@@ -55,11 +57,40 @@ void render_pipeline_draw() {
 		pipeline_surface_t* s = &local.surfaces[i];
 		if (s->enabled == false) continue;
 
+		int32_t width  = s->tex->width  / s->quilt_width;
+		int32_t height = s->tex->height / s->quilt_height;
+
 		skg_event_begin("Draw Surface");
 		{
-			skg_tex_target_bind(&s->tex->tex);
+#if defined(SKG_DIRECT3D11)
+			skg_tex_target_bind(&s->tex->tex, -1, 0);
 			skg_target_clear   (true, &s->clear_color.r);
-			render_draw_matrix (s->view_matrices, s->proj_matrices, i, s->surface_count, s->layer);
+				
+			for (int32_t quilt_y = 0; quilt_y < s->quilt_height; quilt_y += 1) {
+			for (int32_t quilt_x = 0; quilt_x < s->quilt_width;  quilt_x += 1) {
+				int32_t viewport[4] = {quilt_x*width, quilt_y*height, width, height};
+				skg_viewport(viewport);
+
+				int32_t idx = quilt_x + quilt_y * s->quilt_width;
+				render_draw_queue(s->view_matrices, s->proj_matrices, idx, s->array_count, s->layer);
+			} }
+#elif defined (SKG_OPENGL)
+			for (int32_t layer = 0; layer < s->array_count; layer++) {
+				skg_tex_target_bind(&s->tex->tex, layer, 0);
+				skg_target_clear(true, &s->clear_color.r);
+
+				for (int32_t quilt_y = 0; quilt_y < s->quilt_height; quilt_y += 1) {
+				for (int32_t quilt_x = 0; quilt_x < s->quilt_width;  quilt_x += 1) {
+					int32_t viewport[4] = { quilt_x * width, quilt_y * height, width, height };
+					skg_viewport(viewport);
+
+					int32_t idx = quilt_x + quilt_y * s->quilt_width + layer * s->quilt_width * s->quilt_height;
+					render_draw_queue(s->view_matrices, s->proj_matrices, idx, 1, s->layer);
+				} }
+			}
+#else
+#pragma error
+#endif
 		}
 		skg_event_end();
 	}
@@ -79,15 +110,17 @@ void render_pipeline_shutdown() {
 
 ///////////////////////////////////////////
 
-pipeline_surface_id render_pipeline_surface_create(tex_format_ color, tex_format_ depth, int32_t surface_count) {
+pipeline_surface_id render_pipeline_surface_create(tex_format_ color, tex_format_ depth, int32_t array_count, int32_t quilt_width, int32_t quilt_height) {
 	pipeline_surface_t result = {};
 	result.enabled       = false; // shouldn't be enabled until the tex is sized
 	result.color         = color;
 	result.depth         = depth;
 	result.layer         = render_layer_all;
-	result.surface_count = surface_count;
-	result.view_matrices = sk_malloc_t(matrix, surface_count);
-	result.proj_matrices = sk_malloc_t(matrix, surface_count);
+	result.array_count   = array_count;
+	result.quilt_width   = quilt_width;
+	result.quilt_height  = quilt_height;
+	result.view_matrices = sk_malloc_t(matrix, array_count * quilt_width * quilt_height);
+	result.proj_matrices = sk_malloc_t(matrix, array_count * quilt_width * quilt_height);
 	return local.surfaces.add(result);
 }
 
@@ -110,12 +143,12 @@ bool32_t render_pipeline_surface_resize(pipeline_surface_id surface_id, int32_t 
 	// If this is the first time getting called, the texture will be null, and
 	// we'll need to create a fresh new one.
 	if (surface->tex == nullptr) {
-		log_diagf("Creating target surface: <~grn>%d<~clr>x<~grn>%d<~clr>x<~grn>%d<~clr>@<~grn>%d<~clr>msaa", width, height, surface->surface_count, multisample);
+		log_diagf("Creating target surface: <~grn>%d<~clr>x<~grn>%d<~clr>x<~grn>%d<~clr>@<~grn>%d<~clr>msaa", width, height, surface->array_count, multisample);
 
 		surface->tex         = tex_create(tex_type_image_nomips | tex_type_rendertarget, surface->color);
 		surface->multisample = multisample;
 		surface->enabled     = true;
-		tex_set_color_arr(surface->tex, width, height, nullptr, surface->surface_count, nullptr, multisample);
+		tex_set_color_arr(surface->tex, width, height, nullptr, surface->array_count, nullptr, multisample);
 
 		char name[64];
 		snprintf(name, sizeof(name), "sk/pipeline_surface_%d", surface_id);
@@ -124,7 +157,7 @@ bool32_t render_pipeline_surface_resize(pipeline_surface_id surface_id, int32_t 
 		tex_add_zbuffer(surface->tex, surface->depth);
 		tex_t zbuffer = tex_get_zbuffer(surface->tex);
 		snprintf(name, sizeof(name), "sk/pipeline_surface_%d_depth", surface_id);
-		tex_set_id(zbuffer, name);
+		tex_set_id (zbuffer, name);
 		tex_release(zbuffer);
 		return true;
 	}
@@ -134,9 +167,9 @@ bool32_t render_pipeline_surface_resize(pipeline_surface_id surface_id, int32_t 
 	if (width == tex_get_width(surface->tex) && height == tex_get_height(surface->tex) && surface->multisample == multisample)
 		return false;
 
-	log_diagf("Resizing target surface: <~grn>%d<~clr>x<~grn>%d<~clr>x<~grn>%d<~clr>@<~grn>%d<~clr>msaa", width, height, surface->surface_count, multisample);
+	log_diagf("Resizing target surface: <~grn>%d<~clr>x<~grn>%d<~clr>x<~grn>%d<~clr>@<~grn>%d<~clr>msaa", width, height, surface->array_count, multisample);
 	surface->multisample = multisample;
-	tex_set_color_arr(surface->tex, width, height, nullptr, surface->surface_count, nullptr, multisample);
+	tex_set_color_arr(surface->tex, width, height, nullptr, surface->array_count, nullptr, multisample);
 
 	return true;
 }
@@ -156,6 +189,42 @@ void render_pipeline_surface_to_swapchain(pipeline_surface_id surface_id, skg_sw
 		skg_swapchain_present(swapchain);
 	}
 	skg_event_end();
+}
+
+///////////////////////////////////////////
+
+void render_pipeline_surface_to_tex(pipeline_surface_id surface_id, tex_t destination, material_t mat) {
+	pipeline_surface_t* surface = &local.surfaces[surface_id];
+
+	skg_event_begin("Present to Tex");
+	{
+		if (mat) {
+			material_set_texture(mat, "source", surface->tex);
+			render_blit(destination, mat);
+		} else {
+			skg_tex_copy_to(&surface->tex->tex, -1, &destination->tex, -1);
+		}
+	}
+	skg_event_end();
+}
+
+///////////////////////////////////////////
+
+void render_pipeline_surface_get_surface_info(pipeline_surface_id surface_id, int32_t view_idx, int32_t *out_array_idx, int32_t *out_xywh_rect) {
+	pipeline_surface_t* surface = &local.surfaces[surface_id];
+
+	int32_t array_step      = surface->quilt_width * surface->quilt_height;
+	int32_t arr             = view_idx / array_step;
+	int32_t array_based_idx = (view_idx - (arr * array_step));
+
+	int32_t y = array_based_idx / surface->quilt_width;
+	int32_t x = array_based_idx % surface->quilt_width;
+
+	*out_array_idx = arr;
+	out_xywh_rect[2] = surface->tex->width  / surface->quilt_width;
+	out_xywh_rect[3] = surface->tex->height / surface->quilt_height;
+	out_xywh_rect[0] = x * out_xywh_rect[2];
+	out_xywh_rect[1] = y * out_xywh_rect[3];
 }
 
 ///////////////////////////////////////////
@@ -183,6 +252,12 @@ void render_pipeline_surface_set_enabled(pipeline_surface_id surface, bool32_t e
 
 ///////////////////////////////////////////
 
+bool32_t render_pipeline_surface_get_enabled(pipeline_surface_id surface) {
+	return local.surfaces[surface].enabled;
+}
+
+///////////////////////////////////////////
+
 void render_pipeline_surface_set_layer(pipeline_surface_id surface, render_layer_ layer) {
 	local.surfaces[surface].layer = layer;
 }
@@ -197,7 +272,7 @@ void render_pipeline_surface_set_clear(pipeline_surface_id surface, color128 col
 
 void render_pipeline_surface_set_perspective(pipeline_surface_id surface_id, matrix* view_matrices, matrix* proj_matrices, int32_t count) {
 	pipeline_surface_t* surface = &local.surfaces[surface_id];
-	if (count != surface->surface_count) log_err("Surface count mismatch.");
+	if (count != surface->array_count*surface->quilt_width*surface->quilt_height) log_err("Surface count mismatch.");
 
 	memcpy(surface->view_matrices, view_matrices, sizeof(matrix) * count);
 	memcpy(surface->proj_matrices, proj_matrices, sizeof(matrix) * count);

--- a/StereoKitC/systems/render_pipeline.h
+++ b/StereoKitC/systems/render_pipeline.h
@@ -7,16 +7,19 @@ namespace sk {
 
 typedef int32_t pipeline_surface_id;
 
-pipeline_surface_id render_pipeline_surface_create         (tex_format_ color, tex_format_ depth, int32_t surface_count);
-void                render_pipeline_surface_destroy        (pipeline_surface_id surface);
-bool32_t            render_pipeline_surface_resize         (pipeline_surface_id surface, int32_t width, int32_t height, int32_t multisample);
-void                render_pipeline_surface_to_swapchain   (pipeline_surface_id surface, skg_swapchain_t* swapchain);
-void                render_pipeline_surface_set_tex        (pipeline_surface_id surface, tex_t tex);
-tex_t               render_pipeline_surface_get_tex        (pipeline_surface_id surface);
-void                render_pipeline_surface_set_enabled    (pipeline_surface_id surface, bool32_t enabled);
-void                render_pipeline_surface_set_layer      (pipeline_surface_id surface, render_layer_ layer);
-void                render_pipeline_surface_set_clear      (pipeline_surface_id surface, color128 color);
-void                render_pipeline_surface_set_perspective(pipeline_surface_id surface, matrix* view_matrices, matrix* proj_matrices, int32_t count);
+pipeline_surface_id render_pipeline_surface_create          (tex_format_ color, tex_format_ depth, int32_t array_count, int32_t quilt_width, int32_t quilt_height);
+void                render_pipeline_surface_destroy         (pipeline_surface_id surface);
+bool32_t            render_pipeline_surface_resize          (pipeline_surface_id surface, int32_t width, int32_t height, int32_t multisample);
+void                render_pipeline_surface_to_swapchain    (pipeline_surface_id surface, skg_swapchain_t* swapchain);
+void                render_pipeline_surface_to_tex          (pipeline_surface_id surface, tex_t destination, material_t mat);
+void                render_pipeline_surface_get_surface_info(pipeline_surface_id surface, int32_t view_idx, int32_t* out_array_idx, int32_t* out_xywh_rect);
+void                render_pipeline_surface_set_tex         (pipeline_surface_id surface, tex_t tex);
+tex_t               render_pipeline_surface_get_tex         (pipeline_surface_id surface);
+void                render_pipeline_surface_set_enabled     (pipeline_surface_id surface, bool32_t enabled);
+bool32_t            render_pipeline_surface_get_enabled     (pipeline_surface_id surface);
+void                render_pipeline_surface_set_layer       (pipeline_surface_id surface, render_layer_ layer);
+void                render_pipeline_surface_set_clear       (pipeline_surface_id surface, color128 color);
+void                render_pipeline_surface_set_perspective (pipeline_surface_id surface, matrix* view_matrices, matrix* proj_matrices, int32_t count);
 
 void render_pipeline_shutdown();
 void render_pipeline_begin();

--- a/StereoKitC/xr_backends/openxr_view.cpp
+++ b/StereoKitC/xr_backends/openxr_view.cpp
@@ -37,14 +37,14 @@ struct swapchain_t {
 	int32_t              height;
 	int32_t              multisample;
 	uint32_t             backbuffer_count; // The number of backbuffer surfaces the swapchain has
-	uint32_t             backbuffer_views; // The number of "views" each backbuffer needs. If this is a platform that can target different texture array surfaces in the shader, then only one view is needed. Otherwise we need one view for each array surface.
 	XrSwapchainImage    *backbuffers;
 	tex_t               *textures;
-	pipeline_surface_id *render_surfaces;
+	pipeline_surface_id  render_surface;
+	int32_t              render_surface_tex;
 	bool32_t             acquired;
 };
 void swapchain_delete(swapchain_t *swapchain) {
-	for (size_t s = 0; s < swapchain->backbuffer_count * swapchain->backbuffer_views; s++)
+	for (size_t s = 0; s < swapchain->backbuffer_count; s++)
 		tex_release(swapchain->textures[s]);
 	if (swapchain->handle)
 		xrDestroySwapchain(swapchain->handle);
@@ -87,10 +87,10 @@ void device_display_delete(device_display_t *display) {
 
 ///////////////////////////////////////////
 
-int32_t   xr_display_primary_idx    = -1;
-system_t* xr_render_sys             = nullptr;
-int64_t   xr_preferred_color_format = -1;
-int64_t   xr_preferred_depth_format = -1;
+int32_t    xr_display_primary_idx    = -1;
+system_t*  xr_render_sys             = nullptr;
+int64_t    xr_preferred_color_format = -1;
+int64_t    xr_preferred_depth_format = -1;
 
 array_t<device_display_t>                          xr_displays           = {};
 array_t<device_display_t>                          xr_displays_2nd       = {};
@@ -445,7 +445,6 @@ bool openxr_display_swapchain_update(device_display_t *display) {
 	}
 	if (w > (int32_t)display->view_configs[0].maxImageRectWidth      ) w = display->view_configs[0].maxImageRectWidth;
 	if (h > (int32_t)display->view_configs[0].maxImageRectHeight     ) h = display->view_configs[0].maxImageRectHeight;
-	if (s > (int32_t)display->view_configs[0].maxSwapchainSampleCount) s = display->view_configs[0].maxSwapchainSampleCount;
 
 	if (   w == sc_color->width
 		&& h == sc_color->height
@@ -453,52 +452,53 @@ bool openxr_display_swapchain_update(device_display_t *display) {
 		return true;
 	}
 
+	// A "quilt" is a grid of images on a single texture. This terminology is
+	// used for lenticular displays like Looking Glass, and we're using it here
+	// to describe more generically what's happening in a "double wide" 
+	// rendering scenario. This gives us some extra ability to experiment with
+	// memory/image layout like "double tall", and possibly more features later.
+	int32_t array_count  = display->view_cap;
+	int32_t quilt_width  = 1;
+	int32_t quilt_height = 1;
+#if defined(SKG_OPENGL)
+	array_count  = 1;
+	quilt_width  = 1;
+	quilt_height = display->view_cap;
+#endif
+	w = w * quilt_width;
+	h = h * quilt_height;
+
 	// Create the new swapchains for the current size
-	if (!openxr_create_swapchain(&display->swapchain_color, display->type, true,  display->view_cap, xr_preferred_color_format, w, h, s)) return false;
-	if (!openxr_create_swapchain(&display->swapchain_depth, display->type, false, display->view_cap, xr_preferred_depth_format, w, h, s)) return false;
+	if (!openxr_create_swapchain(&display->swapchain_color, display->type, true,  array_count, xr_preferred_color_format, w, h, 1)) return false;
+	if (!openxr_create_swapchain(&display->swapchain_depth, display->type, false, array_count, xr_preferred_depth_format, w, h, 1)) return false;
 
-	log_diagf("Set view: <~grn>%s<~clr> to %d<~BLK>x<~clr>%d<~BLK>@<~clr>%d<~BLK>msaa<~clr>", openxr_view_name(display->type), sc_color->width, sc_color->height, sc_color->multisample);
-
-	// If shaders can't select layers from a texture array, we'll have to
-	// separate the layers into individual render targets.
-	if (skg_capability(skg_cap_tex_layer_select) && xr_has_single_pass) {
-		sc_color->backbuffer_views = 1;
-		sc_depth->backbuffer_views = 1;
-	} else {
-		sc_color->backbuffer_views = display->view_cap;
-		sc_depth->backbuffer_views = display->view_cap;
-	}
+	log_diagf("Set swapchain: <~grn>%s<~clr> to %d<~BLK>x<~clr>%d", openxr_view_name(display->type), sc_color->width, sc_color->height);
 
 	// Create texture objects if we don't have 'em
 	if (sc_color->textures == nullptr) {
-		sc_color->textures = sk_malloc_t(tex_t, (size_t)sc_color->backbuffer_count * sc_color->backbuffer_views);
-		sc_depth->textures = sk_malloc_t(tex_t, (size_t)sc_depth->backbuffer_count * sc_depth->backbuffer_views);
-		memset(sc_color->textures, 0, sizeof(tex_t) * sc_color->backbuffer_count * sc_color->backbuffer_views);
-		memset(sc_depth->textures, 0, sizeof(tex_t) * sc_depth->backbuffer_count * sc_depth->backbuffer_views);
+		sc_color->textures = sk_malloc_t(tex_t, (size_t)sc_color->backbuffer_count);
+		sc_depth->textures = sk_malloc_t(tex_t, (size_t)sc_depth->backbuffer_count);
+		memset(sc_color->textures, 0, sizeof(tex_t) * sc_color->backbuffer_count);
+		memset(sc_depth->textures, 0, sizeof(tex_t) * sc_depth->backbuffer_count);
 
-		for (uint32_t back = 0; back < sc_color->backbuffer_count; back++) {
-			for (uint32_t view = 0; view < sc_color->backbuffer_views; view++) {
-				int32_t index = view*sc_color->backbuffer_count + back;
+		for (uint32_t i = 0; i < sc_color->backbuffer_count; i++) {
+			sc_color->textures[i] = tex_create(tex_type_rendertarget, tex_get_tex_format(xr_preferred_color_format));
+			sc_depth->textures[i] = tex_create(tex_type_depth,        tex_get_tex_format(xr_preferred_depth_format));
 
-				sc_color->textures[index] = tex_create(tex_type_rendertarget, tex_get_tex_format(xr_preferred_color_format));
-				sc_depth->textures[index] = tex_create(tex_type_depth,        tex_get_tex_format(xr_preferred_depth_format));
-
-				char           name[64];
-				static int32_t target_index = 0;
-				target_index++;
-				snprintf(name, sizeof(name), "renderer/colortarget_%d", target_index);
-				tex_set_id(sc_color->textures[index], name);
-				snprintf(name, sizeof(name), "renderer/depthtarget_%d", target_index);
-				tex_set_id(sc_depth->textures[index], name);
-			}
+			char           name[64];
+			static int32_t target_index = 0;
+			target_index++;
+			snprintf(name, sizeof(name), "renderer/colortarget_%d", target_index);
+			tex_set_id(sc_color->textures[i], name);
+			snprintf(name, sizeof(name), "renderer/depthtarget_%d", target_index);
+			tex_set_id(sc_depth->textures[i], name);
 		}
 
-		sc_color->render_surfaces = sk_malloc_t(pipeline_surface_id, sc_color->backbuffer_views);
-		for (uint32_t i = 0; i < sc_color->backbuffer_views; i++)
-			sc_color->render_surfaces[i] = render_pipeline_surface_create(
-				tex_get_tex_format(xr_preferred_color_format),
-				tex_get_tex_format(xr_preferred_depth_format),
-				display->view_cap/sc_color->backbuffer_views);
+		sc_color->render_surface_tex = -1;
+		sc_color->render_surface     = render_pipeline_surface_create(
+			tex_get_tex_format(xr_preferred_color_format),
+			tex_get_tex_format(xr_preferred_depth_format),
+			array_count, quilt_width, quilt_height);
 	}
 
 	// Update or set the native textures
@@ -513,19 +513,12 @@ bool openxr_display_swapchain_update(device_display_t *display) {
 		native_surface_col   = (void*)(uint64_t)sc_color->backbuffers[back].image;
 		native_surface_depth = (void*)(uint64_t)sc_depth->backbuffers[back].image;
 #endif
-		if (sc_color->backbuffer_views == 1) {
-			tex_set_surface(sc_color->textures[back], native_surface_col,   tex_type_rendertarget, xr_preferred_color_format, sc_color->width, sc_color->height, display->view_cap);
-			tex_set_surface(sc_depth->textures[back], native_surface_depth, tex_type_depth,        xr_preferred_depth_format, sc_depth->width, sc_depth->height, display->view_cap);
-			tex_set_zbuffer(sc_color->textures[back], sc_depth->textures[back]);
-		} else {
-			for (uint32_t layer = 0; layer < sc_color->backbuffer_views; layer++) {
-				int32_t index = layer * sc_color->backbuffer_count + back;
-				tex_set_surface_layer(sc_color->textures[index], native_surface_col,   tex_type_rendertarget, xr_preferred_color_format, sc_color->width, sc_color->height, layer);
-				tex_set_surface_layer(sc_depth->textures[index], native_surface_depth, tex_type_depth,        xr_preferred_depth_format, sc_depth->width, sc_depth->height, layer);
-				tex_set_zbuffer      (sc_color->textures[index], sc_depth->textures[index]);
-			}
-		}
+		tex_set_surface(sc_color->textures[back], native_surface_col,   tex_type_rendertarget, xr_preferred_color_format, sc_color->width, sc_color->height, array_count);
+		tex_set_surface(sc_depth->textures[back], native_surface_depth, tex_type_depth,        xr_preferred_depth_format, sc_depth->width, sc_depth->height, array_count);
+		tex_set_zbuffer(sc_color->textures[back], sc_depth->textures[back]);
 	}
+
+	render_pipeline_surface_resize(sc_color->render_surface, sc_color->width, sc_color->height, s);
 
 	if (display->type == XR_PRIMARY_CONFIG) {
 		device_data.display_width  = w;
@@ -744,8 +737,7 @@ bool openxr_render_frame() {
 		// Set up the primary displays
 		for (int32_t i = 0; i < xr_displays.count; i++) {
 			device_display_t* display = &xr_displays[i];
-			for (uint32_t s = 0; s < display->swapchain_color.backbuffer_views; s++)
-				render_pipeline_surface_set_enabled(display->swapchain_color.render_surfaces[s], display->active);
+			render_pipeline_surface_set_enabled(display->swapchain_color.render_surface, display->active);
 			if (!display->active) continue;
 
 			if (!openxr_display_locate(display, xr_time))
@@ -766,8 +758,7 @@ bool openxr_render_frame() {
 		xr_compositor_2nd_layer_ptrs.clear();
 		for (int32_t i = 0; i < xr_displays_2nd.count; i++) {
 			device_display_t* display = &xr_displays_2nd[i];
-			for (uint32_t s = 0; s < display->swapchain_color.backbuffer_views; s++)
-				render_pipeline_surface_set_enabled(display->swapchain_color.render_surfaces[s], display->active);
+			render_pipeline_surface_set_enabled(display->swapchain_color.render_surface, display->active);
 			if (!display->active) continue;
 
 			if (!openxr_display_locate(display, xr_time))
@@ -791,11 +782,8 @@ bool openxr_render_frame() {
 		}
 	} else {
 		// Disable all surfaces
-		for (int32_t i = 0; i < xr_displays.count; i++) {
-			swapchain_t* swapchain = &xr_displays[i].swapchain_color;
-			for (uint32_t s = 0; s < swapchain->backbuffer_views; s++)
-				render_pipeline_surface_set_enabled(swapchain->render_surfaces[s], false);
-		}
+		for (int32_t i = 0; i < xr_displays.count; i++)
+			render_pipeline_surface_set_enabled(xr_displays[i].swapchain_color.render_surface, false);
 	}
 
 	// Execute any code that's dependent on the predicted time, such as
@@ -810,6 +798,12 @@ bool openxr_render_frame() {
 
 	// Release the swapchains for all active displays
 	if (render_displays) {
+		for (int32_t i = 0; i < xr_displays.count; i++) {
+			swapchain_t* swapchain = &xr_displays[i].swapchain_color;
+			if (render_pipeline_surface_get_enabled(swapchain->render_surface))
+				render_pipeline_surface_to_tex     (swapchain->render_surface, swapchain->textures[swapchain->render_surface_tex], nullptr);
+		}
+
 		for (int32_t i = 0; i < xr_displays    .count; i++) openxr_display_swapchain_release(&xr_displays    [i]);
 		for (int32_t i = 0; i < xr_displays_2nd.count; i++) openxr_display_swapchain_release(&xr_displays_2nd[i]);
 	}
@@ -868,16 +862,20 @@ bool openxr_display_locate(device_display_t* display, XrTime at_time) {
 	// And now we'll iterate through each viewpoint, and render it!
 	vec2 clip_planes = render_get_clip();
 	for (uint32_t i = 0; i < view_count; i++) {
+		int32_t array_idx    = 0;
+		int32_t view_rect[4] = {};
+		render_pipeline_surface_get_surface_info(display->swapchain_color.render_surface, i, &array_idx, view_rect);
+
 		// Set up our rendering information for the viewpoint we're using right
 		// now!
 		XrCompositionLayerProjectionView *view = &display->view_layers[i];
 		*view = { XR_TYPE_COMPOSITION_LAYER_PROJECTION_VIEW };
 		view->pose = display->view_xr[i].pose;
 		view->fov  = display->view_xr[i].fov;
-		view->subImage.imageArrayIndex  = i;
 		view->subImage.swapchain        = display->swapchain_color.handle;
-		view->subImage.imageRect.offset = { 0, 0 };
-		view->subImage.imageRect.extent = { display->swapchain_color.width, display->swapchain_color.height };
+		view->subImage.imageArrayIndex  = array_idx;
+		view->subImage.imageRect.offset = { view_rect[0], view_rect[1] };
+		view->subImage.imageRect.extent = { view_rect[2], view_rect[3] };
 
 		if (xr_ext_available.KHR_composition_layer_depth) {
 			XrCompositionLayerDepthInfoKHR *depth = &display->view_depths[i];
@@ -885,10 +883,10 @@ bool openxr_display_locate(device_display_t* display, XrTime at_time) {
 			depth->maxDepth = 1;
 			depth->nearZ    = clip_planes.x;
 			depth->farZ     = clip_planes.y;
-			depth->subImage.imageArrayIndex  = i;
 			depth->subImage.swapchain        = display->swapchain_depth.handle;
-			depth->subImage.imageRect.offset = { 0, 0 };
-			depth->subImage.imageRect.extent = { display->swapchain_depth.width, display->swapchain_depth.height };
+			depth->subImage.imageArrayIndex  = array_idx;
+			depth->subImage.imageRect.offset = { view_rect[0], view_rect[1] };
+			depth->subImage.imageRect.extent = { view_rect[2], view_rect[3] };
 			view->next = depth;
 		}
 
@@ -905,13 +903,10 @@ bool openxr_display_locate(device_display_t* display, XrTime at_time) {
 	display->projection_layer.views      = view_count == 0 ? nullptr : display->view_layers;
 	display->projection_layer.layerFlags = XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT;
 
-	int32_t surfaces = display->view_cap / display->swapchain_color.backbuffer_views;
-	for (uint32_t v = 0; v < display->swapchain_color.backbuffer_views; v++) {
-		render_pipeline_surface_set_perspective(display->swapchain_color.render_surfaces[v],
-			&display->view_transforms [v * surfaces],
-			&display->view_projections[v * surfaces],
-			surfaces);
-	}
+	render_pipeline_surface_set_perspective(display->swapchain_color.render_surface,
+		display->view_transforms,
+		display->view_projections,
+		display->view_cap);
 
 	return true;
 }
@@ -933,13 +928,10 @@ void openxr_display_swapchain_acquire(device_display_t* display, color128 color,
 	xrWaitSwapchainImage(display->swapchain_color.handle, &wait_info);
 	xrWaitSwapchainImage(display->swapchain_depth.handle, &wait_info);
 
-	for (uint32_t s_layer = 0; s_layer < display->swapchain_color.backbuffer_views; s_layer++) {
-		int32_t index = s_layer*display->swapchain_color.backbuffer_count + color_id;
-
-		render_pipeline_surface_set_tex  (display->swapchain_color.render_surfaces[s_layer], display->swapchain_color.textures[index]);
-		render_pipeline_surface_set_clear(display->swapchain_color.render_surfaces[s_layer], color);
-		render_pipeline_surface_set_layer(display->swapchain_color.render_surfaces[s_layer], render_filter);
-	}
+	//render_pipeline_surface_set_tex  (display->swapchain_color.render_surfaces[s_layer], display->swapchain_color.textures[index]);
+	display->swapchain_color.render_surface_tex = color_id;
+	render_pipeline_surface_set_clear(display->swapchain_color.render_surface, color);
+	render_pipeline_surface_set_layer(display->swapchain_color.render_surface, render_filter);
 }
 
 ///////////////////////////////////////////

--- a/StereoKitC/xr_backends/simulator.cpp
+++ b/StereoKitC/xr_backends/simulator.cpp
@@ -92,7 +92,7 @@ bool simulator_init() {
 	default: return false;
 	}
 
-	sim_surface = render_pipeline_surface_create(tex_format_rgba32, render_preferred_depth_fmt(), 1);
+	sim_surface = render_pipeline_surface_create(tex_format_rgba32, render_preferred_depth_fmt(), 1, 1, 1);
 	skg_swapchain_t* swapchain = platform_win_get_swapchain(sim_window);
 	if (swapchain)
 		sim_surface_resize(sim_surface, swapchain->width, swapchain->height);

--- a/StereoKitC/xr_backends/window.cpp
+++ b/StereoKitC/xr_backends/window.cpp
@@ -81,7 +81,7 @@ bool window_init() {
 	default: return false;
 	}
 
-	local->surface = render_pipeline_surface_create(tex_format_rgba32, render_preferred_depth_fmt(), 1);
+	local->surface = render_pipeline_surface_create(tex_format_rgba32, render_preferred_depth_fmt(), 1, 1, 1);
 	skg_swapchain_t* swapchain = platform_win_get_swapchain(local->window);
 	if (swapchain)
 		window_surface_resize(local->surface, swapchain->width, swapchain->height);


### PR DESCRIPTION
SK now defaults to 4x MSAA in XR.

In the general case, StereoKit will request a swapchain with no MSAA, and a rendertarget with MSAA. It will then resolve the MSAA surface to the swapchain when finished rendering.

The OpenGL implementation now uses a double-wide surface instead of an array texture. This was done to try bypassing what was likely a driver issue with layer blitting, but may also enable SK to bypass some additional issues on Linux situations as well.

This _also_ uses the GLES only `GL_EXT_multisampled_render_to_texture2` extension when available, as it is on most Android XR devices. This allows swapchain surfaces to use MSAA without paying the extra VRAM cost, by resolving the extra samples per-tile. This also allows us to skip using a rendertarget, and just draw directly to the swapchain.

There may be some lingering issues related to creating / recreating swapchains at runtime, as well as some UWP issues.