### PR TITLE
Update sk_gpu for gl state optimizations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,8 +201,8 @@ CPMAddPackage( # We're scraping the comment after the NAME for some other script
 )
 
 CPMAddPackage( # We're scraping the comment after the NAME for some other scripts
-  NAME sk_gpu # 2024.8.7
-  URL https://github.com/StereoKit/sk_gpu/releases/download/v2024.8.7/sk_gpu.v2024.8.7.zip
+  NAME sk_gpu # 2024.8.8
+  URL https://github.com/StereoKit/sk_gpu/releases/download/v2024.8.8/sk_gpu.v2024.8.8.zip
 )
 # For building directly with in-progress sk_gpu changes, point this to your
 # local sk_gpu clone, and use it instead of CPM.


### PR DESCRIPTION
This sk_gpu update caches gl state in an effort to reduce the number of gl state changes per draw call. In the StereoKitTest PBR scene, this drops gl events from 1200 to 700.

This may not result in major (or even minor) perf differences, but that may depend on the driver implementation.

`SKG_GL_EXPLICIT_STATE` can be defined when building to disable this optimization.