### PR TITLE
Text size and clipping

### DIFF
--- a/Examples/StereoKitTest/Tests/TestText.cs
+++ b/Examples/StereoKitTest/Tests/TestText.cs
@@ -1,0 +1,38 @@
+﻿using StereoKit;
+
+class TestText : ITest
+{
+	TextStyle style;
+	string    shortText = "Some short text.";
+	string    longText  = "Twas brillig, and the slithy toves Did gyre and gimble in the wabe: All mimsy were the borogoves, And the mome raths outgrabe.\nBeware the Jabberwock, my son! The jaws that bite, the claws that catch! Beware the Jubjub bird, and shun The frumious Bandersnatch!";
+
+	public void Initialize() {
+		style = TextStyle.FromFont(Font.FromFile("aileron_font.ttf"), 0.02f, Color.White);
+	}
+	public void Shutdown() { }
+	public void Step()
+	{
+		Quat r = Quat.FromAngles(0, 180, 0);
+		Vec3 at = new Vec3(0,0,-0.5f);
+		Text.Add(shortText, Matrix.TR(at, r), style, TextAlign.TopLeft, TextAlign.TopLeft);
+		Vec2 s = Text.Size(shortText);
+		Mesh.Cube.Draw(Material.Unlit, Matrix.TS(at.x + s.x / 2, at.y - s.y / 2, at.z - 0.001f, new Vec3(s.x, s.y, 0.001f)), Color.Black);
+
+		at = new Vec3(0, 0.1f, -0.5f);
+		Text.Add(longText, Matrix.TR(at, r), style, TextAlign.TopLeft, TextAlign.TopLeft);
+		s = Text.Size(longText);
+		Mesh.Cube.Draw(Material.Unlit, Matrix.TS(at.x + s.x / 2, at.y - s.y / 2, at.z - 0.001f, new Vec3(s.x, s.y, 0.001f)), Color.Black) ;
+
+
+		at = new Vec3(0, 0.2f, -0.5f);
+		Text.Add(shortText, Matrix.TR(at, r), new Vec2(0.5f, 0.2f), TextFit.Wrap, style, TextAlign.TopLeft, TextAlign.TopLeft);
+		s = Text.Size(shortText, 0.5f);
+		Mesh.Cube.Draw(Material.Unlit, Matrix.TS(at.x + s.x / 2, at.y - s.y / 2, at.z - 0.001f, new Vec3(s.x, s.y, 0.001f)), Color.Black);
+
+		at = new Vec3(0, 0.5f, -0.5f);
+		Text.Add(longText, Matrix.TR(at, r), new Vec2(0.5f,0.2f), TextFit.Wrap, style, TextAlign.TopLeft, TextAlign.TopLeft);
+		s = Text.Size(longText, 0.5f);
+		Mesh.Cube.Draw(Material.Unlit, Matrix.TS(at.x + s.x / 2, at.y - s.y / 2, at.z - 0.001f, new Vec3(s.x, s.y, 0.001f)), Color.Black);
+
+	}
+}

--- a/Examples/StereoKitTest/Tests/TestText.cs
+++ b/Examples/StereoKitTest/Tests/TestText.cs
@@ -1,5 +1,4 @@
 ﻿using StereoKit;
