### PR TITLE
Allow SK to break out of suspend loop in the event of a Quit call.

### DIFF
--- a/StereoKitC/stereokit.cpp
+++ b/StereoKitC/stereokit.cpp
@@ -170,14 +170,14 @@ void sk_shutdown() {
 void sk_shutdown_unsafe(void) {
 	log_show_any_fail_reason();
 
-	systems_shutdown();
+	systems_shutdown      ();
 	sk_mem_log_allocations();
-	log_clear_subscribers();
-	quit_reason_ local_quit_reason = local.quit_reason;
+	log_clear_subscribers ();
 
+	quit_reason_ temp_quit_reason = local.quit_reason;
 	local = {};
 	local.disallow_user_shutdown = true;
-	local.quit_reason = local_quit_reason;
+	local.quit_reason            = temp_quit_reason;
 }
 
 

--- a/StereoKitC/systems/system.cpp
+++ b/StereoKitC/systems/system.cpp
@@ -138,20 +138,19 @@ bool systems_initialize() {
 
 	for (int32_t i = 0; i < systems.count; i++) {
 		int32_t index = system_init_order[i];
-		if (systems[index].func_initialize != nullptr) {
-			log_diagf("Initializing %s", systems[index].name);
+		if (systems[index].func_initialize == nullptr) continue;
+		log_diagf("Initializing %s", systems[index].name);
 
-			// start timing
-			uint64_t start = stm_now();
+		// start timing
+		uint64_t start = stm_now();
 
-			if (!systems[index].func_initialize()) {
-				log_errf("System %s failed to initialize!", systems[index].name);
-				return false;
-			}
-
-			// end timing
-			systems[index].profile_start_duration = stm_since(start);
+		if (!systems[index].func_initialize()) {
+			log_errf("System %s failed to initialize!", systems[index].name);
+			return false;
 		}
+
+		// end timing
+		systems[index].profile_start_duration = stm_since(start);
 	}
 	systems_initialized = true;
 	log_info("Initialization successful");
@@ -174,13 +173,6 @@ void system_execute(system_t *sys) {
 	sys->profile_step_duration += sys->profile_frame_duration;
 	sys->profile_step_count    += 1;
 	sys->profile_frame_duration = 0;
-}
-
-///////////////////////////////////////////
-
-void systems_step() {
-	for (int32_t i = 0; i < systems.count; i++)
-		system_execute(&systems[i]);
 }
 
 ///////////////////////////////////////////

--- a/StereoKitC/systems/system.h
+++ b/StereoKitC/systems/system.h
@@ -46,7 +46,6 @@ struct system_t {
 
 void      systems_add         (const system_t *system);
 bool      systems_initialize  ();
-void      systems_step        ();
 void      systems_step_partial(system_run_ run_section, int32_t system_idx);
 void      systems_shutdown    ();
 system_t* systems_find        (const char *name);


### PR DESCRIPTION
When the `Activity` received a `Finish` call, OpenXR was dropping to IDLE, which tells SK to behave as if it is suspending. However, OpenXR's IDLE ended up happening before `Activity.OnDestroy` which meant SK didn't have time to hear any `SK.Quit` called from there.

This commit adds checks to `sk_is_running()` in the suspend loop, so that SK can break out and shut down properly from this suspend state.

I'm still seeing some JNI related crashes inside of xrDestroyInstance on Quest, (and not on Snapdragon) but it at least does fully shut down with this change.