### PR TITLE
Thread safety on core asset list

### DIFF
--- a/StereoKit/BuildStereoKitSDK.targets
+++ b/StereoKit/BuildStereoKitSDK.targets
@@ -99,7 +99,7 @@
 	</Target>
 	
 	<!-- Error out if StereoKitC hasn't successfully built! -->
-	<Target Name="SKSDKCheckBuildFiles" BeforeTargets="BeforeBuild">
+	<Target Name="SKSDKCheckBuildFiles" AfterTargets="PreBuildEvent" BeforeTargets="CoreCompile">
 		<Error Condition="!Exists('$(SKSDKLibPath)')" Text="StereoKitC was not properly built! Binary file $(SKSDKLibPath) is missing." />
 	</Target>
 </Project>

--- a/StereoKit/StereoKit.csproj
+++ b/StereoKit/StereoKit.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0</TargetFrameworks>
+		<TargetFramework>netstandard2.0</TargetFramework>
 		<PlatformTarget>AnyCPU</PlatformTarget>
 		<OutputPath>../bin/</OutputPath>
 		<DocumentationFile>../bin/StereoKit.xml</DocumentationFile>

--- a/StereoKitC/asset_types/assets.cpp
+++ b/StereoKitC/asset_types/assets.cpp
@@ -51,6 +51,7 @@ struct asset_thread_t {
 ///////////////////////////////////////////
 
 array_t<asset_header_t *>      assets = {};
+ft_mutex_t                     assets_lock = {};
 array_t<asset_header_t *>      assets_multithread_destroy = {};
 ft_mutex_t                     assets_multithread_destroy_lock = {};
 ft_mutex_t                     assets_job_lock = {};
@@ -83,12 +84,16 @@ void *assets_find(const char *id, asset_type_ type) {
 ///////////////////////////////////////////
 
 void *assets_find(uint64_t id, asset_type_ type) {
-	int32_t count = assets.count;
-	for (int32_t i = 0; i < count; i++) {
-		if (assets[i]->id == id && assets[i]->type == type && assets[i]->refs > 0)
-			return assets[i];
+	void* result = nullptr;
+	ft_mutex_lock(assets_lock);
+	for (int32_t i = 0; i < assets.count; i++) {
+		if (assets[i]->id == id && assets[i]->type == type && assets[i]->refs > 0) {
+			result = assets[i];
+			break;
+		}
 	}
-	return nullptr;
+	ft_mutex_unlock(assets_lock);
+	return result;
 }
 
 ///////////////////////////////////////////
@@ -122,18 +127,21 @@ void *assets_allocate(asset_type_ type) {
 	default: log_err("Unimplemented asset type!"); abort();
 	}
 
-	char name[64];
-	snprintf(name, sizeof(name), "auto/asset_%d", assets.count);
-
 	asset_header_t *header = (asset_header_t *)sk_malloc(size);
 	memset(header, 0, size);
 	header->type    = type;
+	header->state   = asset_state_none;
+	assets_addref(header);
+
+	ft_mutex_lock(assets_lock);
+	char name[64];
+	snprintf(name, sizeof(name), "auto/asset_%d", assets.count);
 	header->id      = hash_fnv64_string(name);
 	header->id_text = string_copy(name);
 	header->index   = assets.count;
-	header->state   = asset_state_none;
-	assets_addref(header);
+
 	assets.add(header);
+	ft_mutex_unlock(assets_lock);
 	return header;
 }
 
@@ -231,12 +239,14 @@ void assets_destroy(asset_header_t *asset) {
 	}
 
 	// Remove it from our list of assets
+	ft_mutex_lock(assets_lock);
 	for (int32_t i = 0; i < assets.count; i++) {
 		if (assets[i] == asset) {
 			assets.remove(i);
 			break;
 		}
 	}
+	ft_mutex_unlock(assets_lock);
 
 	// And at last, free the memory we allocated for it!
 	sk_free(asset);
@@ -342,6 +352,7 @@ char *assets_file(const char *file_name) {
 ///////////////////////////////////////////
 
 bool assets_init() {
+	assets_lock                     = ft_mutex_create();
 	assets_multithread_destroy_lock = ft_mutex_create();
 	assets_job_lock                 = ft_mutex_create();
 	asset_thread_task_mtx           = ft_mutex_create();
@@ -440,6 +451,7 @@ void assets_shutdown() {
 	ft_mutex_destroy(&assets_multithread_destroy_lock);
 	ft_mutex_destroy(&assets_job_lock);
 	ft_mutex_destroy(&assets_load_event_lock);
+	ft_mutex_destroy(&assets_lock);
 	ft_condition_destroy(&asset_tasks_available);
 
 	assets_load_call_list.free();
@@ -744,6 +756,10 @@ int32_t asset_thread(void *thread_inst_obj) {
 	asset_thread_t* thread = (asset_thread_t*)thread_inst_obj;
 	thread->id      = ft_id_current();
 	thread->running = true;
+
+	// Don't start processing assets until initialization is finished
+	while (asset_thread_enabled && !sk_is_initialized())
+		platform_sleep(1);
 
 	ft_mutex_t wait_mtx = ft_mutex_create();
 

--- a/StereoKitC/systems/_stereokit_systems.cpp
+++ b/StereoKitC/systems/_stereokit_systems.cpp
@@ -32,7 +32,8 @@ bool stereokit_systems_register() {
 	system_t sys_platform_begin   = { "FrameBegin"  };
 	system_t sys_platform_render  = { "FrameRender" };
 
-	system_set_step_deps(sys_platform_render, "App", "Text", "Sprites", "Lines", "World", "UILate", "Animation");
+	system_set_initialize_deps(sys_platform, "Assets");
+	system_set_step_deps      (sys_platform_render, "App", "Text", "Sprites", "Lines", "World", "UILate", "Animation");
 
 	sys_platform       .func_initialize = platform_init;
 	sys_platform       .func_shutdown   = platform_shutdown;
@@ -72,11 +73,10 @@ bool stereokit_systems_register() {
 	systems_add(&sys_renderer);
 
 	system_t sys_assets = { "Assets" };
-	system_set_initialize_deps(sys_assets, "Platform");
-	system_set_step_deps      (sys_assets, "FrameRender");
-	sys_assets.func_initialize       = assets_init;
-	sys_assets.func_step             = assets_step;
-	sys_assets.func_shutdown         = assets_shutdown;
+	system_set_step_deps(sys_assets, "FrameRender");
+	sys_assets.func_initialize = assets_init;
+	sys_assets.func_step       = assets_step;
+	sys_assets.func_shutdown   = assets_shutdown;
 	systems_add(&sys_assets);
 
 	system_t sys_audio = { "Audio" };


### PR DESCRIPTION
The core asset list had no thread locks, and weren't safe from multithreaded edits. This popped up for the first time with a `asset_find` call when using C#'s `Lazy<>` to create an asset in Debug mode.

This moves the asset system to the beginning of the initialization list, and delays the asset processing threads to start after SK's initialization has completed. 

A note: since SK does have a few default assets that get generated in initialization, it might be a good idea in the future to either start the asset processing threads a tiny bit earlier during initialization, or block initialization from returning right away and add a small segment at the end to let the asset threads process default assets. This might need some investigation to see if this is even necessary.