### PR TITLE
Targets file for easier custom SK builds.

### DIFF
--- a/.github/workflows/verify_compile.yml
+++ b/.github/workflows/verify_compile.yml
@@ -25,13 +25,13 @@ jobs:
 
     - name: Build Native Win32 x64
       run: |
-        cmake --preset Win32_x64_Release_Fast
-        cmake --build --preset Win32_x64_Release_Fast
+        cmake --preset Win32_x64_Release
+        cmake --build --preset Win32_x64_Release
 
     - name: Build Native UWP x64
       run: |
-        cmake --preset Uwp_x64_Release_Fast
-        cmake --build --preset Uwp_x64_Release_Fast
+        cmake --preset Uwp_x64_Release
+        cmake --build --preset Uwp_x64_Release
 
   native-linux-android-dotnet:
     runs-on: ubuntu-20.04
@@ -56,8 +56,8 @@ jobs:
 
     - name: Build Native Linux x64
       run: |
-        cmake --preset Linux_x64_Release_Fast
-        cmake --build --preset Linux_x64_Release_Fast
+        cmake --preset Linux_x64_Release
+        cmake --build --preset Linux_x64_Release
 
     - name: Set up Android NDK
       uses: nttld/setup-ndk@v1.4.2
@@ -78,8 +78,8 @@ jobs:
 
     - name: Build Native Android ARM64
       run: |
-        cmake --preset Android_Arm64_Release_Fast
-        cmake --build --preset Android_Arm64_Release_Fast
+        cmake --preset Android_Arm64_Release
+        cmake --build --preset Android_Arm64_Release
       env:
         NDK: ${{ steps.setup-ndk.outputs.ndk-path }}
 

--- a/Examples/StereoKitTest/StereoKitTest.csproj
+++ b/Examples/StereoKitTest/StereoKitTest.csproj
@@ -34,31 +34,6 @@
 		<None Remove="StereoKitTest_Xamarin\**" />
 	</ItemGroup>
 	
-	<!-- Reference the StereoKit project, emulate how the NuGet behaves -->
-	<ItemGroup>
-		<ProjectReference Include="$(ProjectDir)..\..\StereoKit\StereoKit.csproj" />
-		<None Visible="false" Condition="'$(OS)'=='Windows_NT'" CopyToOutputDirectory="PreserveNewest" Link="runtimes\win-x64\native\StereoKitC.dll"     Include="$(ProjectDir)..\..\bin\distribute\bin\Win32\x64\$(Configuration)\StereoKitC.dll" />
-		<None Visible="false" Condition="'$(OS)'=='Windows_NT'" CopyToOutputDirectory="PreserveNewest" Link="runtimes\win-x64\native\StereoKitC.pdb"     Include="$(ProjectDir)..\..\bin\distribute\bin\Win32\x64\$(Configuration)\StereoKitC.pdb" />
-		<None Visible="false" Condition="'$(OS)'!='Windows_NT'" CopyToOutputDirectory="PreserveNewest" Link="runtimes\linux-x64\native\libStereoKitC.so" Include="$(ProjectDir)../../bin/distribute/bin/Linux/x64/$(Configuration)/libStereoKitC.so" />
-		<None
-			Visible="false"
-			Condition="'$(OS)'!='Windows_NT' and Exists('$(ProjectDir)../../bin/distribute/bin/Linux/x64/$(Configuration)/libStereoKitC.so.dbg')"
-			CopyToOutputDirectory="PreserveNewest"
-			Link="runtimes\linux-x64\native\libStereoKitC.so.dbg"
-			Include="$(ProjectDir)../../bin/distribute/bin/Linux/x64/$(Configuration)/libStereoKitC.so.dbg" />
-	</ItemGroup>
-
-	<Target Name="SKCheckSKShaderC" BeforeTargets="StereoKit_ShaderBuild" Condition="'$(OS)'=='Windows_NT'">
-		<!--Make sure the shader compiler is available to us, this is only
-		    necessary for VS based builds that don't use cmake for StereoKitC-->
-		<Exec Command="cd $([MSBuild]::NormalizePath('$(ProjectDir)..\..\')) &amp;&amp; powershell.exe -ExecutionPolicy Bypass -NoProfile -NonInteractive -File &quot;tools\Update-Dependencies.ps1&quot; -arch x64 -config Debug -plat Win32 -onlyDep sk_gpu" />
-	</Target>
-	
-	<!-- Error out if StereoKitC hasn't successfully built! -->
-	<Target Name="SKCheckBuildFiles" BeforeTargets="BeforeBuild">
-		<Error Condition="'$(OS)'=='Windows_NT' and !Exists('$(ProjectDir)..\..\bin\distribute\bin\Win32\x64\$(Configuration)\StereoKitC.dll')"   Text="StereoKitC was not properly built! Binary file $(ProjectDir)..\..\bin\distribute\bin\Win32\x64\$(Configuration)\StereoKitC.dll is missing." />
-		<Error Condition="'$(OS)'!='Windows_NT' and !Exists('$(ProjectDir)../../bin/distribute/bin/Linux/x64/$(Configuration)/libStereoKitC.so')" Text="StereoKitC was not properly built! Binary file $(ProjectDir)../../bin/distribute/bin/Linux/x64/$(Configuration)/libStereoKitC.so is missing." />
-	</Target>
 
 	<!-- This guide file shouldn't be compiled -->
 	<ItemGroup>
