### PR TITLE
Add scrolling ability to UI.Text.

### DIFF
--- a/StereoKit/Native/NativeAPI.cs
+++ b/StereoKit/Native/NativeAPI.cs
@@ -768,7 +768,6 @@ namespace StereoKit
 		[DllImport(dll, CharSet = CharSet.Unicode, CallingConvention = call)] public static extern BtnState ui_volume_at_16      (string id, Bounds bounds, UIConfirm interact_type, IntPtr out_opt_hand, IntPtr out_opt_focus_state);
 		[DllImport(dll, CharSet = CharSet.Unicode, CallingConvention = call)] public static extern BtnState ui_volume_at_16      (string id, Bounds bounds, UIConfirm interact_type, out Handed out_opt_hand, IntPtr out_opt_focus_state);
 		[DllImport(dll, CharSet = CharSet.Unicode, CallingConvention = call)] public static extern BtnState ui_volume_at_16      (string id, Bounds bounds, UIConfirm interact_type, out Handed out_opt_hand, out BtnState out_opt_focus_state);
-		[DllImport(dll, CharSet = CharSet.Unicode, CallingConvention = call)] public static extern void     ui_text_at_16        (string text, TextAlign text_align, TextFit fit, Vec3 window_relative_pos, Vec2 size);
 		[return: MarshalAs(UnmanagedType.Bool)]
 		[DllImport(dll, CharSet = CharSet.Unicode, CallingConvention = call)] public static extern bool     ui_button_at_16      (string text, Vec3 window_relative_pos, Vec2 size);
 		[return: MarshalAs(UnmanagedType.Bool)]
@@ -792,8 +791,18 @@ namespace StereoKit
 		[DllImport(dll, CharSet = cSet,            CallingConvention = call)] public static extern void ui_hseparator      ();
 		[DllImport(dll, CharSet = CharSet.Unicode, CallingConvention = call)] public static extern void ui_label_16        (string text, [MarshalAs(UnmanagedType.Bool)] bool use_padding);
 		[DllImport(dll, CharSet = CharSet.Unicode, CallingConvention = call)] public static extern void ui_label_sz_16     (string text, Vec2 size, [MarshalAs(UnmanagedType.Bool)] bool use_padding);
-		[DllImport(dll, CharSet = CharSet.Unicode, CallingConvention = call)] public static extern void ui_text_16         (string text, TextAlign text_align);
-		[DllImport(dll, CharSet = CharSet.Unicode, CallingConvention = call)] public static extern void ui_text_sz_16      (string text, TextAlign text_align, TextFit fit, Vec2 size);
+		[return: MarshalAs(UnmanagedType.Bool)]
+		[DllImport(dll, CharSet = CharSet.Unicode, CallingConvention = call)] public static extern bool ui_text_16         (string text, ref Vec2 scroll, UIScroll scrollDirection, float height, TextAlign text_align, TextFit fit);
+		[return: MarshalAs(UnmanagedType.Bool)]
+		[DllImport(dll, CharSet = CharSet.Unicode, CallingConvention = call)] public static extern bool ui_text_16         (string text, IntPtr   scroll, UIScroll scrollDirection, float height, TextAlign text_align, TextFit fit);
+		[return: MarshalAs(UnmanagedType.Bool)]
+		[DllImport(dll, CharSet = CharSet.Unicode, CallingConvention = call)] public static extern bool ui_text_sz_16      (string text, ref Vec2 scroll, UIScroll scrollDirection, Vec2  size,   TextAlign text_align, TextFit fit);
+		[return: MarshalAs(UnmanagedType.Bool)]
+		[DllImport(dll, CharSet = CharSet.Unicode, CallingConvention = call)] public static extern bool ui_text_sz_16      (string text, IntPtr   scroll, UIScroll scrollDirection, Vec2  size,   TextAlign text_align, TextFit fit);
+		[return: MarshalAs(UnmanagedType.Bool)]
+		[DllImport(dll, CharSet = CharSet.Unicode, CallingConvention = call)] public static extern bool ui_text_at_16      (string text, ref Vec2 scroll, UIScroll scrollDirection, TextAlign text_align, TextFit fit, Vec3 window_relative_pos, Vec2 size);
+		[return: MarshalAs(UnmanagedType.Bool)]
+		[DllImport(dll, CharSet = CharSet.Unicode, CallingConvention = call)] public static extern bool ui_text_at_16      (string text, IntPtr   scroll, UIScroll scrollDirection, TextAlign text_align, TextFit fit, Vec3 window_relative_pos, Vec2 size);
 		[DllImport(dll, CharSet = cSet,            CallingConvention = call)] public static extern void ui_image           (IntPtr sprite_image, Vec2 size);
 		[return: MarshalAs(UnmanagedType.Bool)]
 		[DllImport(dll, CharSet = CharSet.Unicode, CallingConvention = call)] public static extern bool ui_button_16       (string text);

