### PR TITLE
UWP MSAA fix

### DIFF
--- a/StereoKitC/stereokit.cpp
+++ b/StereoKitC/stereokit.cpp
@@ -101,8 +101,16 @@ bool32_t sk_init(sk_settings_t settings) {
 	if (local.settings.flatscreen_width   == 0      ) local.settings.flatscreen_width   = 1280;
 	if (local.settings.flatscreen_height  == 0      ) local.settings.flatscreen_height  = 720;
 	if (local.settings.render_scaling     == 0      ) local.settings.render_scaling     = 1;
-	if (local.settings.render_multisample == 0      ) local.settings.render_multisample = 4;
 	if (local.settings.mode               == app_mode_none) local.settings.mode         = app_mode_xr;
+
+	// HoloLens (UWP) can't handle MSAA and a resolve, so we set MSAA to 1 by
+	// default there. Fortunately it looks great without it, so we don't really
+	// need MSAA there. This setting is still explicitly assignable.
+#if defined(SK_OS_WINDOWS_UWP)
+	if (local.settings.render_multisample == 0      ) local.settings.render_multisample = 1;
+#else
+	if (local.settings.render_multisample == 0      ) local.settings.render_multisample = 4;
+#endif
 
 #if defined(SK_OS_ANDROID)
 	// don't allow flatscreen fallback on Android

--- a/StereoKitC/xr_backends/openxr_view.cpp
+++ b/StereoKitC/xr_backends/openxr_view.cpp
@@ -401,6 +401,8 @@ bool openxr_display_create(XrViewConfigurationType view_type, device_display_t *
 	// Extract information from the views we got
 	out_display->type             = view_type;
 	out_display->active           = true;
+	out_display->swapchain_color.render_surface = -1;
+	out_display->swapchain_depth.render_surface = -1;
 	out_display->projection_layer = { XR_TYPE_COMPOSITION_LAYER_PROJECTION };
 	out_display->view_xr          = sk_malloc_t(XrView,                           out_display->view_cap);
 	out_display->view_configs     = sk_malloc_t(XrViewConfigurationView,          out_display->view_cap);
@@ -453,6 +455,8 @@ bool openxr_display_swapchain_update(device_display_t *display) {
 		&& s == sc_color->multisample) {
 		return true;
 	}
+
+	xr_draw_to_swapchain = skg_capability(skg_cap_tiled_multisample) || s == 1;
 
 	// A "quilt" is a grid of images on a single texture. This terminology is
 	// used for lenticular displays like Looking Glass, and we're using it here
@@ -740,6 +744,7 @@ bool openxr_render_frame() {
 		// Set up the primary displays
 		for (int32_t i = 0; i < xr_displays.count; i++) {
 			device_display_t* display = &xr_displays[i];
+			if (display->swapchain_color.render_surface < 0) continue;
 			render_pipeline_surface_set_enabled(display->swapchain_color.render_surface, display->active);
 			if (!display->active) continue;
 
@@ -761,6 +766,7 @@ bool openxr_render_frame() {
 		xr_compositor_2nd_layer_ptrs.clear();
 		for (int32_t i = 0; i < xr_displays_2nd.count; i++) {
 			device_display_t* display = &xr_displays_2nd[i];
+			if (display->swapchain_color.render_surface < 0) continue;
 			render_pipeline_surface_set_enabled(display->swapchain_color.render_surface, display->active);
 			if (!display->active) continue;
 
@@ -804,7 +810,7 @@ bool openxr_render_frame() {
 		if (xr_draw_to_swapchain == false) {
 			for (int32_t i = 0; i < xr_displays.count; i++) {
 				swapchain_t* swapchain = &xr_displays[i].swapchain_color;
-				if (render_pipeline_surface_get_enabled(swapchain->render_surface))
+				if (swapchain->render_surface >= 0 && render_pipeline_surface_get_enabled(swapchain->render_surface))
 					render_pipeline_surface_to_tex(swapchain->render_surface, swapchain->textures[swapchain->render_surface_tex], nullptr);
 			}
 		}


### PR DESCRIPTION
Secondary views had an unassigned render_surface that defaulted to zero, and would overwrite the enabled state of the main render surface.

Also default UWP to no MSAA, it tanks the performance too much, and isn't really necessary.