@@ -68,7 +43,9 @@
 		<None Include="Guides\GuideGettingStarted.cs" />
 	</ItemGroup>
 
-	<Import Project="$(ProjectDir)..\..\StereoKit\StereoKit.props" />
-	<Import Project="$(ProjectDir)..\..\StereoKit\SKAssets.targets" />
-	<Import Project="$(ProjectDir)..\..\StereoKit\SKShaders.targets" />
+	<!-- Include the Stereokit project manually. This is similar to including the
+	     StereoKit NuGet, but different because C# cannot consume a NuGet package
+	     directly. -->
+	<Import Project="$(ProjectDir)..\..\StereoKit\BuildStereoKitSDK.targets" />
+
 </Project>

--- a/Examples/StereoKitTest/StereoKitTest_NetAndroid/StereoKitTest_NetAndroid.csproj
+++ b/Examples/StereoKitTest/StereoKitTest_NetAndroid/StereoKitTest_NetAndroid.csproj
@@ -27,9 +27,10 @@
 		<NoWarn>XA4211;XA1006;XA4301;CS1587</NoWarn>
 	</PropertyGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="..\..\..\StereoKit\StereoKit.csproj" />
-	</ItemGroup>
+	<!-- Include the Stereokit project manually. This is similar to including the
+	     StereoKit NuGet, but different because C# cannot consume a NuGet package
+	     directly. -->
+	<Import Project="$(ProjectDir)..\..\..\StereoKit\BuildStereoKitSDK.targets" />
 
 	<PropertyGroup>
 		<AndroidManifest          >AndroidManifest.xml</AndroidManifest>
@@ -47,43 +48,4 @@
 		<Compile Include="..\Tests\*.cs" Visible="false" />
 	</ItemGroup>
 
