### PR TITLE
Fix omitEmptyFrames with hands

### DIFF
--- a/StereoKitC/xr_backends/openxr_view.cpp
+++ b/StereoKitC/xr_backends/openxr_view.cpp
@@ -735,6 +735,11 @@ bool openxr_render_frame() {
 	// Timing also needs some work, may be best as some sort of anchor system
 	xr_time = frame_state.predictedDisplayTime;
 
+	// Execute any code that's dependent on the predicted time, such as
+	// updating the location of controller models. This often includes drawing,
+	// which means this must come before our render usage check.
+	input_step_late();
+
 	// If there's nothing to render, we may want to totally skip all projection
 	// layers entirely.
 	bool render_displays =
@@ -801,14 +806,6 @@ bool openxr_render_frame() {
 		for (int32_t i = 0; i < xr_displays.count; i++)
 			render_pipeline_surface_set_enabled(xr_displays[i].swapchain_color.render_surface, false);
 	}
-
-	// Execute any code that's dependent on the predicted time, such as
-	// updating the location of controller models.
-	// 
-	// Input can be costly to look at on some systems, so this happens _after_
-	// swapchains are acquired, so they're in close time proximity to
-	// xrWaitFrame. Theoretically better?
-	input_step_late();
 
 	render_pipeline_draw();
 


### PR DESCRIPTION
This fixes an issue where hand meshes alone would not keep the primary composition layer alive during omitEmptyFrames. Since hands use predicted time, they were getting drawn _after_ the composition layer checked for draw items.

This change moves that hand draw code before the visibility check, so hand meshes are now accounted for properly.