-using System;
 
 class TestText : ITest
 {
@@ -27,13 +26,14 @@ class TestText : ITest
 
 		at = new Vec3(0, 0.2f, -0.5f);
 		s = Text.Size(shortText, 0.5f);
-		Text.Add(shortText, Matrix.TR(at, r), new Vec2(0.5f, s.y), TextFit.Wrap | TextFit.Clip, style, Color.White, TextAlign.TopLeft, TextAlign.TopLeft, 0.0f, ((float)Math.Sin(Time.Totalf))*s.y, 0);
+		Text.Add(shortText, Matrix.TR(at, r), new Vec2(0.5f, s.y), TextFit.Wrap, style, TextAlign.TopLeft, TextAlign.TopLeft);
 		Mesh.Cube.Draw(Material.Unlit, Matrix.TS(at.x + s.x / 2, at.y - s.y / 2, at.z - 0.001f, new Vec3(s.x, s.y, 0.001f)), Color.Black);
 
 		at = new Vec3(0, 0.5f, -0.5f);
 		s = Text.Size(longText, 0.5f);
-		Text.Add(longText, Matrix.TR(at, r), new Vec2(0.5f,s.y), TextFit.Wrap | TextFit.Clip, style, Color.White, TextAlign.TopLeft, TextAlign.TopLeft, 0.0f, ((float)Math.Sin(Time.Totalf)) * s.y, 0);
+		Text.Add(longText, Matrix.TR(at, r), new Vec2(0.5f,s.y), TextFit.Wrap, style, TextAlign.TopLeft, TextAlign.TopLeft);
 		Mesh.Cube.Draw(Material.Unlit, Matrix.TS(at.x + s.x / 2, at.y - s.y / 2, at.z - 0.001f, new Vec3(s.x, s.y, 0.001f)), Color.Black);
 
+		Tests.Screenshot("Tests/TextSize.jpg", 1, 800, 300, 75, V.XYZ(0.85f, 0.3f, 0.0f), V.XYZ(0.85f, 0.3f, -0.5f));
 	}
 }

--- a/Examples/StereoKitTest/Tests/TestText.cs
+++ b/Examples/StereoKitTest/Tests/TestText.cs
@@ -1,4 +1,5 @@
 ﻿using StereoKit;
+using System;
 
 class TestText : ITest
 {
@@ -25,13 +26,13 @@ class TestText : ITest
 
 
 		at = new Vec3(0, 0.2f, -0.5f);
-		Text.Add(shortText, Matrix.TR(at, r), new Vec2(0.5f, 0.2f), TextFit.Wrap, style, TextAlign.TopLeft, TextAlign.TopLeft);
 		s = Text.Size(shortText, 0.5f);
+		Text.Add(shortText, Matrix.TR(at, r), new Vec2(0.5f, s.y), TextFit.Wrap | TextFit.Clip, style, Color.White, TextAlign.TopLeft, TextAlign.TopLeft, 0.0f, ((float)Math.Sin(Time.Totalf))*s.y, 0);
 		Mesh.Cube.Draw(Material.Unlit, Matrix.TS(at.x + s.x / 2, at.y - s.y / 2, at.z - 0.001f, new Vec3(s.x, s.y, 0.001f)), Color.Black);
 
 		at = new Vec3(0, 0.5f, -0.5f);
-		Text.Add(longText, Matrix.TR(at, r), new Vec2(0.5f,0.2f), TextFit.Wrap, style, TextAlign.TopLeft, TextAlign.TopLeft);
 		s = Text.Size(longText, 0.5f);
+		Text.Add(longText, Matrix.TR(at, r), new Vec2(0.5f,s.y), TextFit.Wrap | TextFit.Clip, style, Color.White, TextAlign.TopLeft, TextAlign.TopLeft, 0.0f, ((float)Math.Sin(Time.Totalf)) * s.y, 0);
 		Mesh.Cube.Draw(Material.Unlit, Matrix.TS(at.x + s.x / 2, at.y - s.y / 2, at.z - 0.001f, new Vec3(s.x, s.y, 0.001f)), Color.Black);
 
 	}

--- a/Examples/StereoKitTest/Tests/TestTextStyle.cs
+++ b/Examples/StereoKitTest/Tests/TestTextStyle.cs
@@ -10,12 +10,12 @@ class TestTextStyle : ITest
 	{
 		Tests.RunForFrames(2);
 		style1 = Text.MakeStyle(
-			Font.FromFile("C:/Windows/Fonts/times.ttf") ?? Default.Font,
+			Font.FromFile("aileron_font.ttf") ?? Default.Font,
 			2 * U.cm,
 			Color.HSV(0,1,1));
 
 		style2 = Text.MakeStyle(
-			Font.FromFile("C:/Windows/Fonts/times.ttf") ?? Default.Font,
+			Font.FromFile("aileron_font.ttf") ?? Default.Font,
 			1 * U.cm,
 			Color.HSV(.33f,.5f,1));
 	}