--- a/StereoKit/Native/NativeTypes.cs
+++ b/StereoKit/Native/NativeTypes.cs
@@ -808,6 +808,24 @@ namespace StereoKit
 		Right  = TopRight   | BottomRight,
 	}
 
+	/// <summary>This describes how UI elements with scrollable regions scroll
+	/// around or use scroll bars! This allows you to enable or disable
+	/// vertical and horizontal scrolling.</summary>
+	public enum UIScroll
+	{
+		/// <summary>No scroll bars or scrolling.</summary>
+		None       = 0,
+		/// <summary>This will enable vertical scroll bars or scrolling.
+		/// </summary>
+		Vertical   = 1 << 0,
+		/// <summary>This will enable horizontal scroll bars or scrolling.
+		/// </summary>
+		Horizontal = 1 << 1,
+		/// <summary>This will enable both vertical and horizontal scroll bars
+		/// or scrolling.</summary>
+		Both = Vertical | Horizontal,
+	}
+
 	/// <summary>A point on a lathe for a mesh generation algorithm. This is the
 	/// 'silhouette' of the mesh, or the shape the mesh would take if you spun
 	/// this line of points in a cylinder.</summary>

--- a/StereoKit/Systems/UI.cs
+++ b/StereoKit/Systems/UI.cs
@@ -369,7 +369,7 @@ namespace StereoKit
 		/// within its bounds? TextAlign.TopLeft is how most English text is
 		/// aligned.</param>
 		public static void Text(string text, TextAlign textAlign = TextAlign.TopLeft)
-			=> NativeAPI.ui_text_16(text, textAlign);
+			=> NativeAPI.ui_text_16(text, IntPtr.Zero, UIScroll.None, 0, textAlign, TextFit.Wrap);
 
 		/// <summary>Displays a large chunk of text on the current layout.
 		/// This can include new lines and spaces, and will properly wrap
@@ -389,7 +389,7 @@ namespace StereoKit
 		/// X this is the remaining width of the current layout, and for Y this
 		/// is UI.LineHeight.</param>
 		public static void Text(string text, TextAlign textAlign, TextFit fit, Vec2 size)
-			=> NativeAPI.ui_text_sz_16(text, textAlign, fit, size);
+			=> NativeAPI.ui_text_sz_16(text, IntPtr.Zero, UIScroll.None, size, textAlign, fit);
 
 		/// <summary>Displays a large chunk of text on the current layout.
 		/// This can include new lines and spaces, and will properly wrap
@@ -409,7 +409,48 @@ namespace StereoKit
 		/// <param name="size">The layout size for this element in Hierarchy
 		/// space.</param>
 		public static void TextAt(string text, TextAlign textAlign, TextFit fit, Vec3 topLeftCorner, Vec2 size)
