### PR TITLE
UI.GenQuadrantMesh now can generate non-quadrant meshes.

### DIFF
--- a/StereoKit/Native/NativeAPI.cs
+++ b/StereoKit/Native/NativeAPI.cs
@@ -708,7 +708,7 @@ namespace StereoKit
 
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   ui_quadrant_size_verts  ([In, Out] Vertex[] ref_vertices, int vertex_count, float overflow);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   ui_quadrant_size_mesh   (IntPtr ref_mesh, float overflow);
-		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr ui_gen_quadrant_mesh    (UICorner rounded_corners, float corner_radius, uint corner_resolution, [MarshalAs(UnmanagedType.Bool)] bool delete_flat_sides, [In] UILathePt[] lathe_pts, int lathe_pt_count);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr ui_gen_quadrant_mesh    (UICorner rounded_corners, float corner_radius, uint corner_resolution, [MarshalAs(UnmanagedType.Bool)] bool delete_flat_sides, [MarshalAs(UnmanagedType.Bool)] bool quadrantify, [In] UILathePt[] lathe_pts, int lathe_pt_count);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   ui_show_volumes         ([MarshalAs(UnmanagedType.Bool)] bool show);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   ui_enable_far_interact  ([MarshalAs(UnmanagedType.Bool)] bool enable);
 		[return: MarshalAs(UnmanagedType.Bool)]

--- a/StereoKit/Systems/UI.cs
+++ b/StereoKit/Systems/UI.cs
@@ -1543,11 +1543,22 @@ namespace StereoKit
 		/// <param name="deleteFlatSides">If two adjacent corners are sharp, should
 		/// we skip connecting them with triangles? If this edge will always be
 		/// covered, then deleting these faces may save you some performance.</param>
+		/// <param name="quadrantify">Does this generate a mesh compatible with
+		/// StereoKit's quadrant shader system, or is this just a traditional
+		/// mesh? In most cases, this should be true, but UI elements such as
+		/// the rounded button may be exceptions.</param>
 		/// <param name="lathePts">The lathe points to sweep around the edge.</param>
 		/// <returns>The final Mesh, ready for use in SK's theming system.</returns>
+		public static Mesh GenQuadrantMesh(UICorner roundedCorners, float cornerRadius, uint cornerResolution, bool deleteFlatSides, bool quadrantify, params UILathePt[] lathePts)
+		{
+			IntPtr result = NativeAPI.ui_gen_quadrant_mesh(roundedCorners, cornerRadius, cornerResolution, deleteFlatSides, quadrantify, lathePts, lathePts.Length);
+			return result != IntPtr.Zero ? new Mesh(result) : null;
+		}
+
+		/// <inheritdoc cref="GenQuadrantMesh(UICorner, float, uint, bool, bool, UILathePt[])"/>
 		public static Mesh GenQuadrantMesh(UICorner roundedCorners, float cornerRadius, uint cornerResolution, bool deleteFlatSides, params UILathePt[] lathePts)
 		{
-			IntPtr result = NativeAPI.ui_gen_quadrant_mesh(roundedCorners, cornerRadius, cornerResolution, deleteFlatSides, lathePts, lathePts.Length);
+			IntPtr result = NativeAPI.ui_gen_quadrant_mesh(roundedCorners, cornerRadius, cornerResolution, deleteFlatSides, true, lathePts, lathePts.Length);
 			return result != IntPtr.Zero ? new Mesh(result) : null;
 		}
 

--- a/StereoKitC/shaders_builtin/shader_builtin_ui.hlsl
+++ b/StereoKitC/shaders_builtin/shader_builtin_ui.hlsl
@@ -16,7 +16,7 @@ struct psIn {
 	float4 pos     : SV_POSITION;
 	float2 uv      : TEXCOORD0;
 	float3 world   : TEXCOORD1;
-	half3  color   : COLOR0;
+	half4  color   : COLOR0;
 	uint   view_id : SV_RenderTargetArrayIndex;
 };
 
@@ -30,13 +30,14 @@ psIn vs(vsIn input, uint id : SV_InstanceID) {
 	o.pos   = mul(world, sk_viewproj[o.view_id]);
 	o.world = world.xyz;
 	o.uv    = input.uv;
-	o.color = (color * input.color * sk_inst[id].color).rgb * sk_lighting(normal);
+	o.color.rgb = color.rgb * input.color.rgb * sk_inst[id].color.rgb * sk_lighting(normal);
+	o.color.a   = input.color.a;
 	return o;
 }
 
 float4 ps(psIn input) : SV_TARGET {
 	float  glow = pow(1 - saturate(sk_finger_distance(input.world) / 0.12), 10);
-	float4 col  = float4(lerp(input.color.rgb, half3(1, 1, 1), glow), 1);
+	float4 col  = float4(lerp(input.color.rgb, half3(1, 1, 1), glow), input.color.a);
 
 	return diffuse.Sample(diffuse_s, input.uv) * col;
 }

--- a/StereoKitC/stereokit_ui.h
+++ b/StereoKitC/stereokit_ui.h
@@ -145,7 +145,7 @@ typedef uint64_t id_hash_t;
 
 SK_API void     ui_quadrant_size_verts  (vert_t *ref_vertices, int32_t vertex_count, float overflow_percent);
 SK_API void     ui_quadrant_size_mesh   (mesh_t ref_mesh, float overflow_percent);
-SK_API mesh_t   ui_gen_quadrant_mesh    (ui_corner_ rounded_corners, float corner_radius, uint32_t corner_resolution, bool32_t delete_flat_sides, const ui_lathe_pt_t* lathe_pts, int32_t lathe_pt_count);
+SK_API mesh_t   ui_gen_quadrant_mesh    (ui_corner_ rounded_corners, float corner_radius, uint32_t corner_resolution, bool32_t delete_flat_sides, bool32_t quadrantify, const ui_lathe_pt_t* lathe_pts, int32_t lathe_pt_count);
 SK_API void     ui_show_volumes         (bool32_t      show);
 SK_API void     ui_enable_far_interact  (bool32_t      enable);
 SK_API bool32_t ui_far_interact_enabled (void);


### PR DESCRIPTION
This fixes `UI.ButtonRound` not being round at sizes other than default. 
`Material.UI` now has behavior a bit more consistent with `Material.UIQuadrant`.