### PR TITLE
Double wide instead of double tall

### DIFF
--- a/StereoKitC/xr_backends/openxr_view.cpp
+++ b/StereoKitC/xr_backends/openxr_view.cpp
@@ -468,8 +468,8 @@ bool openxr_display_swapchain_update(device_display_t *display) {
 	int32_t quilt_height = 1;
 #if defined(SKG_OPENGL)
 	array_count  = 1;
-	quilt_width  = 1;
-	quilt_height = display->view_cap;
+	quilt_width  = display->view_cap;
+	quilt_height = 1;
 #endif
 	w = w * quilt_width;
 	h = h * quilt_height;


### PR DESCRIPTION
WiVRn doesn't seem to play well with the double-tall swapchain layout that StereoKit has been using since adding MSAA. More info at #1039.

This change switches the swapchain to a double-wide layout instead of double-tall to bypass the issue. WiVRn will continue to look into the issue on their end separately. Double tall was always just an interesting possibility with _theoretical_ memory layout benefits, and not a hard requisite of any sort. It would still be interesting to profile the difference in the future to see if the theory matches practice!