--- a/StereoKit/Native/NativeAPI.cs
+++ b/StereoKit/Native/NativeAPI.cs
@@ -314,6 +314,7 @@ namespace StereoKit
 		[DllImport(dll, CharSet = CharSet.Unicode, CallingConvention = call)] public static extern void      text_add_at_16        (string text, in Matrix transform, TextStyle style, TextAlign position, TextAlign align, float off_x, float off_y, float off_z, Color vertex_tint_linear);
 		[DllImport(dll, CharSet = CharSet.Unicode, CallingConvention = call)] public static extern float     text_add_in_16        (string text, in Matrix transform, Vec2 size, TextFit fit, TextStyle style, TextAlign position, TextAlign align, float off_x, float off_y, float off_z, Color vertex_tint_linear);
 		[DllImport(dll, CharSet = CharSet.Unicode, CallingConvention = call)] public static extern Vec2      text_size_16          (string text, TextStyle style);
+		[DllImport(dll, CharSet = CharSet.Unicode, CallingConvention = call)] public static extern Vec2      text_size_constrained_16 (string text, TextStyle style, float max_width);
 
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr    text_style_get_material   (TextStyle style);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern float     text_style_get_char_height(TextStyle style);

--- a/StereoKit/Systems/Text.cs
+++ b/StereoKit/Systems/Text.cs
@@ -293,5 +293,27 @@ namespace StereoKit
 		/// <returns>The width and height of the text in meters.</returns>
 		public static Vec2 Size(string text)
 			=> NativeAPI.text_size_16(text, TextStyle.Default);
+
+		/// <summary>Need to know how much space text will take when
+		/// constrained to a certain width? This will find it using the default
+		/// text style!</summary>
+		/// <param name="text">Text to measure the size of.</param>
+		/// <param name="maxWidth">Width of the available space in meters.</param>
+		/// <returns>The size that this text will take up, in meters! Width
+		/// will be the same as maxWidth as long as the text takes more than
+		/// one line, and height will be the total height of the text.</returns>
+		public static Vec2 Size(string text, float maxWidth)
+			=> NativeAPI.text_size_constrained_16(text, TextStyle.Default, maxWidth);
+
+		/// <summary>Need to know how much space text will take when
+		/// constrained to a certain width? This will find it using the
+		/// indicated text style!</summary>
+		/// <param name="text">Text to measure the size of.</param>
+		/// <param name="maxWidth">Width of the available space in meters.</param>
+		/// <returns>The size that this text will take up, in meters! Width
+		/// will be the same as maxWidth as long as the text takes more than
+		/// one line, and height will be the total height of the text.</returns>
+		public static Vec2 Size(string text, TextStyle style, float maxWidth)
+			=> NativeAPI.text_size_constrained_16(text, style, maxWidth);
 	}
 }

