### PR TITLE
Added `HierarchyParent` enum.

### DIFF
--- a/Examples/StereoKitTest/Docs/DocUI.cs
+++ b/Examples/StereoKitTest/Docs/DocUI.cs
@@ -215,7 +215,7 @@ class DocUI : ITest
 			}
 			UI.PopEnabled();
 
-			UI.PushEnabled(true, true);
+			UI.PushEnabled(true, HierarchyParent.Ignore);
 			{
 				// This label was enabled, overriding the parent, and so is
 				// enabled.

--- a/Examples/StereoKitTest/Tests/TestHierarchy.cs
+++ b/Examples/StereoKitTest/Tests/TestHierarchy.cs
@@ -1,0 +1,32 @@
+﻿using StereoKit;
+
+class TestHierarchy : ITest
+{
+	public void Initialize() {}
+	public void Shutdown() {}
+
+	public void Step()
+	{
+		// A simple test for verifying inheriting vs ignoring in transform
+		// hierarchies.
+		Hierarchy.Push(Matrix.TS(0,0,-0.5f, 0.5f));
+			Mesh.Cube.Draw(Material.Default, Matrix.S(0.1f), Color.HSV(0,0.7f,1.0f));
+
+			Hierarchy.Push(Matrix.TS(0.25f, 0, -0.5f, 0.5f), HierarchyParent.Inherit);
+				Mesh.Cube.Draw(Material.Default, Matrix.S(0.1f), Color.HSV(0.3f, 0.7f, 1.0f));
+				Tests.Test(TestInheritHierarchy);
+			Hierarchy.Pop();
+
+			Hierarchy.Push(Matrix.TS(0.25f,0, -0.5f, 0.5f), HierarchyParent.Ignore);
+				Mesh.Cube.Draw(Material.Default, Matrix.S(0.1f), Color.HSV(0.6f, 0.7f, 1.0f));
+				Tests.Test(TestIgnoreHierarchy);
+			Hierarchy.Pop();
+
+		Hierarchy.Pop();
+
+		Tests.Screenshot("Tests/Hierarchy.jpg", 400, 200, 20, V.XYZ(0.125f, 0, 0), V.XYZ(0.125f, 0, -0.5f));
+	}
+
+	bool TestInheritHierarchy() => Vec3.Distance( Hierarchy.ToWorld(Vec3.Zero), new Vec3(0.125f, 0, -0.75f) ) < 0.00001f;
+	bool TestIgnoreHierarchy () => Vec3.Distance( Hierarchy.ToWorld(Vec3.Zero), new Vec3(0.25f, 0, -0.5f) ) < 0.00001f;
+}

--- a/StereoKit/Native/NativeAPI.cs
+++ b/StereoKit/Native/NativeAPI.cs
@@ -727,7 +727,7 @@ namespace StereoKit
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern TextStyle ui_get_text_style   ();
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void ui_push_tint             (Color tint_gamma);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void ui_pop_tint              ();
-		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void ui_push_enabled          ([MarshalAs(UnmanagedType.Bool)] bool enabled, [MarshalAs(UnmanagedType.Bool)] bool ignoreParent);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void ui_push_enabled          ([MarshalAs(UnmanagedType.Bool)] bool enabled, HierarchyParent parentBehavior);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void ui_pop_enabled           ();
 		[return: MarshalAs(UnmanagedType.Bool)]
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern bool ui_is_enabled            ();

--- a/StereoKit/Native/NativeAPI.cs
+++ b/StereoKit/Native/NativeAPI.cs
@@ -464,7 +464,7 @@ namespace StereoKit
 
 		///////////////////////////////////////////
 
-		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void hierarchy_push(in Matrix transform);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void hierarchy_push(in Matrix transform, HierarchyParent parentBehavior);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void hierarchy_pop();
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void hierarchy_set_enabled([MarshalAs(UnmanagedType.Bool)] bool enabled);
 		[return: MarshalAs(UnmanagedType.Bool)]

--- a/StereoKit/Native/NativeEnums.cs
+++ b/StereoKit/Native/NativeEnums.cs
@@ -751,6 +751,19 @@ namespace StereoKit
 		Ortho        = 1,
 	}
 