-			=> NativeAPI.ui_text_at_16(text, textAlign, fit, topLeftCorner, size);
+			=> NativeAPI.ui_text_at_16(text, IntPtr.Zero, UIScroll.None, textAlign, fit, topLeftCorner, size);
+
+		/// <summary>A scrolling text element! This is for reading large chunks
+		/// of text that may be too long to fit in the available space. It
+		/// requires a size, as well as a place to store the current scroll
+		/// value. Text uses the UI's current font settings, which can be
+		/// changed with UI.Push/PopTextStyle.</summary>
+		/// <param name="text">The text you wish to display, there's no
+		/// additional parsing done to this text, so put it in as you want to
+		/// see it!</param>
+		/// <param name="scroll">This is the current scroll value of the text,
+		/// in meters, _not_ percent.</param>
+		/// <param name="scrollDirection">What scroll bars are allowed to show
+		/// on this text? Vertical, horizontal, both?</param>
+		/// <param name="size">The layout size for this element in Hierarchy
+		/// space.</param>
+		/// <param name="textAlign">Where should the text position itself
+		/// within its bounds? TextAlign.TopLeft is how most English text is
+		/// aligned.</param>
+		/// <param name="fit">Describe how the text should behave when one of
+		/// its size dimensions conflicts with the provided 'size' parameter.
+		/// `UI.Text` uses `TextFit.Wrap` by default, and this scrolling
+		/// overload will always add `TextFit.Clip` internally.</param>
+		/// <returns>Returns true if any of the scroll bars have changed this
+		/// frame.</returns>
+		public static bool Text(string text, ref Vec2 scroll, UIScroll scrollDirection, Vec2 size, TextAlign textAlign = TextAlign.TopLeft, TextFit fit = TextFit.Wrap)
+			=> NativeAPI.ui_text_sz_16(text, ref scroll, scrollDirection, size, textAlign, fit);
+
+		/// <inheritdoc cref="Text(string, ref Vec2, UIScroll, Vec2, TextAlign, TextFit)"/>
+		/// <param name="height">The vertical height of this Text element,
+		/// width will automatically take the remainder of the current layout
+		/// width.</param>
+		public static bool Text(string text, ref Vec2 scroll, UIScroll scrollDirection, float height, TextAlign textAlign = TextAlign.TopLeft, TextFit fit = TextFit.Wrap)
+			=> NativeAPI.ui_text_16(text, ref scroll, scrollDirection, height, textAlign, fit);
+
+		/// <inheritdoc cref="Text(string, ref Vec2, UIScroll, Vec2, TextAlign, TextFit)"/>
+		/// <param name="topLeftCorner">This is the top left corner of the UI
+		/// element relative to the current Hierarchy.</param>
+		/// <param name="size">The layout size for this element in Hierarchy
+		/// space.</param>
+		public static bool TextAt(string text, ref Vec2 scroll, UIScroll scrollDirection, TextAlign textAlign, TextFit fit, Vec3 topLeftCorner, Vec2 size)
+			=> NativeAPI.ui_text_at_16(text, ref scroll, scrollDirection, textAlign, fit, topLeftCorner, size);
 
 		/// <summary>Adds an image to the UI!</summary>
 		/// <param name="image">A valid sprite.</param>

--- a/StereoKitC/stereokit.h
+++ b/StereoKitC/stereokit.h
@@ -1265,6 +1265,7 @@ typedef enum text_fit_ {
 	  on going.*/
 	text_fit_overflow       = 1 << 4
 } text_fit_;
+SK_MakeFlag(text_fit_)
 
 /*A bit-flag enum for describing alignment or positioning.
   Items can be combined using the '|' operator, like so:
@@ -1489,6 +1490,7 @@ typedef enum render_clear_ {
 	/*Clear both color and depth data.*/
 	render_clear_all   = render_clear_color | render_clear_depth,
 } render_clear_;