-	<Import Project="$(ProjectDir)..\..\..\StereoKit\StereoKit.props" />
-	<Import Project="$(ProjectDir)..\..\..\StereoKit\SKAssets.targets" />
-	<Import Project="$(ProjectDir)..\..\..\StereoKit\SKShaders.targets" />
-
-	<!-- Make sure the Android binaries are built and included. -->
-	<PropertyGroup>
-		<!--Unlike the other projects, this seems to invoke from the bin
-		    folder, and $(ProjectDir) doesn't work.-->
-		<PreBuildEvent>cd ..\..\..\..\..\..\</PreBuildEvent>
-		<PreBuildEvent Condition="'$(TestBuildMode)'=='ARM64'">$(PreBuildEvent) &amp;&amp; cmake --preset Android_Arm64_$(Configuration) &amp;&amp; cmake --build --preset Android_Arm64_$(Configuration)</PreBuildEvent>
-		<PreBuildEvent Condition="'$(TestBuildMode)'=='x64'">$(PreBuildEvent) &amp;&amp; cmake --preset Android_x64_$(Configuration) &amp;&amp; cmake --build --preset Android_x64_$(Configuration)</PreBuildEvent>
-	</PropertyGroup>
-
-	<Target Name="SKTestRebuildAndroid" AfterTargets="Clean">
-		<RemoveDir Condition="'$(TestBuildMode)'=='ARM64'" Directories="..\..\..\..\..\..\bin\intermediate\cmake\Android_ARM64_$(Configuration)" />
-		<RemoveDir Condition="'$(TestBuildMode)'=='x64'" Directories="..\..\..\..\..\..\bin\intermediate\cmake\Android_x64_$(Configuration)" />
-	</Target>
-
-	<Target Name="SKCheckBuildFiles" BeforeTargets="CoreBuild" AfterTargets="PreBuild">
-		<Message Importance="high" Text="=========$(TestBuildMode)" />
-		<Error Condition="('$(TestBuildMode)'=='ARM64') and !Exists('$(ProjectDir)..\..\..\bin\distribute\bin\Android\arm64-v8a\$(ConfigurationName)\libStereoKitC.so')" Text="StereoKitC was not properly built! Binary files are missing." />
-		<Error Condition="('$(TestBuildMode)'=='x64') and !Exists('$(ProjectDir)..\..\..\bin\distribute\bin\Android\x86_64\$(ConfigurationName)\libStereoKitC.so')" Text="StereoKitC was not properly built! Binary files are missing." />
-
-		<Error
-			Condition="!Exists('$(MSBuildThisFileDirectory)../android_openxr_loaders/$(SKOpenXRLoader.ToLower())/arm64/libopenxr_loader.so') and !Exists('$(MSBuildThisFileDirectory)../android_openxr_loaders/$(SKOpenXRLoader.ToLower())/x64/libopenxr_loader.so') and !Exists('$(SKOpenXRLoaderFolder)$(SKOpenXRLoader)/arm64/libopenxr_loader.so') and !Exists('$(SKOpenXRLoaderFolder)$(SKOpenXRLoader)/x64/libopenxr_loader.so') and !Exists('$(ProjectDir)..\..\..\bin\distribute\bin\Android\arm64-v8a\$(Configuration)\$(SKOpenXRLoader.ToLower())\libopenxr_loader.so') and !Exists('$(ProjectDir)..\..\..\bin\distribute\bin\Android\x86_64\$(Configuration)\$(SKOpenXRLoader.ToLower())\libopenxr_loader.so')"
-			Text="Couldn't find binaries for the '$(SKOpenXRLoader)' OpenXR Loader. Expected to find a 'libopenxr_loader.so' in the '$(SKOpenXRLoaderFolder)\$(SKOpenXRLoader)\arm64|x64\' or '$(MSBuildThisFileDirectory)..\android_openxr_loaders\$(SKOpenXRLoader.ToLower())\arm64|x64\' folders." />
-	</Target>
-
-	<ItemGroup>
-		<!--<None                 Visible="false" Condition="'$(TestBuildMode)'=='ARM64'" Include="$(ProjectDir)..\..\..\bin\distribute\bin\Android\arm64-v8a\$(Configuration)\libStereoKitC.so.dbg"             CopyToOutputDirectory="PreserveNewest" Abi="arm64-v8a" />-->
-		<AndroidNativeLibrary Visible="false" Condition="'$(TestBuildMode)'=='ARM64'" Include="$(ProjectDir)..\..\..\bin\distribute\bin\Android\arm64-v8a\$(Configuration)\libStereoKitC.so"                 CopyToOutputDirectory="PreserveNewest" Abi="arm64-v8a" />
-		<AndroidNativeLibrary Visible="false" Condition="'$(TestBuildMode)'=='ARM64'" Include="$(ProjectDir)..\..\..\bin\distribute\bin\Android\arm64-v8a\$(Configuration)\$(SKOpenXRLoader.ToLower())\*.so" CopyToOutputDirectory="PreserveNewest" Abi="arm64-v8a" />
-		<AndroidNativeLibrary Visible="false" Condition="'$(TestBuildMode)'=='ARM64'" Include="$(SKOpenXRLoaderFolder)\$(SKOpenXRLoader)\arm64\*.so"                                                         CopyToOutputDirectory="PreserveNewest" Abi="arm64-v8a" />
-		
-		<!--<None                 Visible="false" Condition="'$(TestBuildMode)'=='x64'" Include="$(ProjectDir)..\..\..\bin\distribute\bin\Android\x86_64\$(Configuration)\libStereoKitC.so.dbg"             CopyToOutputDirectory="PreserveNewest" Abi="x86_64" />-->
-		<AndroidNativeLibrary Visible="false" Condition="'$(TestBuildMode)'=='x64'" Include="$(ProjectDir)..\..\..\bin\distribute\bin\Android\x86_64\$(Configuration)\libStereoKitC.so"                 CopyToOutputDirectory="PreserveNewest" Abi="x86_64" />
-		<AndroidNativeLibrary Visible="false" Condition="'$(TestBuildMode)'=='x64'" Include="$(ProjectDir)..\..\..\bin\distribute\bin\Android\x86_64\$(Configuration)\$(SKOpenXRLoader.ToLower())\*.so" CopyToOutputDirectory="PreserveNewest" Abi="x86_64" />
-		<AndroidNativeLibrary Visible="false" Condition="'$(TestBuildMode)'=='x64'" Include="$(SKOpenXRLoaderFolder)\$(SKOpenXRLoader)\arm64\*.so"                                                      CopyToOutputDirectory="PreserveNewest" Abi="x86_64" />
-	</ItemGroup>
 </Project>

