### PR TITLE
Remove adding asset folder to font file name

### DIFF
--- a/StereoKit/Assets/Font.cs
+++ b/StereoKit/Assets/Font.cs
@@ -62,13 +62,11 @@ namespace StereoKit {
 			return inst == IntPtr.Zero ? null : new Font(inst);
 		}
 
-		/// <summary>Loads a font and creates a font asset from it.</summary>
-		/// <param name="fontFiles">A list of file addresses for the font! For
-		/// example: 'C:/Windows/Fonts/segoeui.ttf'. If a glyph is not found,
-		/// StereoKit will look in the next font file in the list.</param>
-		/// <returns>A font from the given files, or null if all of the files
-		/// failed to load properly! If any of the given files successfully 
-		/// loads, then this font will be a valid asset.</returns>
+		/// <summary>Loads font from a specified list of font family names</summary>
+		/// <param name="fontFamily">List of font family names separated by comma(,)
+		/// similar to a list of names css allows.</param>
+		/// <returns>A font from the given font family names, Most of the OS provide 
+		/// fallback fonts, hence there will always be a set of fonts.</returns>
 		public static Font FromFamily(string fontFamily)
 		{
 			IntPtr inst = NativeAPI.font_create_family(fontFamily);

--- a/StereoKitC/asset_types/font.cpp
+++ b/StereoKitC/asset_types/font.cpp
@@ -59,9 +59,8 @@ int32_t font_source_add(const char *filename) {
 
 	if (font_sources[id].references == 1) {
 		size_t length;
-		char* asset_filename = assets_file(filename);
-		if (!platform_read_file(asset_filename, (void **)&font_sources[id].file, &length)) {
-			log_warnf("Font file failed to load: %s %s", filename, asset_filename);
+		if (!platform_read_file(filename, (void **)&font_sources[id].file, &length)) {
+			log_warnf("Font file failed to load: %s", filename);
 		} else {
 			stbtt_InitFont(&font_sources[id].info, (const unsigned char *)font_sources[id].file, stbtt_GetFontOffsetForIndex((const unsigned char *)font_sources[id].file,0));
 			font_sources[id].scale = stbtt_ScaleForPixelHeight(&font_sources[id].info, (float)font_resolution);


### PR DESCRIPTION
This fix addresses the issues found in #1020 

Not being able to load a font file from assets folder
Doc of fromFamily method has been updated.
Tested on WSL linux with 'courier'. Did not get/see any crash happening.