+	/// <summary>When used with a hierarchy modifying function that will push/pop items onto a
+	/// stack, this can be used to change the behavior of how parent hierarchy items
+	/// will affect the item being added to the top of the stack.</summary>
+	public enum HierarchyParent {
+		/// <summary>Inheriting is generally the default behavior of a hierarchy stack, the
+		/// current item will inherit the properties of the parent stack item in some
+		/// form or another.</summary>
+		Inherit,
+		/// <summary>Ignoring the parent hierarchy stack item will let you skip inheriting
+		/// anything from the parent item. The new item remains exactly as provided.</summary>
+		Ignore,
+	}
+
 	/// <summary>When opening the Platform.FilePicker, this enum describes
 	/// how the picker should look and behave.</summary>
 	public enum PickerMode {

--- a/StereoKit/Systems/Hierarchy.cs
+++ b/StereoKit/Systems/Hierarchy.cs
@@ -21,8 +21,13 @@
 		/// stack! All Push calls must have an accompanying Pop call.</summary>
 		/// <param name="parentTransform">The transform Matrix you want to 
 		/// apply to all following draw calls.</param>
-		public static void Push(in Matrix parentTransform)
-			=> NativeAPI.hierarchy_push(parentTransform);
+		/// <param name="parentBehavior">This determines how this matrix
+		/// combines with the parent matrix below it. Normal behavior is to
+		/// "inherit" the parent matrix, but there are cases where you may wish
+		/// to entirely ignore the parent transform. For example, if you're in
+		/// UI space, and wish to do some world space rendering.</param>
+		public static void Push(in Matrix parentTransform, HierarchyParent parentBehavior = HierarchyParent.Inherit)
+			=> NativeAPI.hierarchy_push(parentTransform, parentBehavior);
 
 		/// <summary>Removes the top Matrix from the stack!</summary>
 		public static void Pop()

--- a/StereoKit/Systems/UI.cs
+++ b/StereoKit/Systems/UI.cs
@@ -1322,8 +1322,20 @@ namespace StereoKit
 		/// interactable?</param>
 		/// <param name="ignoreParent">Do we want to ignore or inherit the
 		/// state of the current stack?</param>
-		public static void PushEnabled(bool enabled, bool ignoreParent = false)
-			=> NativeAPI.ui_push_enabled(enabled, ignoreParent);
+		[Obsolete("Use override with HierarchyParent parameter")]
+		public static void PushEnabled(bool enabled, bool ignoreParent)
+			=> NativeAPI.ui_push_enabled(enabled, ignoreParent ? HierarchyParent.Ignore : HierarchyParent.Inherit);
+
+		/// <summary>All UI between PushEnabled and its matching PopEnabled
+		/// will set the UI to an enabled or disabled state, allowing or
+		/// preventing interaction with specific elements. The default state is
+		/// true.</summary>
+		/// <param name="enabled">Should the following elements be enabled and
+		/// interactable?</param>
+		/// <param name="parentBehavior">Do we want to ignore or inherit the
+		/// state of the current stack?</param>
+		public static void PushEnabled(bool enabled, HierarchyParent parentBehavior = HierarchyParent.Inherit)
+			=> NativeAPI.ui_push_enabled(enabled, parentBehavior);
 
 		/// <summary>Removes an 'enabled' state from the stack, and whatever
 		/// was below will then be used as the primary enabled state.</summary>

--- a/StereoKitC/hierarchy.cpp
+++ b/StereoKitC/hierarchy.cpp
@@ -55,12 +55,12 @@ void hierarchy_step() {
 
 ///////////////////////////////////////////
 
-void hierarchy_push(const matrix &transform) {
+void hierarchy_push(const matrix &transform, hierarchy_parent_ parent_behavior) {
 	local->stack.add(hierarchy_item_t{transform, matrix_identity, false});
 	local->enabled = local->userenabled;
 
 	int32_t size = local->stack.count;
-	if (size > 1)
+	if (size > 1 && parent_behavior == hierarchy_parent_inherit)
 		matrix_mul(local->stack[size - 1].transform, local->stack[size - 2].transform, local->stack[size - 1].transform);
 }
 

--- a/StereoKitC/stereokit.h
+++ b/StereoKitC/stereokit.h
@@ -1560,7 +1560,20 @@ SK_API int32_t               render_list_prev_count(const render_list_t list);
 
 ///////////////////////////////////////////
 
-SK_API void          hierarchy_push              (const sk_ref(matrix) transform);
+/*When used with a hierarchy modifying function that will push/pop items onto a
+  stack, this can be used to change the behavior of how parent hierarchy items
+  will affect the item being added to the top of the stack.*/
+typedef enum hierarchy_parent_ {
+	/*Inheriting is generally the default behavior of a hierarchy stack, the
+	  current item will inherit the properties of the parent stack item in some
+	  form or another.*/
+	hierarchy_parent_inherit,
+	/*Ignoring the parent hierarchy stack item will let you skip inheriting
+	  anything from the parent item. The new item remains exactly as provided.*/
+	hierarchy_parent_ignore,
+} hierarchy_parent_;
+
+SK_API void          hierarchy_push              (const sk_ref(matrix) transform, hierarchy_parent_ parent_behavior sk_default(hierarchy_parent_inherit));
 SK_API void          hierarchy_pop               (void);
 SK_API void          hierarchy_set_enabled       (bool32_t enabled);
 SK_API bool32_t      hierarchy_is_enabled        (void);

--- a/StereoKitC/stereokit_ui.h
+++ b/StereoKitC/stereokit_ui.h
@@ -175,7 +175,7 @@ SK_API void     ui_pop_text_style        (void);
 SK_API text_style_t ui_get_text_style    (void);
 SK_API void     ui_push_tint             (color128 tint_gamma);
 SK_API void     ui_pop_tint              (void);
-SK_API void     ui_push_enabled          (bool32_t enabled, bool32_t ignore_parent sk_default(false));
+SK_API void     ui_push_enabled          (bool32_t enabled, hierarchy_parent_ parent_behavior sk_default(hierarchy_parent_inherit));
 SK_API void     ui_pop_enabled           (void);
 SK_API bool32_t ui_is_enabled            (void);
 SK_API void     ui_push_preserve_keyboard(bool32_t preserve_keyboard);

--- a/StereoKitC/ui/ui_core.cpp
+++ b/StereoKitC/ui/ui_core.cpp
@@ -1066,8 +1066,8 @@ void ui_pop_id() {
 
 ///////////////////////////////////////////
 
-void ui_push_enabled(bool32_t enabled, bool32_t ignore_parent) {
-	skui_enabled_stack.add(ignore_parent
+void ui_push_enabled(bool32_t enabled, hierarchy_parent_ parent_behavior) {
+	skui_enabled_stack.add(parent_behavior == hierarchy_parent_ignore
 		? enabled
 		: ((bool)enabled == true) && ((bool)ui_is_enabled() == true));
 }


### PR DESCRIPTION
This helps clarify what's happening in the code in certain circumstances. For example, when using a `bool` instead of `HierarchyParent` with `UI.PushEnabled`, you might see something like this:

```csharp
UI.PushEnabled(true, true);
```

Which is not particularly clear. This would now look like this instead:

```csharp
UI.PushEnabled(true, HierarchyParent.Ignore);
```

Which is easy to understand at a glance.

This also adds `HierarchyParent` functionality to the transform `Hierarchy.Push`.