--- a/Examples/StereoKitTest/StereoKitTest_UWP/StereoKitTest_UWP.csproj
+++ b/Examples/StereoKitTest/StereoKitTest_UWP/StereoKitTest_UWP.csproj
@@ -27,6 +27,7 @@
     <LangVersion>latest</LangVersion>
     <SKAssetFolder>..\..\Assets</SKAssetFolder>
     <SKAssetDestination>Assets</SKAssetDestination>
+		<SKShowDebugVars>true</SKShowDebugVars>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
     <DebugSymbols>true</DebugSymbols>
@@ -54,6 +55,12 @@
   <PropertyGroup>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
   </PropertyGroup>
+  
+  <!-- Include the Stereokit project manually. This is similar to including the
+	     StereoKit NuGet, but different because C# cannot consume a NuGet package
+	     directly. -->
+	<Import Project="$(ProjectDir)..\..\..\StereoKit\BuildStereoKitSDK.targets" />
+
   <ItemGroup>
     <Compile Include="..\*.cs" Visible="false" />
     <Compile Include="..\Demos\*.cs" Visible="false" />
@@ -62,11 +69,13 @@
     <Compile Include="..\Docs\*.cs" Visible="false" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
+
   <ItemGroup>
     <AppxManifest Include="Package.appxmanifest">
       <SubType>Designer</SubType>
     </AppxManifest>
   </ItemGroup>
+
   <ItemGroup>
     <Content Include="Properties\Default.rd.xml" />
     <Content Include="Assets\LockScreenLogo.scale-200.png" />
@@ -77,13 +86,7 @@
     <Content Include="Assets\StoreLogo.png" />
     <Content Include="Assets\Wide310x150Logo.scale-200.png" />
   </ItemGroup>
-  <PropertyGroup>
-    <SKAssetFolder>..\..\Assets</SKAssetFolder>
-    <SKAssetDestination>Assets</SKAssetDestination>
-  </PropertyGroup>
-  <Import Project="..\..\..\StereoKit\StereoKit.props" />
-  <Import Project="..\..\..\StereoKit\SKAssets.targets" />
-  <Import Project="..\..\..\StereoKit\SKShaders.targets" />
+  
   <ItemGroup>
     <PackageReference Include="Microsoft.MixedReality.QR">
       <Version>0.5.3019</Version>