--- a/StereoKitC/stereokit.h
+++ b/StereoKitC/stereokit.h
@@ -1327,6 +1327,8 @@ SK_API float         text_add_in                   (const char*     text_utf8,  
 SK_API float         text_add_in_16                (const char16_t* text_utf16, const sk_ref(matrix)  transform, vec2 size, text_fit_ fit, text_style_t style sk_default(0), text_align_ position sk_default(text_align_center), text_align_ align sk_default(text_align_center), float off_x sk_default(0), float off_y sk_default(0), float off_z sk_default(0), color128 vertex_tint_linear sk_default({1,1,1,1}));
 SK_API vec2          text_size                     (const char*     text_utf8,  text_style_t style sk_default(0));
 SK_API vec2          text_size_16                  (const char16_t* text_utf16, text_style_t style sk_default(0));
+SK_API vec2          text_size_constrained         (const char*     text_utf8,  text_style_t style, float max_width);
+SK_API vec2          text_size_constrained_16      (const char16_t* text_utf16, text_style_t style, float max_width);
 SK_API vec2          text_char_at                  (const char*     text_utf8,  text_style_t style, int32_t char_index, vec2 *opt_size, text_fit_ fit, text_align_ position, text_align_ align);
 SK_API vec2          text_char_at_16               (const char16_t* text_utf16, text_style_t style, int32_t char_index, vec2 *opt_size, text_fit_ fit, text_align_ position, text_align_ align);
 

--- a/StereoKitC/systems/text.cpp
+++ b/StereoKitC/systems/text.cpp
@@ -546,7 +546,7 @@ float text_add_in_g(const C* text, const matrix& transform, vec2 size, text_fit_
 	step.wrap   = fit & text_fit_wrap;
 	step.style  = &text_styles[style];
 	step.bounds = size;
-	step.start  = { off_x, off_y };
+	step.start  = { };
 
 	// Debug draw bounds
 	/*vec2 dbg_start = step.start;
@@ -591,6 +591,9 @@ float text_add_in_g(const C* text, const matrix& transform, vec2 size, text_fit_
 	else if (position & text_align_x_right)  step.start.x += step.bounds.x;
 	if      (position & text_align_y_center) step.start.y += step.bounds.y / 2.f;
 	else if (position & text_align_y_bottom) step.start.y += step.bounds.y;
+	vec2 bounds_min = step.start - step.bounds;
+	vec2 bounds_max = step.start;
+	step.start += vec2{ off_x, off_y };
 	step.pos = step.start;
 
 	// Figure out the vertical align of the text
@@ -605,15 +608,14 @@ float text_add_in_g(const C* text, const matrix& transform, vec2 size, text_fit_
 	color32 color = color_to_32( color32_to_128(step.style->color) * vertex_tint_linear );
 
 	// Core loop for drawing the text
-	vec2     bounds_min = step.start - step.bounds;
-	bool     clip       = fit & text_fit_clip;
-	char32_t c          = 0;
+	bool     clip = fit & text_fit_clip;
+	char32_t c    = 0;
 	text_step_next_line<C, char_decode_b_T>(text, step.style, step.align, step.wrap, step.bounds.x, step.start.x, &step.line_remaining, &step.pos);
 	if (clip) {
 		while(char_decode_b_T(text, &text, &c)) {
 			const font_char_t *char_info = font_get_glyph(step.style->font, c);
 			if (!text_is_space(c)) {
-				text_add_quad_clipped(step.pos.x, step.pos.y, off_z, bounds_min, step.start, char_info, *step.style, color, buffer, tr, normal, up, right);
+				text_add_quad_clipped(step.pos.x, step.pos.y, off_z, bounds_min, bounds_max, char_info, *step.style, color, buffer, tr, normal, up, right);
 			}
 			text_step_position<C, char_decode_b_T>(c, char_info, text, step.style, step.align, step.wrap, step.bounds.x, step.start.x, &step.line_remaining, &step.pos);
 		}

--- a/StereoKitC/systems/text.cpp
+++ b/StereoKitC/systems/text.cpp
@@ -52,10 +52,10 @@ struct text_stepper_t {
 array_t<_text_style_t> text_styles  = {};
 array_t<text_buffer_t> text_buffers = {};
 
-template<typename C, bool (*char_decode_b_T)(const C*, const C**, char32_t*)>
+/*template<typename C, bool (*char_decode_b_T)(const C*, const C**, char32_t*)>
 float text_step_height(const C* text, int32_t* out_length, const text_stepper_t& step);
 template<typename C, bool (*char_decode_b_T)(const C*, const C**, char32_t*)>
-void text_step_next_line(const C* start, text_stepper_t& step);
+void text_step_next_line(const C* start, text_stepper_t& step);*/
 
 ///////////////////////////////////////////
 
@@ -204,6 +204,29 @@ void text_style_set_char_height(text_style_t style, float height_meters) {
 
 ///////////////////////////////////////////
 
+template<typename C, bool (*char_decode_b_T)(const C*, const C**, char32_t*)>
+inline vec2 text_size_constrained_g(const C* text, text_style_t style_id, float max_width) {
+	const _text_style_t* style = &text_styles[style_id];
+
+	const C *curr           = text;
+	int32_t  line_count     = 1;
+	int32_t  line_remaining = 0;
+	float    largest_width  = text_step_line_length<C, char_decode_b_T>(curr, &line_remaining, &curr, style, true, max_width);
+	while (*curr != 0) {
+		float curr_width = text_step_line_length<C, char_decode_b_T>(curr, &line_remaining, &curr, style, true, max_width);
+		if (largest_width < curr_width)
+			largest_width = curr_width;
+		line_count += 1;
+	}
+
+	return {line_count > 1 ? max_width : largest_width, (line_count + (line_count - 1) * style->line_spacing) * style->char_height };
+}
+
+vec2 text_size_constrained   (const char     *text_utf8,  text_style_t style, float max_width) { return text_size_constrained_g<char,     utf8_decode_fast_b >(text_utf8,  style, max_width); }
+vec2 text_size_constrained_16(const char16_t* text_utf16, text_style_t style, float max_width) { return text_size_constrained_g<char16_t, utf16_decode_fast_b>(text_utf16, style, max_width); }
+
+///////////////////////////////////////////
+
 template<typename C, bool (*char_decode_b_T)(const C *, const C **, char32_t *)>
 inline vec2 text_size_g(const C *text, text_style_t style) {
 	if (text == nullptr) return {};
@@ -266,7 +289,7 @@ inline vec2 text_char_at_g(const C *text, text_style_t style, int32_t char_index
 
 	// Calculate the strlen and text height for verical centering
 	int32_t text_length = 0;
-	float   text_height = text_step_height<C, char_decode_b_T>(text, &text_length, step);
+	float   text_height = text_step_height<C, char_decode_b_T>(text, &text_length, step.style, step.wrap, step.bounds.x);
 	// if the size is still zero, then lets use the calculated height
 	if (step.bounds.y == 0)
 		step.bounds.y = text_height;
@@ -287,7 +310,7 @@ inline vec2 text_char_at_g(const C *text, text_style_t style, int32_t char_index
 	char32_t c          = 0;
 	int32_t  count      = 0;
 	if (*text != '\0')
-		text_step_next_line<C, char_decode_b_T>(text, step);
+		text_step_next_line<C, char_decode_b_T>(text, step.style, step.align, step.wrap, step.bounds.x, step.start.x, &step.line_remaining, &step.pos);
 	while(char_decode_b_T(text, &text, &c)) {
 		if (count == char_index) {
 			return step.pos;
@@ -296,7 +319,7 @@ inline vec2 text_char_at_g(const C *text, text_style_t style, int32_t char_index
 		
 		step.line_remaining--;
 		if (step.line_remaining <= 0 && *text != '\0') {
-			text_step_next_line<C, char_decode_b_T>(text, step);
+			text_step_next_line<C, char_decode_b_T>(text, step.style, step.align, step.wrap, step.bounds.x, step.start.x, &step.line_remaining, &step.pos);
 			step.pos.y -= step.style->char_height * step.style->line_spacing;
 		} else if (c != '\n') {
 			step.pos.x -= char_info->xadvance * step.style->char_height;
@@ -313,23 +336,23 @@ vec2 text_char_at_16(const char16_t* text_utf16, text_style_t style, int32_t cha
 ///////////////////////////////////////////
 
 template<typename C, bool (*char_decode_b_T)(const C *, const C **, char32_t *)>
-float text_step_line_length(const C *start, int32_t *out_char_count, const C **out_next_start, const text_stepper_t &step) {
+float text_step_line_length(const C *start, int32_t *out_char_count, const C **out_next_start, const _text_style_t *style, bool wrap, float max_width) {
 	// If we're not wrapping, this is really simple
-	if (!step.wrap) {
-		const C *curr  = start;
+	if (wrap == false) {
+		const C* curr  = start;
 		char32_t ch    = 0;
 		float    width = 0;
 		int32_t  count = 0;
 		while (char_decode_b_T(curr, &curr, &ch) && ch != '\n') {
-			width += font_get_glyph(step.style->font, ch)->xadvance;
+			width += font_get_glyph(style->font, ch)->xadvance;
 			count++;
 		}
-		*out_char_count = ch == '\n' ? count+1 : count;
+		*out_char_count = ch == '\n' ? count + 1 : count;
 		*out_next_start = curr;
-		return width * step.style->char_height;
+		return width * style->char_height;
 	}
 
-	// Otherwise, we gotta do it the tricky way
+	// If we _are_ wrapping, we gotta do it the tricky way
 	float    curr_width = 0;
 	float    last_width = 0;
 	int32_t  last_count = 0;
@@ -357,11 +380,11 @@ float text_step_line_length(const C *start, int32_t *out_char_count, const C **o
 			break;
 
 		// Advance by character width
-		const font_char_t *char_info  = font_get_glyph(step.style->font, curr);
-		float              next_width = char_info->xadvance*step.style->char_height + curr_width;
+		const font_char_t *char_info  = font_get_glyph(style->font, curr);
+		float              next_width = char_info->xadvance*style->char_height + curr_width;
 
 		// Check if it steps out of bounds
-		if (!is_break && next_width > step.bounds.x) {
+		if (!is_break && next_width > max_width) {
 			// If there were no breaks in this line, set to the previous character
 			if (last_width == 0) {
 				last_width = curr_width;
@@ -387,46 +410,46 @@ float text_step_line_length(const C *start, int32_t *out_char_count, const C **o
 ///////////////////////////////////////////
 
 template<typename C, bool (*char_decode_b_T)(const C *, const C **, char32_t *)>
-float text_step_height(const C *text, int32_t *out_length, const text_stepper_t &step) {
+float text_step_height(const C *text, int32_t *out_length, const _text_style_t *style, bool wrap, float max_width) {
 	int32_t  count  = 1;
 	int32_t  length = 0;
 	const C *curr   = text;
 	float    height = 0;
 	while (count > 0) {
-		text_step_line_length<C, char_decode_b_T>(curr, &count, &curr, step);
+		text_step_line_length<C, char_decode_b_T>(curr, &count, &curr, style, wrap, max_width);
 		length += count;
 		if (count > 0)
 			height += 1;
 	}
 
 	*out_length = length;
-	return (height + (height-1)*step.style->line_spacing) * step.style->char_height;
+	return (height + (height-1)*style->line_spacing) * style->char_height;
 }
 
 ///
 
 template<typename C, bool (*char_decode_b_T)(const C *, const C **, char32_t *)>
-void text_step_next_line(const C *start, text_stepper_t &step) {
+void text_step_next_line(const C *start, const _text_style_t* style, text_align_ align, bool wrap, float max_width, float start_x, int32_t *out_line_remaining, vec2 *ref_pos) {
 	const C *next;
-	float line_size  = text_step_line_length<C, char_decode_b_T>(start, &step.line_remaining, &next, step);
+	float line_size  = text_step_line_length<C, char_decode_b_T>(start, out_line_remaining, &next, style, wrap, max_width);
 	float align_x    = 0;
-	if (step.align & text_align_x_center) align_x = ((step.bounds.x - line_size) / 2.f);
-	if (step.align & text_align_x_right)  align_x =  (step.bounds.x - line_size);
-	step.pos.x  = step.start.x - align_x;
-	step.pos.y -= step.style->char_height;
+	if (align & text_align_x_center) align_x = ((max_width - line_size) / 2.f);
+	if (align & text_align_x_right)  align_x =  (max_width - line_size);
+	ref_pos->x  = start_x - align_x;
+	ref_pos->y -= style->char_height;
 }
 
 template<typename C, bool (*char_decode_b_T)(const C *, const C **, char32_t *)>
-void text_step_position(char32_t ch, const font_char_t *char_info, const C *next, text_stepper_t &step) {
-	step.line_remaining--;
-	if (step.line_remaining <= 0) {
-		text_step_next_line<C, char_decode_b_T>(next, step);
-		step.pos.y -= step.style->char_height * step.style->line_spacing;
+void text_step_position(char32_t ch, const font_char_t *char_info, const C *next, const _text_style_t* style, text_align_ align, bool wrap, float max_width, float start_x, int32_t* ref_line_remaining, vec2* ref_pos) {
+	*ref_line_remaining = *ref_line_remaining - 1;
+	if (*ref_line_remaining <= 0) {
+		text_step_next_line<C, char_decode_b_T>(next, style, align, wrap, max_width, start_x, ref_line_remaining, ref_pos);
+		ref_pos->y -= style->char_height * style->line_spacing;
 		return;
 	}
 
 	if (ch != '\n'){
-		step.pos.x -= char_info->xadvance*step.style->char_height;
+		ref_pos->x -= char_info->xadvance*style->char_height;
 	}
 }
 
@@ -558,7 +581,7 @@ float text_add_in_g(const C* text, const matrix& transform, vec2 size, text_fit_
 
 	// Calculate the strlen and text height for verical centering
 	int32_t text_length = 0;
-	float   text_height = text_step_height<C, char_decode_b_T>(text, &text_length, step);
+	float   text_height = text_step_height<C, char_decode_b_T>(text, &text_length, step.style, step.wrap, step.bounds.x);
 	// if the size is still zero, then lets use the calculated height
 	if (step.bounds.y == 0)
 		step.bounds.y = text_height;
@@ -585,14 +608,14 @@ float text_add_in_g(const C* text, const matrix& transform, vec2 size, text_fit_
 	vec2     bounds_min = step.start - step.bounds;
 	bool     clip       = fit & text_fit_clip;
 	char32_t c          = 0;
-	text_step_next_line<C, char_decode_b_T>(text, step);
+	text_step_next_line<C, char_decode_b_T>(text, step.style, step.align, step.wrap, step.bounds.x, step.start.x, &step.line_remaining, &step.pos);
 	if (clip) {
 		while(char_decode_b_T(text, &text, &c)) {
 			const font_char_t *char_info = font_get_glyph(step.style->font, c);
 			if (!text_is_space(c)) {
 				text_add_quad_clipped(step.pos.x, step.pos.y, off_z, bounds_min, step.start, char_info, *step.style, color, buffer, tr, normal, up, right);
 			}
-			text_step_position<C, char_decode_b_T>(c, char_info, text, step);
+			text_step_position<C, char_decode_b_T>(c, char_info, text, step.style, step.align, step.wrap, step.bounds.x, step.start.x, &step.line_remaining, &step.pos);
 		}
 	} else {
 		while (char_decode_b_T(text, &text, &c)) {
@@ -600,7 +623,7 @@ float text_add_in_g(const C* text, const matrix& transform, vec2 size, text_fit_
 			if (!text_is_space(c)) {
 				text_add_quad(step.pos.x, step.pos.y, off_z, char_info, *step.style, color, buffer, base, normal, up, right);
 			}
-			text_step_position<C, char_decode_b_T>(c, char_info, text, step);
+			text_step_position<C, char_decode_b_T>(c, char_info, text, step.style, step.align, step.wrap, step.bounds.x, step.start.x, &step.line_remaining, &step.pos);
 		}
 	}
 	return (step.start.y - step.pos.y) - step.style->char_height;


### PR DESCRIPTION
This adds a `Text.Size` overload that adds an available width constraint for determining the size of wrapped text!

Also made it so that `Text.Add` offset parameters no longer affect the location of the clipping region. This allows for offsets to be used to scroll and clip text inside of the available text area.