### PR TITLE
Added `Renderer.ViewportScaling`

### DIFF
--- a/Examples/StereoKitTest/Demos/DemoRenderScaling.cs
+++ b/Examples/StereoKitTest/Demos/DemoRenderScaling.cs
@@ -15,16 +15,18 @@ class DemoRenderScaling : ITest
 
 	float multisample;
 	float scaling;
+	float viewScaling;
 
 	public void Initialize()
 	{
 		multisample = Renderer.Multisample;
 		scaling     = Renderer.Scaling;
+		viewScaling = Renderer.ViewportScaling;
 	}
 	public void Shutdown() { }
 	public void Step()
 	{
-		UI.WindowBegin("Aliasing Settings", ref windowPose);
+		UI.WindowBegin("Render Scaling Settings", ref windowPose, new Vec2(0.3f,0));
 
 		if (Backend.XRType != BackendXRType.OpenXR)
 		{
@@ -54,6 +56,14 @@ class DemoRenderScaling : ITest
 			Renderer.Multisample = (int)multisample;
 			Renderer.Scaling     = scaling;
 		}
+
+		UI.HSeparator();
+
+		UI.Label("Viewport Scaling");
+		UI.Label($"{viewScaling:0.00}", V.XY(0.04f, 0));
+		UI.SameLine();
+		if (UI.HSlider("viewscaling", ref viewScaling, 0.1f, 1, 0))
+			Renderer.ViewportScaling = viewScaling;
 
 		if (Backend.XRType != BackendXRType.OpenXR)
 			UI.PopEnabled();

--- a/StereoKit/Native/NativeAPI.cs
+++ b/StereoKit/Native/NativeAPI.cs
@@ -432,6 +432,8 @@ namespace StereoKit
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void               render_set_filter     (RenderLayer layer_filter);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void               render_set_scaling    (float display_tex_scale);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern float              render_get_scaling    ();
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void               render_set_viewport_scaling(float viewport_rect_scale);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern float              render_get_viewport_scaling();
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void               render_set_multisample(int display_tex_multisample);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern int                render_get_multisample();
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void               render_override_capture_filter([MarshalAs(UnmanagedType.Bool)] bool use_override_filter, RenderLayer layer_filter);

--- a/StereoKit/Systems/Renderer.cs
+++ b/StereoKit/Systems/Renderer.cs
@@ -73,10 +73,20 @@ namespace StereoKit
 		/// of the recommended size. Note that the final resolution may also be
 		/// clamped or quantized. Only works in XR mode. If known in advance,
 		/// set this via SKSettings in initialization. This is a _very_ costly
-		/// change to make.</summary>
+		/// change to make. Consider if ViewportScaling will work for you
+		/// instead, and prefer that.</summary>
 		public static float Scaling {
 			get => NativeAPI.render_get_scaling();
 			set => NativeAPI.render_set_scaling(value);
+		}
+
+		/// <summary>This allows you to trivially scale down the area of the
+		/// swapchain that StereoKit renders to! This can be used to boost
+		/// performance in situations where full resolution is not needed, or
+		/// to reduce GPU time. This value is locked to the 0-1 range.</summary>
+		public static float ViewportScaling {
+			get => NativeAPI.render_get_viewport_scaling();
+			set => NativeAPI.render_set_viewport_scaling(value);
 		}
 
 		/// <summary>Allows you to set the multisample (MSAA) level of the

--- a/StereoKitC/stereokit.h
+++ b/StereoKitC/stereokit.h
@@ -1529,6 +1529,8 @@ SK_API void                  render_set_filter     (render_layer_ layer_filter);
 SK_API render_layer_         render_get_filter     (void);
 SK_API void                  render_set_scaling    (float display_tex_scale);
 SK_API float                 render_get_scaling    (void);
+SK_API void                  render_set_viewport_scaling(float viewport_rect_scale);
+SK_API float                 render_get_viewport_scaling(void);
 SK_API void                  render_set_multisample(int32_t display_tex_multisample);
 SK_API int32_t               render_get_multisample(void);
 SK_API void                  render_override_capture_filter(bool32_t use_override_filter, render_layer_ layer_filter sk_default(render_layer_all));

--- a/StereoKitC/systems/render.cpp
+++ b/StereoKitC/systems/render.cpp
@@ -113,6 +113,7 @@ struct render_state_t {
 	spherical_harmonics_t   lighting_src;
 	color128                clear_col;
 	render_list_t           list_primary;
+	float                   viewport_scale;
 	float                   scale;
 	int32_t                 multisample;
 	render_layer_           primary_filter;
@@ -174,6 +175,7 @@ bool render_init() {
 	local.ortho_viewport_height = 1.0f;
 	local.clear_col             = color128{0,0,0,0};
 	local.list_primary          = nullptr;
+	local.viewport_scale        = 1;
 	local.scale                 = sk_get_settings_ref()->render_scaling;
 	local.multisample           = sk_get_settings_ref()->render_multisample;
 	local.primary_filter        = render_layer_all_first_person;
@@ -571,6 +573,18 @@ void render_set_scaling(float texture_scale) {
 
 float render_get_scaling() {
 	return local.scale;
+}
+
+///////////////////////////////////////////
+
+void render_set_viewport_scaling(float viewport_rect_scale) {
+	local.viewport_scale = fmaxf(0,fminf(1,viewport_rect_scale));
+}
+
+///////////////////////////////////////////
+
+float render_get_viewport_scaling(void) {
+	return local.viewport_scale;
 }
 
 ///////////////////////////////////////////

--- a/StereoKitC/systems/render_pipeline.cpp
+++ b/StereoKitC/systems/render_pipeline.cpp
@@ -13,6 +13,7 @@ struct pipeline_surface_t {
 	tex_format_   color;
 	tex_format_   depth;
 	render_layer_ layer;
+	float         viewport_scale;
 	int32_t       array_count;
 	int32_t       quilt_width;
 	int32_t       quilt_height;
@@ -59,8 +60,8 @@ void render_pipeline_draw() {
 		pipeline_surface_t* s = &local.surfaces[i];
 		if (s->enabled == false) continue;
 
-		int32_t width  = s->tex->width  / s->quilt_width;
-		int32_t height = s->tex->height / s->quilt_height;
+		int32_t width  = (int32_t)fmaxf(1, (float)(s->tex->width  / s->quilt_width ) * s->viewport_scale);
+		int32_t height = (int32_t)fmaxf(1, (float)(s->tex->height / s->quilt_height) * s->viewport_scale);
 
 		skg_event_begin("Draw Surface");
 		{
@@ -70,7 +71,7 @@ void render_pipeline_draw() {
 				
 			for (int32_t quilt_y = 0; quilt_y < s->quilt_height; quilt_y += 1) {
 			for (int32_t quilt_x = 0; quilt_x < s->quilt_width;  quilt_x += 1) {
-				int32_t viewport[4] = {quilt_x*width, quilt_y*height, width, height};
+				int32_t viewport[4] = {quilt_x*width, quilt_y*height, width, height };
 				skg_viewport(viewport);
 
 				int32_t idx = quilt_x + quilt_y * s->quilt_width;
@@ -116,15 +117,16 @@ void render_pipeline_shutdown() {
 
 pipeline_surface_id render_pipeline_surface_create(tex_format_ color, tex_format_ depth, int32_t array_count, int32_t quilt_width, int32_t quilt_height) {
 	pipeline_surface_t result = {};
-	result.enabled       = false; // shouldn't be enabled until the tex is sized
-	result.color         = color;
-	result.depth         = depth;
-	result.layer         = render_layer_all;
-	result.array_count   = array_count;
-	result.quilt_width   = quilt_width;
-	result.quilt_height  = quilt_height;
-	result.view_matrices = sk_malloc_t(matrix, array_count * quilt_width * quilt_height);
-	result.proj_matrices = sk_malloc_t(matrix, array_count * quilt_width * quilt_height);
+	result.enabled        = false; // shouldn't be enabled until the tex is sized
+	result.color          = color;
+	result.depth          = depth;
+	result.layer          = render_layer_all;
+	result.viewport_scale = 1;
+	result.array_count    = array_count;
+	result.quilt_width    = quilt_width;
+	result.quilt_height   = quilt_height;
+	result.view_matrices  = sk_malloc_t(matrix, array_count * quilt_width * quilt_height);
+	result.proj_matrices  = sk_malloc_t(matrix, array_count * quilt_width * quilt_height);
 	return local.surfaces.add(result);
 }
 
@@ -225,8 +227,8 @@ void render_pipeline_surface_get_surface_info(pipeline_surface_id surface_id, in
 	int32_t x = array_based_idx % surface->quilt_width;
 
 	*out_array_idx = arr;
-	out_xywh_rect[2] = surface->tex ? surface->tex->width  / surface->quilt_width : 0;
-	out_xywh_rect[3] = surface->tex ? surface->tex->height / surface->quilt_height: 0;
+	out_xywh_rect[2] = surface->tex ? (int32_t)fmaxf(1, (float)(surface->tex->width  / surface->quilt_width ) * surface->viewport_scale) : 0;
+	out_xywh_rect[3] = surface->tex ? (int32_t)fmaxf(1, (float)(surface->tex->height / surface->quilt_height) * surface->viewport_scale) : 0;
 	out_xywh_rect[0] = x * out_xywh_rect[2];
 	out_xywh_rect[1] = y * out_xywh_rect[3];
 }
@@ -264,6 +266,12 @@ bool32_t render_pipeline_surface_get_enabled(pipeline_surface_id surface) {
 
 void render_pipeline_surface_set_layer(pipeline_surface_id surface, render_layer_ layer) {
 	local.surfaces[surface].layer = layer;
+}
+
+///////////////////////////////////////////
+
+void render_pipeline_surface_set_viewport_scale(pipeline_surface_id surface, float viewport_rect_scale) {
+	local.surfaces[surface].viewport_scale = viewport_rect_scale;
 }
 
 ///////////////////////////////////////////

--- a/StereoKitC/systems/render_pipeline.h
+++ b/StereoKitC/systems/render_pipeline.h
@@ -7,19 +7,20 @@ namespace sk {
 
 typedef int32_t pipeline_surface_id;
 
-pipeline_surface_id render_pipeline_surface_create          (tex_format_ color, tex_format_ depth, int32_t array_count, int32_t quilt_width, int32_t quilt_height);
-void                render_pipeline_surface_destroy         (pipeline_surface_id surface);
-bool32_t            render_pipeline_surface_resize          (pipeline_surface_id surface, int32_t width, int32_t height, int32_t multisample);
-void                render_pipeline_surface_to_swapchain    (pipeline_surface_id surface, skg_swapchain_t* swapchain);
-void                render_pipeline_surface_to_tex          (pipeline_surface_id surface, tex_t destination, material_t mat);
-void                render_pipeline_surface_get_surface_info(pipeline_surface_id surface, int32_t view_idx, int32_t* out_array_idx, int32_t* out_xywh_rect);
-void                render_pipeline_surface_set_tex         (pipeline_surface_id surface, tex_t tex);
-tex_t               render_pipeline_surface_get_tex         (pipeline_surface_id surface);
-void                render_pipeline_surface_set_enabled     (pipeline_surface_id surface, bool32_t enabled);
-bool32_t            render_pipeline_surface_get_enabled     (pipeline_surface_id surface);
-void                render_pipeline_surface_set_layer       (pipeline_surface_id surface, render_layer_ layer);
-void                render_pipeline_surface_set_clear       (pipeline_surface_id surface, color128 color);
-void                render_pipeline_surface_set_perspective (pipeline_surface_id surface, matrix* view_matrices, matrix* proj_matrices, int32_t count);
+pipeline_surface_id render_pipeline_surface_create            (tex_format_ color, tex_format_ depth, int32_t array_count, int32_t quilt_width, int32_t quilt_height);
+void                render_pipeline_surface_destroy           (pipeline_surface_id surface);
+bool32_t            render_pipeline_surface_resize            (pipeline_surface_id surface, int32_t width, int32_t height, int32_t multisample);
+void                render_pipeline_surface_to_swapchain      (pipeline_surface_id surface, skg_swapchain_t* swapchain);
+void                render_pipeline_surface_to_tex            (pipeline_surface_id surface, tex_t destination, material_t mat);
+void                render_pipeline_surface_get_surface_info  (pipeline_surface_id surface, int32_t view_idx, int32_t* out_array_idx, int32_t* out_xywh_rect);
+void                render_pipeline_surface_set_tex           (pipeline_surface_id surface, tex_t tex);
+tex_t               render_pipeline_surface_get_tex           (pipeline_surface_id surface);
+void                render_pipeline_surface_set_enabled       (pipeline_surface_id surface, bool32_t enabled);
+bool32_t            render_pipeline_surface_get_enabled       (pipeline_surface_id surface);
+void                render_pipeline_surface_set_layer         (pipeline_surface_id surface, render_layer_ layer);
+void                render_pipeline_surface_set_viewport_scale(pipeline_surface_id surface, float viewport_rect_scale);
+void                render_pipeline_surface_set_clear         (pipeline_surface_id surface, color128 color);
+void                render_pipeline_surface_set_perspective   (pipeline_surface_id surface, matrix* view_matrices, matrix* proj_matrices, int32_t count);
 
 void render_pipeline_shutdown();
 void render_pipeline_begin();

--- a/StereoKitC/xr_backends/openxr_view.cpp
+++ b/StereoKitC/xr_backends/openxr_view.cpp
@@ -942,8 +942,9 @@ void openxr_display_swapchain_acquire(device_display_t* display, color128 color,
 	if (xr_draw_to_swapchain)
 		render_pipeline_surface_set_tex(display->swapchain_color.render_surface, display->swapchain_color.textures[color_id]);
 	display->swapchain_color.render_surface_tex = color_id;
-	render_pipeline_surface_set_clear(display->swapchain_color.render_surface, color);
-	render_pipeline_surface_set_layer(display->swapchain_color.render_surface, render_filter);
+	render_pipeline_surface_set_clear         (display->swapchain_color.render_surface, color);
+	render_pipeline_surface_set_layer         (display->swapchain_color.render_surface, render_filter);
+	render_pipeline_surface_set_viewport_scale(display->swapchain_color.render_surface, render_get_viewport_scaling());
 }
 
 ///////////////////////////////////////////


### PR DESCRIPTION
`Renderer.ViewportScaling` is an alternative to `Renderer.Scaling` for cheaper/faster resolution switching. Renderer.Scaling will create a new swapchain with the desired resolution scale, so it can scale up past OpenXR's suggested render surface size. However, ViewportScaling can at most be 1.0, as it is implemented by simply providing a smaller viewport for rendering and submitting to OpenXR. There is no cost for changing ViewportScaling, you're merely limited to sizes within the size of the current swapchain surface.