@@ -92,34 +95,8 @@
       <Version>6.2.14</Version>
     </PackageReference>
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\StereoKit\StereoKit.csproj">
-      <Project>{0152979d-5d5e-4d18-9ef7-7261581b2bc6}</Project>
-      <Name>StereoKit</Name>
-    </ProjectReference>
-  </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
-  <!-- Make sure the UWP binaries are built and included. -->
-  <PropertyGroup>
-    <SKCMakePreset Condition="'$(Platform)' == 'ARM'"  >Uwp_Arm32_$(Configuration)</SKCMakePreset>
-    <SKCMakePreset Condition="'$(Platform)' == 'ARM64'">Uwp_Arm64_$(Configuration)</SKCMakePreset>
-    <SKCMakePreset Condition="'$(Platform)' == 'x64'"  >Uwp_x64_$(Configuration)</SKCMakePreset>
-    <PreBuildEvent>cd $(ProjectDir)..\..\..\ &amp; cmake --preset $(SKCMakePreset) &amp; cmake --build --preset $(SKCMakePreset)</PreBuildEvent>
-  </PropertyGroup>
-  <Target Name="SKTestRebuildUWP" AfterTargets="Clean">
-    <RemoveDir Directories="$(ProjectDir)..\..\..\bin\intermediate\UWP_$(Platform)" />
-  </Target>
-  <Target Name="SKCheckBuildFiles" BeforeTargets="CoreBuild" AfterTargets="PreBuild">
-    <Message Importance="high" Text="=========$(Platform)" />
-    <Error Condition="!Exists('$(ProjectDir)..\..\..\bin\distribute\bin\UWP\$(Platform)\$(Configuration)\StereoKitC.dll')" Text="StereoKitC was not properly built! Binary files are missing." />
-  </Target>
-  <ItemGroup>
-    <None Visible="false" Include="$(ProjectDir)..\..\..\bin\distribute\bin\UWP\$(Platform)\$(Configuration)\StereoKitC.dll" CopyToOutputDirectory="PreserveNewest" />
-    <None Visible="false" Include="$(ProjectDir)..\..\..\bin\distribute\bin\UWP\$(Platform)\$(Configuration)\StereoKitC.pdb" CopyToOutputDirectory="PreserveNewest" />
-    <!-- Needed for ucrtbased.dll when running a debug build. -->
-    <SDKReference Condition="'$(Configuration)' == 'Debug'" Include="Microsoft.VCLibs, Version=14.0" />
-  </ItemGroup>
 </Project>