+SK_MakeFlag(render_clear_)
 
 /*The projection mode used by StereoKit for the main camera! You
   can use this with Renderer.Projection. These options are only

--- a/StereoKitC/stereokit_ui.h
+++ b/StereoKitC/stereokit_ui.h
@@ -113,6 +113,15 @@ typedef enum ui_corner_ {
 	ui_corner_left         = ui_corner_top_left    | ui_corner_bottom_left,
 	ui_corner_right        = ui_corner_top_right   | ui_corner_bottom_right,
 } ui_corner_;
+SK_MakeFlag(ui_corner_)
+
+typedef enum ui_scroll_ {
+	ui_scroll_none       = 0,
+	ui_scroll_vertical   = 1 << 0,
+	ui_scroll_horizontal = 1 << 1,
+	ui_scroll_both       = ui_scroll_vertical | ui_scroll_horizontal,
+} ui_scroll_;
+SK_MakeFlag(ui_scroll_)
 
 typedef struct ui_lathe_pt_t {
 	vec2     pt;
@@ -210,12 +219,12 @@ SK_API void     ui_label             (const char*     text, bool32_t use_padding
 SK_API void     ui_label_16          (const char16_t* text, bool32_t use_padding sk_default(true));
 SK_API void     ui_label_sz          (const char*     text, vec2 size, bool32_t use_padding sk_default(true));
 SK_API void     ui_label_sz_16       (const char16_t* text, vec2 size, bool32_t use_padding sk_default(true));
-SK_API void     ui_text              (const char*     text, text_align_ text_align sk_default(text_align_top_left));
-SK_API void     ui_text_16           (const char16_t* text, text_align_ text_align sk_default(text_align_top_left));
-SK_API void     ui_text_sz           (const char*     text, text_align_ text_align, text_fit_ fit, vec2 size);
-SK_API void     ui_text_sz_16        (const char16_t* text, text_align_ text_align, text_fit_ fit, vec2 size);
-SK_API void     ui_text_at           (const char*     text, text_align_ text_align, text_fit_ fit, vec3 window_relative_pos, vec2 size);
-SK_API void     ui_text_at_16        (const char16_t* text, text_align_ text_align, text_fit_ fit, vec3 window_relative_pos, vec2 size);
+SK_API bool32_t ui_text              (const char*     text, vec2* opt_ref_scroll sk_default(nullptr), ui_scroll_ scroll_direction sk_default(ui_scroll_vertical), float height sk_default(0), text_align_ text_align sk_default(text_align_top_left), text_fit_ fit sk_default(text_fit_wrap));
+SK_API bool32_t ui_text_16           (const char16_t* text, vec2* opt_ref_scroll sk_default(nullptr), ui_scroll_ scroll_direction sk_default(ui_scroll_vertical), float height sk_default(0), text_align_ text_align sk_default(text_align_top_left), text_fit_ fit sk_default(text_fit_wrap));
+SK_API bool32_t ui_text_sz           (const char*     text, vec2* opt_ref_scroll, ui_scroll_ scroll_direction, vec2 size, text_align_ text_align sk_default(text_align_top_left), text_fit_ fit sk_default(text_fit_wrap));
+SK_API bool32_t ui_text_sz_16        (const char16_t* text, vec2* opt_ref_scroll, ui_scroll_ scroll_direction, vec2 size, text_align_ text_align sk_default(text_align_top_left), text_fit_ fit sk_default(text_fit_wrap));
+SK_API bool32_t ui_text_at           (const char*     text, vec2* opt_ref_scroll, ui_scroll_ scroll_direction,            text_align_ text_align, text_fit_ fit, vec3 window_relative_pos, vec2 size);
+SK_API bool32_t ui_text_at_16        (const char16_t* text, vec2* opt_ref_scroll, ui_scroll_ scroll_direction,            text_align_ text_align, text_fit_ fit, vec3 window_relative_pos, vec2 size);
 SK_API bool32_t ui_button            (const char*     text);
 SK_API bool32_t ui_button_16         (const char16_t* text);
 SK_API bool32_t ui_button_sz         (const char*     text, vec2 size);

--- a/StereoKitC/systems/text.cpp
+++ b/StereoKitC/systems/text.cpp
@@ -272,6 +272,8 @@ template<typename C, bool (*char_decode_b_T)(const C*, const C**, char32_t*)>
 inline vec2 text_size_constrained_g(const C* text, text_style_t style_id, float max_width) {
 	const _text_style_t* style = &text_styles[style_id];
 
+	if (max_width <= 0) return {};
+
 	const C *curr           = text;
 	int32_t  line_count     = 1;
 	int32_t  line_remaining = 0;

--- a/StereoKitC/tools/file_picker.cpp
+++ b/StereoKitC/tools/file_picker.cpp
@@ -481,7 +481,7 @@ void file_picker_update() {
 			ui_push_enabled(fp_active != nullptr);
 			if (ui_button("Open")) { snprintf(fp_filename, sizeof(fp_filename), "%s%c%s", fp_path.folder, platform_path_separator_c, fp_active); fp_call = true; fp_call_status = true; }
 			ui_sameline();
-			ui_text_sz(fp_active ? fp_active : "None selected...", text_align_center_left, text_fit_squeeze, {0,0});
+			ui_text(fp_active ? fp_active : "None selected...", nullptr, ui_scroll_none, ui_line_height(), text_align_center_left, text_fit_none);
 			ui_pop_enabled();
 		} break;
 		}
@@ -557,7 +557,7 @@ void file_picker_update() {
 				if (fp_items[i].file_attr.file) {
 					char buffer[128];
 					snprintf(buffer, sizeof(buffer), "%d KB ", (int32_t)(fp_items[i].file_attr.size / 1024));
-					ui_text_sz(buffer, text_align_center_right, text_fit_clip, { size.x, size.y });
+					ui_text_sz(buffer, nullptr, ui_scroll_none, size, text_align_center_right, text_fit_clip);
 					ui_sameline();
 				} else {
 					ui_layout_reserve(size);

--- a/StereoKitC/ui/stereokit_ui.cpp
+++ b/StereoKitC/ui/stereokit_ui.cpp
@@ -36,6 +36,10 @@ const float    skui_aura_radius    = 0.02f;
 
 ///////////////////////////////////////////
 
+bool32_t ui_text_at(const char16_t* text, vec2* opt_ref_scroll, ui_scroll_ scroll_direction, text_fit_ fit, text_align_ text_align, vec3 window_relative_pos, vec2 size);
+
+///////////////////////////////////////////
+
 bool ui_init() {
 	skui_input_target        = 0;
 	skui_input_carat         = 0;
@@ -141,7 +145,11 @@ void ui_hseparator() {
 
 ///////////////////////////////////////////
 
-vec2 text_size(const char16_t* text_utf16, text_style_t style) { return text_size_16(text_utf16, style); }
+vec2 text_size            (const char16_t* text_utf16, text_style_t style)                  { return text_size_16(text_utf16, style); }
+vec2 text_size_constrained(const char16_t* text_utf16, text_style_t style, float max_width) { return text_size_constrained_16(text_utf16, style, max_width); }
+
+float ui_text_in  (const char*     text, text_align_ position, text_align_ align, text_fit_ fit, vec3 start, vec2 size, vec2 offset) { return text_add_in   (text, matrix_t(start), size, fit, ui_get_text_style(), position, align, offset.x,offset.y,0, ui_is_enabled() ? color128{ 1, 1, 1, 1 } : color128{ .5f, .5f, .5f, 1 }); }
+float ui_text_in  (const char16_t* text, text_align_ position, text_align_ align, text_fit_ fit, vec3 start, vec2 size, vec2 offset) { return text_add_in_16(text, matrix_t(start), size, fit, ui_get_text_style(), position, align, offset.x,offset.y,0, ui_is_enabled() ? color128{ 1, 1, 1, 1 } : color128{ .5f, .5f, .5f, 1 }); }
 
 ///////////////////////////////////////////
 
@@ -154,66 +162,13 @@ void ui_label_sz_g(const C *text, vec2 size, bool32_t use_padding) {
 	vec2 padding = use_padding
 		? vec2{ skui_settings.padding, skui_settings.padding }
 		: vec2{ 0, skui_settings.padding };
-	ui_text_at(text, text_align_center_left, text_fit_squeeze, final_pos - vec3{ padding.x, 0, skui_settings.depth/2}, vec2{final_size.x-padding.x*2, final_size.y});
+	ui_text_in(text, text_align_top_left, text_align_center_left, text_fit_squeeze, final_pos - vec3{ padding.x, 0, skui_settings.depth/2}, vec2{final_size.x-padding.x*2, final_size.y}, vec2_zero);
 }
 void ui_label_sz   (const char     *text, vec2 size, bool32_t use_padding) { ui_label_sz_g<char    >(text, size, use_padding); }
 void ui_label_sz_16(const char16_t *text, vec2 size, bool32_t use_padding) { ui_label_sz_g<char16_t>(text, size, use_padding); }
 
-///////////////////////////////////////////
-
-template<typename C>
-void ui_label_g(const C *text, bool32_t use_padding) {
-	vec2 txt_size = text_size(text, ui_get_text_style());
-	vec2 padding  = use_padding
-		? vec2{skui_settings.padding, skui_settings.padding}*2
-		: vec2{0, skui_settings.padding}*2;
-
-	vec3 final_pos;
-	vec2 final_size;
-	ui_layout_reserve_sz(txt_size + padding, false, &final_pos, &final_size);
-
-	ui_text_at(text, text_align_top_left, text_fit_squeeze, final_pos - vec3{padding.x,padding.y,skui_settings.depth}/2, txt_size);
-}
-void ui_label   (const char     *text, bool32_t use_padding) { ui_label_g<char    >(text, use_padding); }
-void ui_label_16(const char16_t *text, bool32_t use_padding) { ui_label_g<char16_t>(text, use_padding); }
-
-///////////////////////////////////////////
-
-float ui_text_in  (const char*     text, text_align_ position, text_align_ align, text_fit_ fit, vec3 start, vec2 size) { return text_add_in   (text, matrix_identity, size, fit, ui_get_text_style(), position, align, start.x, start.y, start.z, ui_is_enabled() ? color128{ 1, 1, 1, 1 } : color128{ .5f, .5f, .5f, 1 }); }
-float ui_text_in  (const char16_t* text, text_align_ position, text_align_ align, text_fit_ fit, vec3 start, vec2 size) { return text_add_in_16(text, matrix_identity, size, fit, ui_get_text_style(), position, align, start.x, start.y, start.z, ui_is_enabled() ? color128{ 1, 1, 1, 1 } : color128{ .5f, .5f, .5f, 1 }); }
-
-///////////////////////////////////////////
-
-void ui_text_at   (const char*     text, text_align_ align, text_fit_ fit, vec3 start, vec2 size) { text_add_in   (text, matrix_identity, size, fit, ui_get_text_style(), text_align_top_left, align, start.x, start.y, start.z, ui_is_enabled() ? color128{ 1, 1, 1, 1 } : color128{ .5f, .5f, .5f, 1 }); }
-void ui_text_at   (const char16_t* text, text_align_ align, text_fit_ fit, vec3 start, vec2 size) { text_add_in_16(text, matrix_identity, size, fit, ui_get_text_style(), text_align_top_left, align, start.x, start.y, start.z, ui_is_enabled() ? color128{ 1, 1, 1, 1 } : color128{ .5f, .5f, .5f, 1 }); }
-void ui_text_at_16(const char16_t* text, text_align_ align, text_fit_ fit, vec3 start, vec2 size) { text_add_in_16(text, matrix_identity, size, fit, ui_get_text_style(), text_align_top_left, align, start.x, start.y, start.z, ui_is_enabled() ? color128{ 1, 1, 1, 1 } : color128{ .5f, .5f, .5f, 1 }); }
-
-///////////////////////////////////////////
-
-template<typename C>
-void ui_text_sz_g(const C *text, text_align_ text_align, text_fit_ fit, vec2 size) {
-	vec3 final_pos;
-	vec2 final_size;
-	ui_layout_reserve_sz(size, false, &final_pos, &final_size);
-
-	ui_text_at(text, text_align, fit, final_pos - vec3{ 0, 0, skui_settings.depth/2 }, final_size);
-}
-void ui_text_sz   (const char     *text, text_align_ text_align, text_fit_ fit, vec2 size) { ui_text_sz_g<char    >(text, text_align, fit, size); }
-void ui_text_sz_16(const char16_t *text, text_align_ text_align, text_fit_ fit, vec2 size) { ui_text_sz_g<char16_t>(text, text_align, fit, size); }
-
-///////////////////////////////////////////
-
-template<typename C>
-void ui_text_g(const C *text, text_align_ text_align) {
-	vec3 offset = ui_layout_at();
-	vec2 size   = { ui_layout_remaining().x, 0 };
-	vec3 at     = offset - vec3{ 0, 0, skui_settings.depth/2 };
-	size.y = ui_text_in(text, text_align_top_left, text_align, text_fit_wrap, at, size);
-
-	ui_layout_reserve(size);
-}
-void ui_text   (const char     *text, text_align_ text_align) { ui_text_g<char    >(text, text_align); }
-void ui_text_16(const char16_t *text, text_align_ text_align) { ui_text_g<char16_t>(text, text_align); }
+void ui_label   (const char     *text, bool32_t use_padding) { ui_label_sz_g<char    >(text, text_size(text, ui_get_text_style()) + (use_padding ? vec2{ skui_settings.padding, skui_settings.padding }*2 : vec2{ 0, skui_settings.padding }*2), use_padding); }
+void ui_label_16(const char16_t *text, bool32_t use_padding) { ui_label_sz_g<char16_t>(text, text_size(text, ui_get_text_style()) + (use_padding ? vec2{ skui_settings.padding, skui_settings.padding }*2 : vec2{ 0, skui_settings.padding }*2), use_padding); }
 
 ///////////////////////////////////////////
 
@@ -293,7 +248,7 @@ void _ui_button_img_surface(const C* text, sprite_t image, ui_btn_layout_ image_
 		sprite_draw(image, matrix_ts(image_at, { image_size, image_size, image_size }), image_align, color_to_32( final_color ));
 	}
 	if (image_layout != ui_btn_layout_center_no_text)
-		ui_text_in(text, text_align, text_layout, text_fit_squeeze, text_at, text_size);
+		ui_text_in(text, text_align, text_layout, text_fit_squeeze, text_at, text_size, vec2_zero);
 }
 
 ///////////////////////////////////////////
@@ -668,7 +623,7 @@ bool32_t ui_input_g(const C *id, C *buffer, int32_t buffer_size, vec2 size, text
 		}
 	}
 
-	ui_text_at(draw_text, text_align_center_left, text_fit_clip, final_pos - vec3{ skui_settings.padding, 0, skui_settings.depth / 2 + 2 * mm2m }, text_bounds);
+	ui_text_in(draw_text, text_align_top_left, text_align_center_left, text_fit_clip, final_pos - vec3{ skui_settings.padding, 0, skui_settings.depth / 2 + 2 * mm2m }, text_bounds, vec2_zero);
 
 	return result;
 }
@@ -832,6 +787,71 @@ bool32_t ui_vslider_f64_16(const char16_t* name, double& value, double min, doub
 ///////////////////////////////////////////
 
 template<typename C>
+bool32_t ui_text_at_g(const C* text, vec2* opt_ref_scroll, ui_scroll_ scroll_direction, text_align_ text_align, text_fit_ fit, vec3 window_relative_pos, vec2 size) {
+	vec2 txt_bounds = size;
+	bool result     = false;
+
+	if (scroll_direction != ui_scroll_none && opt_ref_scroll != nullptr) {
+		float        scroll_size = ui_line_height();
+		text_style_t style       = ui_get_text_style();
+
+		vec2 txt_size = (fit & text_fit_wrap) > 0
+			? text_size_constrained(text, style, size.x - scroll_size)
+			: text_size            (text, style);
+
+		bool show_vertical   = txt_size.y > size.y && (scroll_direction & ui_scroll_vertical)   > 0;
+		bool show_horizontal = txt_size.x > size.x && (scroll_direction & ui_scroll_horizontal) > 0;
+
+		// Do these separately first so the scroll bars create a little gap at the
+		// corner when both are visible.
+		if (show_vertical)   txt_bounds.x -= scroll_size;
+		if (show_horizontal) txt_bounds.y -= scroll_size;
+
+		ui_push_id(text);
+		if (show_vertical)   result = result || ui_vslider_at("vertical",   opt_ref_scroll->y, 0, fmaxf(0, txt_size.y-scroll_size),  0, window_relative_pos - vec3{ txt_bounds.x, 0, 0 }, vec2{scroll_size, txt_bounds.y}, ui_confirm_push, ui_notify_change);
+		if (show_horizontal) result = result || ui_hslider_at("horizontal", opt_ref_scroll->x, 0, fmaxf(0, txt_size.x-txt_bounds.x), 0, window_relative_pos - vec3{ 0, txt_bounds.y, 0 }, vec2{txt_bounds.x, scroll_size}, ui_confirm_push, ui_notify_change);
+		ui_pop_id();
+
+		// Scrolling texts always need to clip, but it can be a small perf
+		// boost if we don't need to clip.
+		if (show_vertical || show_horizontal)
+			fit |= text_fit_clip;
+	}
+
+	ui_text_in(text, text_align_top_left, text_align, fit, window_relative_pos - vec3{ 0, 0, skui_settings.depth / 2 }, txt_bounds, opt_ref_scroll == nullptr ? vec2_zero : *opt_ref_scroll);
+
+	return result;
+}
+
+bool32_t ui_text_at   (const char16_t* text, vec2* opt_ref_scroll, ui_scroll_ scroll_direction, text_align_ text_align, text_fit_ fit, vec3 window_relative_pos, vec2 size) { return ui_text_at_g<char16_t>(text, opt_ref_scroll, scroll_direction, text_align, fit, window_relative_pos, size); }
+bool32_t ui_text_at   (const char*     text, vec2* opt_ref_scroll, ui_scroll_ scroll_direction, text_align_ text_align, text_fit_ fit, vec3 window_relative_pos, vec2 size) { return ui_text_at_g<char    >(text, opt_ref_scroll, scroll_direction, text_align, fit, window_relative_pos, size); }
+bool32_t ui_text_at_16(const char16_t* text, vec2* opt_ref_scroll, ui_scroll_ scroll_direction, text_align_ text_align, text_fit_ fit, vec3 window_relative_pos, vec2 size) { return ui_text_at_g<char16_t>(text, opt_ref_scroll, scroll_direction, text_align, fit, window_relative_pos, size); }
+
+///////////////////////////////////////////
+
+template<typename C>
+bool32_t ui_text_sz_g(const C* text, vec2* opt_ref_scroll, ui_scroll_ scroll_direction, vec2 size, text_align_ text_align, text_fit_ fit) {
+	if (size.x == 0) size.x = ui_layout_remaining().x;
+	if (size.y == 0) size.y = (fit & text_fit_wrap) > 0
+		? text_size_constrained(text, ui_get_text_style(), size.x).y
+		: text_size            (text, ui_get_text_style()).y;
+
+	vec3 final_pos;
+	vec2 final_size;
+	ui_layout_reserve_sz(size, false, &final_pos, &final_size);
+
+	return ui_text_at_g<C>(text, opt_ref_scroll, scroll_direction, text_align, fit, final_pos, final_size);
+}
+
+bool32_t ui_text_sz   (const char*     text, vec2* opt_ref_scroll, ui_scroll_ scroll_direction, vec2 size, text_align_ text_align, text_fit_ fit) { return ui_text_sz_g<char    >(text, opt_ref_scroll, scroll_direction, size, text_align, fit); }
+bool32_t ui_text_sz_16(const char16_t* text, vec2* opt_ref_scroll, ui_scroll_ scroll_direction, vec2 size, text_align_ text_align, text_fit_ fit) { return ui_text_sz_g<char16_t>(text, opt_ref_scroll, scroll_direction, size, text_align, fit); }
+
+bool32_t ui_text      (const char*     text, vec2* opt_ref_scroll, ui_scroll_ scroll_direction, float height, text_align_ text_align, text_fit_ fit) { return ui_text_sz_g<char    >(text, opt_ref_scroll, scroll_direction, { 0, height }, text_align, fit); }
+bool32_t ui_text_16   (const char16_t* text, vec2* opt_ref_scroll, ui_scroll_ scroll_direction, float height, text_align_ text_align, text_fit_ fit) { return ui_text_sz_g<char16_t>(text, opt_ref_scroll, scroll_direction, { 0, height }, text_align, fit); }
+
+///////////////////////////////////////////
+
+template<typename C>
 void ui_window_begin_g(const C *text, pose_t &pose, vec2 window_size, ui_win_ window_type, ui_move_ move_type) {
 	id_hash_t    hash   = ui_push_id(text);
 	ui_window_id win_id = ui_window_find_or_add(hash, window_size);
@@ -875,7 +895,7 @@ void ui_window_begin_g(const C *text, pose_t &pose, vec2 window_size, ui_win_ wi
 		vec2 size     = vec2{ window_size.x == 0 ? txt_size.x : window_size.x-(skui_settings.margin*2), ui_line_height() };
 		vec3 at       = layout->offset - vec3{ skui_settings.padding, -(size.y+skui_settings.margin), 2*mm2m };
 
-		ui_text_at(text, text_align_center_left, text_fit_squeeze, at, size);
+		ui_text_in(text, text_align_top_left, text_align_center_left, text_fit_squeeze, at, size, vec2_zero);
 
 		float header_width = window_size.x == 0 ? size.x + skui_settings.padding * 2 + skui_settings.margin * 2 : size.x;
 		if (win->curr_size.x < header_width)


### PR DESCRIPTION
This is a breaking change for the C api's ui_text.

This also fixes the height of UI.Text, which previously was maybe half a line too tall! This may result in small changes in layout height, and can be particularly noticeable if you were previously vertically centering your text, especially with single line text content.