--- a/StereoKit/BuildStereoKitSDK.targets
+++ b/StereoKit/BuildStereoKitSDK.targets
@@ -1,0 +1,103 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+
+<!-- This file is meant to hook up a project to the StereoKit repository, so
+     you can more easily work with custom modifications to core StereoKit 
+     behavior! It is an alternative to consuming prebuilt binaries from NuGet.
+     -->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+	<!-- Set up variables -->
+	<PropertyGroup>
+		<!-- Make sure the SDK folder is present and normalized for Linux. -->
+		<SKSDKFolder Condition="'$(SKSDKFolder)'==''">$(MSBuildThisFileDirectory)\..</SKSDKFolder>
+		<SKSDKFolder Condition="'$(SKSDKFolder)'!=''">$([MSBuild]::NormalizePath('$(SKSDKFolder)'))</SKSDKFolder>
+
+		<!-- Get a nice name for the OS/Platform we're building for. -->
+		<SKSDKBuildOS Condition="'$(TargetFrameworkIdentifier)'=='MonoAndroid'"                             >Android</SKSDKBuildOS>
+		<SKSDKBuildOS Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)'))=='android'">Android</SKSDKBuildOS>
+		<SKSDKBuildOS Condition="'$(SKSDKBuildOS)'=='' and '$(TargetPlatformIdentifier)'=='UAP'"            >Uwp</SKSDKBuildOS>
+		<SKSDKBuildOS Condition="'$(SKSDKBuildOS)'=='' and '$(OS)'=='Windows_NT'"                           >Win32</SKSDKBuildOS>
+		<SKSDKBuildOS Condition="'$(SKSDKBuildOS)'=='' and '$(OS)'!='Windows_NT'"                           >Linux</SKSDKBuildOS>
+
+		<!-- Find what architecture we'll want to build. -->
+		<SKSDKBuildMode Condition="'$(SKSDKBuildMode)'=='' and '$(Platform)'=='AnyCPU' and '$(SKSDKBuildOS)'=='Android'">ARM64</SKSDKBuildMode>
+		<SKSDKBuildMode Condition="'$(SKSDKBuildMode)'=='' and '$(Platform)'=='AnyCPU' and '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'X64'">x64</SKSDKBuildMode>
+		<SKSDKBuildMode Condition="'$(SKSDKBuildMode)'=='' and '$(Platform)'=='AnyCPU' and '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'ARM64'">ARM64</SKSDKBuildMode>
+		<SKSDKBuildMode Condition="'$(SKSDKBuildMode)'==''">$(Platform)</SKSDKBuildMode>
+		<SKSDKBuildModePreset Condition="'$(SKSDKBuildMode)'=='x64'">x64</SKSDKBuildModePreset>
+		<SKSDKBuildModePreset Condition="'$(SKSDKBuildMode)'=='ARM64'">Arm64</SKSDKBuildModePreset>
+		<SKSDKBuildModePreset Condition="'$(SKSDKBuildMode)'=='ARM'">Arm32</SKSDKBuildModePreset>
+
+		<!-- Get an ABI name, this is a little different from BuildMode on Android. -->
+		<SKSDKBuildAbi Condition="'$(SKSDKBuildOS)'!='Android'">$(SKSDKBuildMode)</SKSDKBuildAbi>
+		<SKSDKBuildAbi Condition="'$(SKSDKBuildOS)'=='Android' and '$(SKSDKBuildMode)'=='x64'">x86_64</SKSDKBuildAbi>
+		<SKSDKBuildAbi Condition="'$(SKSDKBuildOS)'=='Android' and '$(SKSDKBuildMode)'=='ARM64'">arm64-v8a</SKSDKBuildAbi>
+
+		<!-- Get the SK native binary names, which is different per-platform. -->
+		<SKSDKLibFile Condition="'$(SKSDKBuildOS)'=='Win32' or '$(SKSDKBuildOS)'=='Uwp'"    >StereoKitC.dll</SKSDKLibFile>
+		<SKSDKDbgFile Condition="'$(SKSDKBuildOS)'=='Win32' or '$(SKSDKBuildOS)'=='Uwp'"    >StereoKitC.pdb</SKSDKDbgFile>
+		<SKSDKLibFile Condition="'$(SKSDKBuildOS)'=='Linux' or '$(SKSDKBuildOS)'=='Android'">libStereoKitC.so</SKSDKLibFile>
+		<SKSDKDbgFile Condition="'$(SKSDKBuildOS)'=='Linux' or '$(SKSDKBuildOS)'=='Android'">libStereoKitC.so.dbg</SKSDKDbgFile>
+
+		<!-- Make a normalized path to where the native binaries are built to. -->
+		<SKSDKBinDir>$([MSBuild]::NormalizePath('$(SKSDKFolder)\bin\distribute\bin\$(SKSDKBuildOS)\$(SKSDKBuildAbi)\$(Configuration)\'))</SKSDKBinDir>
+		<SKSDKLibPath>$(SKSDKBinDir)$(SKSDKLibFile)</SKSDKLibPath>
+		<SKSDKDbgPath>$(SKSDKBinDir)$(SKSDKDbgFile)</SKSDKDbgPath>
+
+		<!-- Make a Runtime Id for the binary file. -->
+		<SKSDKRID Condition="'$(SKSDKBuildOS)'=='Win32'"  >win-$(SKSDKBuildMode.ToLower())</SKSDKRID>
+		<SKSDKRID Condition="'$(SKSDKBuildOS)'=='Uwp'"    >win10-$(SKSDKBuildMode.ToLower())</SKSDKRID>
+		<SKSDKRID Condition="'$(SKSDKBuildOS)'=='Linux'"  >linux-$(SKSDKBuildMode.ToLower())</SKSDKRID>
+		<SKSDKRID Condition="'$(SKSDKBuildOS)'=='Android'">android-$(SKSDKBuildAbi)</SKSDKRID>
+	</PropertyGroup>
+
+
+	<!-- Import some key functionality from StereoKit's build system. -->
+	<Import Project="$(SKSDKFolder)\StereoKit\StereoKit.props" />
+	<Import Project="$(SKSDKFolder)\StereoKit\SKAssets.targets" />
+	<Import Project="$(SKSDKFolder)\StereoKit\SKShaders.targets" />
+	<ItemGroup>
+		<ProjectReference Include="$(SKSDKFolder)\StereoKit\StereoKit.csproj" Name="StereoKit"/>
+	</ItemGroup>
+
+	<!-- Make sure the native binaries are built before we try and build this C# project. -->
+	<PropertyGroup>
+		<PreBuildEvent>cd $(SKSDKFolder) &amp;&amp; cmake --preset $(SKSDKBuildOS)_$(SKSDKBuildModePreset)_$(Configuration) &amp;&amp; cmake --build --preset $(SKSDKBuildOS)_$(SKSDKBuildModePreset)_$(Configuration)</PreBuildEvent>
+	</PropertyGroup>
+
+	<!-- Attach the native library binaries. -->
+	<ItemGroup>
+		<None    Condition="'$(SKSDKBuildOS)'!='Uwp'"                               Visible="false" CopyToOutputDirectory="PreserveNewest" Link="runtimes\$(SKSDKRID)\native\$(SKSDKLibFile)" Include="$(SKSDKLibPath)" />
+		<None    Condition="'$(SKSDKBuildOS)'!='Uwp' and Exists('$(SKSDKDbgPath)')" Visible="false" CopyToOutputDirectory="PreserveNewest" Link="runtimes\$(SKSDKRID)\native\$(SKSDKDbgFile)" Include="$(SKSDKDbgPath)" />
+		<Content Condition="'$(SKSDKBuildOS)'=='Uwp'"                               Visible="false" CopyToOutputDirectory="PreserveNewest" Include="$(SKSDKLibPath)" />
+		<Content Condition="'$(SKSDKBuildOS)'=='Uwp' and Exists('$(SKSDKDbgPath)')" Visible="false" CopyToOutputDirectory="PreserveNewest" Include="$(SKSDKDbgPath)" />
+	</ItemGroup>
+
+	<!-- Android binaries are included differently. -->
+	<ItemGroup Condition="'$(SKSDKBuildOS)'=='Android'">
+		<!-- <None                 Visible="false" CopyToOutputDirectory="PreserveNewest" Abi="$(SKSDKBuildAbi)" Include="$(SKSDKDbgPath)" /> -->
+		<AndroidNativeLibrary Visible="false" CopyToOutputDirectory="PreserveNewest" Abi="$(SKSDKBuildAbi)" Include="$(SKSDKLibPath)" />
+		<AndroidNativeLibrary Visible="false" CopyToOutputDirectory="PreserveNewest" Abi="$(SKSDKBuildAbi)" Include="$(SKSDKBinDir)$(SKOpenXRLoader.ToLower())\*.so" />
+		<AndroidNativeLibrary Visible="false" CopyToOutputDirectory="PreserveNewest" Abi="$(SKSDKBuildAbi)" Include="$(SKOpenXRLoaderFolder)\$(SKOpenXRLoader)\$(SKSDKBuildMode.ToLower())\*.so" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(SKSDKBuildOS)'=='Uwp'">
+		<!-- Needed for ucrtbased.dll when running a debug build. -->
+		<SDKReference Condition="'$(Configuration)' == 'Debug'" Include="Microsoft.VCLibs, Version=14.0" />
+	</ItemGroup>
+
+	<!-- Full rebuilds of this project should also be full rebuilds of StereoKit. -->
+	<Target Name="SKSDKRebuild" AfterTargets="Clean">
+		<RemoveDir Condition="'$(SKSDKBuildOS)'=='Win32' or  '$(SKSDKBuildOS)'=='Uwp'" Directories="$(SKSDKFolder)\bin\intermediate\$(SKSDKBuildOS)_$(SKSDKBuildMode)" />
+		<RemoveDir Condition="'$(SKSDKBuildOS)'!='Win32' and '$(SKSDKBuildOS)'!='Uwp'" Directories="$(SKSDKFolder)\bin\intermediate\$(SKSDKBuildOS)_$(SKSDKBuildMode)_$(Configuration)" />
+	</Target>
+	
+	<!-- Error out if StereoKitC hasn't successfully built! -->
+	<Target Name="SKSDKCheckBuildFiles" BeforeTargets="BeforeBuild">
+		<Message Text="BeforeBuild: Using $(SKSDKBuildOS) StereoKitC from $(SKSDKLibPath)." Importance="High"/>
+		<Error Condition="!Exists('$(SKSDKLibPath)')" Text="StereoKitC was not properly built! Binary file $(SKSDKLibPath) is missing." />
+	</Target>
+	<Target Name="SKSDKCheckBuildFiles2" BeforeTargets="Build">
+		<Message Text="Build: Using $(SKSDKBuildOS) StereoKitC from $(SKSDKLibPath)." Importance="High"/>
+	</Target>
+</Project>

--- a/StereoKit/BuildStereoKitSDK.targets
+++ b/StereoKit/BuildStereoKitSDK.targets
@@ -62,7 +62,13 @@
 
 	<!-- Make sure the native binaries are built before we try and build this C# project. -->
 	<PropertyGroup>
-		<PreBuildEvent>cd $(SKSDKFolder) &amp;&amp; cmake --preset $(SKSDKBuildOS)_$(SKSDKBuildModePreset)_$(Configuration) &amp;&amp; cmake --build --preset $(SKSDKBuildOS)_$(SKSDKBuildModePreset)_$(Configuration)</PreBuildEvent>
+		<SKSDKPreset>$(SKSDKBuildOS)_$(SKSDKBuildModePreset)_$(Configuration)_Fast</SKSDKPreset>
+		<SKSDKCacheFile Condition="'$(SKSDKBuildOS)'=='Win32' or '$(SKSDKBuildOS)'=='Uwp'">$(SKSDKBuildOS)\bin\intermediate\$(SKSDKBuildOS)_$(SKSDKBuildModePreset)\CMakeCache.txt</SKSDKCacheFile>
+		<SKSDKCacheFile Condition="'$(SKSDKCacheFile)'==''"                               >$(SKSDKBuildOS)\bin\intermediate\$(SKSDKBuildOS)_$(SKSDKBuildModePreset)_$(Configuration)\CMakeCache.txt</SKSDKCacheFile>
+
+		<PreBuildEvent                                         >cd $(SKSDKFolder)</PreBuildEvent>
+		<PreBuildEvent Condition="!Exists('$(SKSDKCacheFile)')">$(PreBuildEvent) &amp;&amp; cmake --preset $(SKSDKPreset) -DSK_BUILD_TESTS=OFF</PreBuildEvent>
+		<PreBuildEvent                                         >$(PreBuildEvent) &amp;&amp; cmake --build --preset $(SKSDKPreset)</PreBuildEvent>
 	</PropertyGroup>
 
 	<!-- Attach the native library binaries. -->

--- a/StereoKit/BuildStereoKitSDK.targets
+++ b/StereoKit/BuildStereoKitSDK.targets
@@ -94,10 +94,6 @@
 	
 	<!-- Error out if StereoKitC hasn't successfully built! -->
 	<Target Name="SKSDKCheckBuildFiles" BeforeTargets="BeforeBuild">
-		<Message Text="BeforeBuild: Using $(SKSDKBuildOS) StereoKitC from $(SKSDKLibPath)." Importance="High"/>
 		<Error Condition="!Exists('$(SKSDKLibPath)')" Text="StereoKitC was not properly built! Binary file $(SKSDKLibPath) is missing." />
-	</Target>
-	<Target Name="SKSDKCheckBuildFiles2" BeforeTargets="Build">
-		<Message Text="Build: Using $(SKSDKBuildOS) StereoKitC from $(SKSDKLibPath)." Importance="High"/>
 	</Target>
 </Project>


### PR DESCRIPTION
This adds an easy way for StereoKit projects to directly consume the StereoKit repository instead of the packages distributed via NuGet! This makes it much easier to use a custom build of StereoKit, whether you're fixing a bug, adding a feature, or just forking around.

In your project's .csproj, just swap the NuGet reference for the new BuildStereoKitSDK.targets file in your local copy of StereoKit, whether through git submodules, or just some other folder on your PC. StereoKit's [test projects](https://github.com/StereoKit/StereoKit/blob/develop/Examples/StereoKitTest/StereoKitTest.csproj) now all use this path.
```xml
<ItemGroup>
	<!-- Instead of this NuGet package reference -->
	<!-- <PackageReference Include="StereoKit" Version="0.3.9" /> -->
</ItemGroup>
<!-- Reference the SDK project's special build file -->
<Import Project="C:\[Path to StereoKit clone]\StereoKit\BuildStereoKitSDK.targets" />
```

You may need to `dotnet restore` after adding this line to your project via CLI for this to behave properly. You will need to be able to build StereoKit locally from source, for instructions and details about this, see [the build guide](https://github.com/StereoKit/StereoKit/blob/develop/BUILDING.md).