### PR TITLE
Text layout refactor

### DIFF
--- a/Examples/StereoKitTest/Docs/DocText.cs
+++ b/Examples/StereoKitTest/Docs/DocText.cs
@@ -17,7 +17,7 @@ class DocText : ITest
 		Text.Add(text, Matrix.Identity, style, TextAlign.TopLeft, TextAlign.TopLeft);
 
 		// Show the bounding regions for the size of the text
-		Color colLayoutArea = Color.Black;
+		Color colLayoutArea = new Color(0.1f,  0.1f, 0.1f);
 		Color colRenderArea = new Color(0.25f, 0.5f, 0.25f);
 
 		Vec2 size  = Text.SizeLayout(text, style);
@@ -27,10 +27,10 @@ class DocText : ITest
 		Mesh.Cube.Draw(Material.Unlit, Matrix.TS(sizeR.XY0/-2 + V.XYZ(0, yOff, 0.002f), sizeR.XY0 + V.XYZ(0, 0, 0.001f)), colRenderArea);
 
 		// Show lines representing the typography units for this style
-		Color32 colCapHeight  = new Color32(150, 255, 150, 255);
+		Color32 colCapHeight  = new Color32( 50, 255,  50, 255);
 		Color32 colBaseline   = new Color32(255, 255, 255, 255);
-		Color32 colAscender   = new Color32(255, 100, 100, 255);
-		Color32 colDescender  = new Color32(100, 100, 255, 255);
+		Color32 colAscender   = new Color32(255,  50,  50, 255);
+		Color32 colDescender  = new Color32( 50,  50, 255, 255);
 		Color32 colLineHeight = new Color32(255, 255, 255, 255);
 
 		float ascenderAt   =  0;
@@ -39,11 +39,11 @@ class DocText : ITest
 		float descenderAt  = -style.Size;
 		float lineHeightAt = -style.LineHeight * style.Size;
 
-		Lines.Add(V.XY0(0,     ascenderAt  ), V.XY0(-size.x,       ascenderAt  ), colAscender,   0.005f);
-		Lines.Add(V.XY0(0,     baselineAt  ), V.XY0(-size.x,       baselineAt  ), colBaseline,   0.005f);
-		Lines.Add(V.XY0(0,     capHeightAt ), V.XY0(-size.x,       capHeightAt ), colCapHeight,  0.005f);
-		Lines.Add(V.XY0(0,     descenderAt ), V.XY0(-size.x,       descenderAt ), colDescender,  0.005f);
-		Lines.Add(V.XY0(0.01f, lineHeightAt), V.XY0(-size.x-0.01f, lineHeightAt), colLineHeight, 0.005f);
+		Lines.Add(V.XY0(0, ascenderAt  ), V.XY0(-size.x, ascenderAt  ), colAscender,   0.003f);
+		Lines.Add(V.XY0(0, baselineAt  ), V.XY0(-size.x, baselineAt  ), colBaseline,   0.003f);
+		Lines.Add(V.XY0(0, capHeightAt ), V.XY0(-size.x, capHeightAt ), colCapHeight,  0.003f);
+		Lines.Add(V.XY0(0, descenderAt ), V.XY0(-size.x, descenderAt ), colDescender,  0.003f);
+		Lines.Add(V.XY0(0, lineHeightAt), V.XY0(-size.x, lineHeightAt), colLineHeight, 0.003f);
 	}
 
 	public void Step()
@@ -54,7 +54,7 @@ class DocText : ITest
 		Hierarchy.Pop();
 
 		Vec2 s = Text.SizeLayout("lÔTy", style);
-		Tests.Screenshot("TextStyleInfo.jpg", 200, 200, V.XYZ(s.x/2, s.y/-2, -0.25f), V.XYZ(s.x/2, s.y/-2, -0.5f));
+		Tests.Screenshot("TextStyleInfo.jpg", 400, 400, V.XYZ(s.x/2, s.y/-2, -0.25f), V.XYZ(s.x/2, s.y/-2, -0.5f));
 	}
 
 	public void Initialize() {}

--- a/Examples/StereoKitTest/Docs/DocText.cs
+++ b/Examples/StereoKitTest/Docs/DocText.cs
@@ -1,0 +1,62 @@
+﻿using StereoKit;
+
+class DocText : ITest
+{
+	TextStyle style = TextStyle.FromFont(Font.FromFile("aileron_font.ttf"), 0.2f, Color.White);
+
+	void ShowTextStyleInfo()
+	{
+		// Some representative characters:
+		// l frequently goes above CapHeight all the way to the Ascender.
+		// Ô will go past the Ascender outside the layout bounds.
+		// T goes the whole way from Baseline to CapHeight.
+		// y will go all the way down to the descender.
+		string text = "lÔTy";
+
+		// Draw the text
+		Text.Add(text, Matrix.Identity, style, TextAlign.TopLeft, TextAlign.TopLeft);
+
+		// Show the bounding regions for the size of the text
+		Color colLayoutArea = Color.Black;
+		Color colRenderArea = new Color(0.25f, 0.5f, 0.25f);
+
+		Vec2 size  = Text.SizeLayout(text, style);
+		Vec2 sizeR = Text.SizeRender(size, style, out float yOff);
+
+		Mesh.Cube.Draw(Material.Unlit, Matrix.TS(size .XY0/-2 + V.XYZ(0, 0,    0.001f), size .XY0 + V.XYZ(0, 0, 0.001f)), colLayoutArea);
+		Mesh.Cube.Draw(Material.Unlit, Matrix.TS(sizeR.XY0/-2 + V.XYZ(0, yOff, 0.002f), sizeR.XY0 + V.XYZ(0, 0, 0.001f)), colRenderArea);
+
+		// Show lines representing the typography units for this style
+		Color32 colCapHeight  = new Color32(150, 255, 150, 255);
+		Color32 colBaseline   = new Color32(255, 255, 255, 255);
+		Color32 colAscender   = new Color32(255, 100, 100, 255);
+		Color32 colDescender  = new Color32(100, 100, 255, 255);
+		Color32 colLineHeight = new Color32(255, 255, 255, 255);
+
+		float ascenderAt   =  0;
+		float baselineAt   = -style.Ascender;
+		float capHeightAt  = -style.Ascender + style.CapHeight;
+		float descenderAt  = -style.Size;
+		float lineHeightAt = -style.LineHeight * style.Size;
+
+		Lines.Add(V.XY0(0,     ascenderAt  ), V.XY0(-size.x,       ascenderAt  ), colAscender,   0.005f);
+		Lines.Add(V.XY0(0,     baselineAt  ), V.XY0(-size.x,       baselineAt  ), colBaseline,   0.005f);
+		Lines.Add(V.XY0(0,     capHeightAt ), V.XY0(-size.x,       capHeightAt ), colCapHeight,  0.005f);
+		Lines.Add(V.XY0(0,     descenderAt ), V.XY0(-size.x,       descenderAt ), colDescender,  0.005f);
+		Lines.Add(V.XY0(0.01f, lineHeightAt), V.XY0(-size.x-0.01f, lineHeightAt), colLineHeight, 0.005f);
+	}
+
+	public void Step()
+	{
+		Hierarchy.Push(Matrix.TR(0, 0, -0.5f, Quat.LookDir(0, 0, 1)));
+
+		ShowTextStyleInfo();
+		Hierarchy.Pop();
+
+		Vec2 s = Text.SizeLayout("lÔTy", style);
+		Tests.Screenshot("TextStyleInfo.jpg", 200, 200, V.XYZ(s.x/2, s.y/-2, -0.25f), V.XYZ(s.x/2, s.y/-2, -0.5f));
+	}
+
+	public void Initialize() {}
+	public void Shutdown  () {}
+}

--- a/Examples/StereoKitTest/Docs/DocText.cs
+++ b/Examples/StereoKitTest/Docs/DocText.cs
@@ -8,7 +8,7 @@ class DocText : ITest
 	{
 		// Some representative characters:
 		// l frequently goes above CapHeight all the way to the Ascender.
-		// Ô will go past the Ascender outside the layout bounds.
+		// Ô will go past the Ascender outside the layout bounds, and slightly below the baseline.
 		// T goes the whole way from Baseline to CapHeight.
 		// y will go all the way down to the descender.
 		string text = "lÔTy";
@@ -36,8 +36,8 @@ class DocText : ITest
 		float ascenderAt   =  0;
 		float baselineAt   = -style.Ascender;
 		float capHeightAt  = -style.Ascender + style.CapHeight;
-		float descenderAt  = -style.Size;
-		float lineHeightAt = -style.LineHeight * style.Size;
+		float descenderAt  = -style.TotalHeight;
+		float lineHeightAt = -style.LineHeightPct * style.TotalHeight;
 
 		Lines.Add(V.XY0(0, ascenderAt  ), V.XY0(-size.x, ascenderAt  ), colAscender,   0.003f);
 		Lines.Add(V.XY0(0, baselineAt  ), V.XY0(-size.x, baselineAt  ), colBaseline,   0.003f);
@@ -54,7 +54,7 @@ class DocText : ITest
 		Hierarchy.Pop();
 
 		Vec2 s = Text.SizeLayout("lÔTy", style);
-		Tests.Screenshot("TextStyleInfo.jpg", 400, 400, V.XYZ(s.x/2, s.y/-2, -0.25f), V.XYZ(s.x/2, s.y/-2, -0.5f));
+		Tests.Screenshot("TextStyleInfo.jpg", 400, 400, V.XYZ(s.x/2, s.y/-2, -0.2f), V.XYZ(s.x/2, s.y/-2, -0.5f));
 	}
 
 	public void Initialize() {}

--- a/Examples/StereoKitTest/Tests/TestText.cs
+++ b/Examples/StereoKitTest/Tests/TestText.cs
@@ -1,24 +1,39 @@
 ﻿using StereoKit;
+using System;
 
 class TestText : ITest
 {
 	TextStyle style;
 	string    shortText = "Some shÖrt text, yes.";
 	string    longText  = "Twas brillig, and the slithy toves Did gyre and gimble in the wabe: All mimsy were the borogoves, And the mome raths outgrabe.\nBeware the Jabberwock, my son! The jaws that bite, the claws that catch! Beware the Jubjub bird, and shun The frumious Bandersnatch!";
+	string    scenders  = "lÔTy\nlÔTy\nlÔTy";
 
 	public void Initialize() {
-		style = TextStyle.FromFont(Font.FromFile("aileron_font.ttf"), 0.02f, Color.White);
+		//style = TextStyle.FromFont(Font.FromFile("aileron_font.ttf"), 0.02f, Color.White);
+		style = TextStyle.FromFont(Font.Default, 0.02f, Color.White);
+		style.Size = 0.02f * (0.02f / style.CapHeight);
 	}
 	public void Shutdown() { }
 	public void Step()
 	{
 		Quat r  = Quat.FromAngles(0, 180, 0);
-		Vec3 at = new Vec3(0,0,-0.5f);
-		Text.Add(shortText, Matrix.TR(at, r), style, TextAlign.TopLeft, TextAlign.TopLeft);
-		Vec2 s = Text.SizeLayout(shortText, style);
+		Vec3 at = new Vec3(0,-0.1f,-0.5f);
+		Text.Add(scenders, Matrix.TR(at, r), style, TextAlign.TopLeft, TextAlign.TopLeft);
+		Vec2 s = Text.SizeLayout(scenders, style);
 		Mesh.Cube.Draw(Material.Unlit, Matrix.TS(at.x + s.x / 2, at.y - s.y / 2, at.z - 0.001f, new Vec3(s.x, s.y, 0.001f)), Color.Black);
 		s = Text.SizeRender(s, style, out float offset);
 		Mesh.Cube.Draw(Material.Unlit, Matrix.TS(at.x + s.x / 2, at.y - s.y / 2 + offset, at.z - 0.002f, new Vec3(s.x, s.y, 0.001f)), new Color(0.25f,0.5f,0.25f));
+
+		DrawTextLineGuides(at + V.XY0(0, 0 * -style.Size * style.LineHeight), s.x, style);
+		DrawTextLineGuides(at + V.XY0(0, 1 * -style.Size * style.LineHeight), s.x, style);
+		DrawTextLineGuides(at + V.XY0(0, 2 * -style.Size * style.LineHeight), s.x, style);
+
+		at = new Vec3(0, 0.0f, -0.5f);
+		Text.Add(shortText, Matrix.TR(at, r), style, TextAlign.TopLeft, TextAlign.TopLeft);
+		s = Text.SizeLayout(shortText, style);
+		Mesh.Cube.Draw(Material.Unlit, Matrix.TS(at.x + s.x / 2, at.y - s.y / 2, at.z - 0.001f, new Vec3(s.x, s.y, 0.001f)), Color.Black);
+		s = Text.SizeRender(s, style, out offset);
+		Mesh.Cube.Draw(Material.Unlit, Matrix.TS(at.x + s.x / 2, at.y - s.y / 2 + offset, at.z - 0.002f, new Vec3(s.x, s.y, 0.001f)), new Color(0.25f, 0.5f, 0.25f));
 
 		at = new Vec3(0, 0.1f, -0.5f);
 		Text.Add(longText, Matrix.TR(at, r), style, TextAlign.TopLeft, TextAlign.TopLeft);
@@ -43,5 +58,19 @@ class TestText : ITest
 		Mesh.Cube.Draw(Material.Unlit, Matrix.TS(at.x + s.x / 2, at.y - s.y / 2 + offset, at.z - 0.002f, new Vec3(s.x, s.y, 0.001f)), new Color(0.25f, 0.5f, 0.25f));
 
 		Tests.Screenshot("Tests/TextSize.jpg", 1, 800, 300, 75, V.XYZ(0.85f, 0.3f, 0.0f), V.XYZ(0.85f, 0.3f, -0.5f));
+	}
+
+	static void DrawTextLineGuides(Vec3 at, float width, TextStyle style)
+	{
+		Color32 capHeight = new Color32(150, 255, 150, 255);
+		Color32 baseline  = new Color32(255, 255, 255, 255);
+		Color32 ascender  = new Color32(255, 100, 100, 255);
+		Color32 descender = new Color32(100, 100, 255, 255);
+
+		Lines.Add(at+V.XYZ(-0.01f, -style.LineHeight*style.Size, 0), at + V.XYZ(width+0.01f, -style.LineHeight*style.Size, 0), baseline, 0.0002f);
+		Lines.Add(at+V.XY0(0, 0                               ), at + V.XY0(width, 0                               ), ascender,  0.0002f);
+		Lines.Add(at+V.XY0(0, -style.Ascender                 ), at + V.XY0(width, -style.Ascender                 ), baseline,  0.0002f);
+		Lines.Add(at+V.XY0(0, -style.Ascender+style.CapHeight ), at + V.XY0(width, -style.Ascender+style.CapHeight ), capHeight, 0.0002f);
+		Lines.Add(at+V.XY0(0, -style.Size                     ), at + V.XY0(width, -style.Size                     ), descender, 0.0002f);
 	}
 }

--- a/Examples/StereoKitTest/Tests/TestText.cs
+++ b/Examples/StereoKitTest/Tests/TestText.cs
@@ -5,72 +5,72 @@ class TestText : ITest
 {
 	TextStyle style;
 	string    shortText = "Some shÖrt text, yes.";
-	string    longText  = "Twas brillig, and the slithy toves Did gyre and gimble in the wabe: All mimsy were the borogoves, And the mome raths outgrabe.\nBeware the Jabberwock, my son! The jaws that bite, the claws that catch! Beware the Jubjub bird, and shun The frumious Bandersnatch!";
+	string    longText  = "Twas brillig, and the slithy toves Did gyre and gimble in the wabe:\nAll mimsy were the borogoves, And the mome raths outgrabe.\nBeware the Jabberwock, my son! The jaws that bite, the claws that catch!\nBeware the Jubjub bird, and shun The frumious Bandersnatch!";
 	string    scenders  = "lÔTy\nlÔTy\nlÔTy";
 
 	public void Initialize() {
-		//style = TextStyle.FromFont(Font.FromFile("aileron_font.ttf"), 0.02f, Color.White);
-		style = TextStyle.FromFont(Font.Default, 0.02f, Color.White);
-		style.Size = 0.02f * (0.02f / style.CapHeight);
+		style = TextStyle.FromFont(Font.FromFile("aileron_font.ttf"), 0.02f, Color.White);
 	}
 	public void Shutdown() { }
 	public void Step()
 	{
+		Color colLayout = new Color(0.1f,  0.1f, 0.1f);
+		Color colRender = new Color(0.25f, 0.5f, 0.25f);
+
 		Quat r  = Quat.FromAngles(0, 180, 0);
-		Vec3 at = new Vec3(0,-0.1f,-0.5f);
+		Vec3 at = new Vec3(0.52f,0.35f,-0.5f);
 		Text.Add(scenders, Matrix.TR(at, r), style, TextAlign.TopLeft, TextAlign.TopLeft);
 		Vec2 s = Text.SizeLayout(scenders, style);
-		Mesh.Cube.Draw(Material.Unlit, Matrix.TS(at.x + s.x / 2, at.y - s.y / 2, at.z - 0.001f, new Vec3(s.x, s.y, 0.001f)), Color.Black);
+		Mesh.Cube.Draw(Material.Unlit, Matrix.TS(at.x + s.x / 2, at.y - s.y / 2, at.z - 0.001f, new Vec3(s.x, s.y, 0.001f)), colLayout);
 		s = Text.SizeRender(s, style, out float offset);
-		Mesh.Cube.Draw(Material.Unlit, Matrix.TS(at.x + s.x / 2, at.y - s.y / 2 + offset, at.z - 0.002f, new Vec3(s.x, s.y, 0.001f)), new Color(0.25f,0.5f,0.25f));
+		Mesh.Cube.Draw(Material.Unlit, Matrix.TS(at.x + s.x / 2, at.y - s.y / 2 + offset, at.z - 0.002f, new Vec3(s.x, s.y, 0.001f)), colRender);
 
-		DrawTextLineGuides(at + V.XY0(0, 0 * -style.Size * style.LineHeight), s.x, style);
-		DrawTextLineGuides(at + V.XY0(0, 1 * -style.Size * style.LineHeight), s.x, style);
-		DrawTextLineGuides(at + V.XY0(0, 2 * -style.Size * style.LineHeight), s.x, style);
+		DrawTextLineGuides(at + V.XY0(0, 0 * -style.TotalHeight * style.LineHeightPct), s.x, style);
+		DrawTextLineGuides(at + V.XY0(0, 1 * -style.TotalHeight * style.LineHeightPct), s.x, style);
+		DrawTextLineGuides(at + V.XY0(0, 2 * -style.TotalHeight * style.LineHeightPct), s.x, style);
 
-		at = new Vec3(0, 0.0f, -0.5f);
-		Text.Add(shortText, Matrix.TR(at, r), style, TextAlign.TopLeft, TextAlign.TopLeft);
-		s = Text.SizeLayout(shortText, style);
-		Mesh.Cube.Draw(Material.Unlit, Matrix.TS(at.x + s.x / 2, at.y - s.y / 2, at.z - 0.001f, new Vec3(s.x, s.y, 0.001f)), Color.Black);
-		s = Text.SizeRender(s, style, out offset);
-		Mesh.Cube.Draw(Material.Unlit, Matrix.TS(at.x + s.x / 2, at.y - s.y / 2 + offset, at.z - 0.002f, new Vec3(s.x, s.y, 0.001f)), new Color(0.25f, 0.5f, 0.25f));
-
-		at = new Vec3(0, 0.1f, -0.5f);
-		Text.Add(longText, Matrix.TR(at, r), style, TextAlign.TopLeft, TextAlign.TopLeft);
-		s = Text.SizeLayout(longText, style);
-		Mesh.Cube.Draw(Material.Unlit, Matrix.TS(at.x + s.x / 2, at.y - s.y / 2, at.z - 0.001f, new Vec3(s.x, s.y, 0.001f)), Color.Black);
-		s = Text.SizeRender(s, style, out offset);
-		Mesh.Cube.Draw(Material.Unlit, Matrix.TS(at.x + s.x / 2, at.y - s.y / 2 + offset, at.z - 0.002f, new Vec3(s.x, s.y, 0.001f)), new Color(0.25f, 0.5f, 0.25f));
-
-
-		at = new Vec3(0, 0.16f, -0.5f);
+		at = new Vec3(0.52f, 0.15f, -0.5f);
 		s = Text.SizeLayout(shortText, style, 0.5f);
 		Text.Add(shortText, Matrix.TR(at, r), new Vec2(0.5f, s.y), TextFit.Wrap, style, TextAlign.TopLeft, TextAlign.TopLeft);
-		Mesh.Cube.Draw(Material.Unlit, Matrix.TS(at.x + s.x / 2, at.y - s.y / 2, at.z - 0.001f, new Vec3(s.x, s.y, 0.001f)), Color.Black);
+		Mesh.Cube.Draw(Material.Unlit, Matrix.TS(at.x + s.x / 2, at.y - s.y / 2, at.z - 0.001f, new Vec3(s.x, s.y, 0.001f)), colLayout);
 		s = Text.SizeRender(s, style, out offset);
-		Mesh.Cube.Draw(Material.Unlit, Matrix.TS(at.x + s.x / 2, at.y - s.y / 2 + offset, at.z - 0.002f, new Vec3(s.x, s.y, 0.001f)), new Color(0.25f, 0.5f, 0.25f));
+		Mesh.Cube.Draw(Material.Unlit, Matrix.TS(at.x + s.x / 2, at.y - s.y / 2 + offset, at.z - 0.002f, new Vec3(s.x, s.y, 0.001f)), colRender);
 
-		at = new Vec3(0, 0.5f, -0.5f);
+		at = new Vec3(0, 0.35f, -0.5f);
 		s = Text.SizeLayout(longText, style, 0.5f);
 		Text.Add(longText, Matrix.TR(at, r), new Vec2(0.5f,s.y), TextFit.Wrap, style, TextAlign.TopLeft, TextAlign.TopLeft);
-		Mesh.Cube.Draw(Material.Unlit, Matrix.TS(at.x + s.x / 2, at.y - s.y / 2, at.z - 0.001f, new Vec3(s.x, s.y, 0.001f)), Color.Black);
+		Mesh.Cube.Draw(Material.Unlit, Matrix.TS(at.x + s.x / 2, at.y - s.y / 2, at.z - 0.001f, new Vec3(s.x, s.y, 0.001f)), colLayout);
 		s = Text.SizeRender(s, style, out offset);
-		Mesh.Cube.Draw(Material.Unlit, Matrix.TS(at.x + s.x / 2, at.y - s.y / 2 + offset, at.z - 0.002f, new Vec3(s.x, s.y, 0.001f)), new Color(0.25f, 0.5f, 0.25f));
+		Mesh.Cube.Draw(Material.Unlit, Matrix.TS(at.x + s.x / 2, at.y - s.y / 2 + offset, at.z - 0.002f, new Vec3(s.x, s.y, 0.001f)), colRender);
 
-		Tests.Screenshot("Tests/TextSize.jpg", 1, 800, 300, 75, V.XYZ(0.85f, 0.3f, 0.0f), V.XYZ(0.85f, 0.3f, -0.5f));
+		at = new Vec3(0.52f, 0.2f, -0.5f);
+		Text.Add(shortText, Matrix.TR(at, r), style, TextAlign.TopLeft, TextAlign.TopLeft);
+		s = Text.SizeLayout(shortText, style);
+		Mesh.Cube.Draw(Material.Unlit, Matrix.TS(at.x + s.x / 2, at.y - s.y / 2, at.z - 0.001f, new Vec3(s.x, s.y, 0.001f)), colLayout);
+		s = Text.SizeRender(s, style, out offset);
+		Mesh.Cube.Draw(Material.Unlit, Matrix.TS(at.x + s.x / 2, at.y - s.y / 2 + offset, at.z - 0.002f, new Vec3(s.x, s.y, 0.001f)), colRender);
+
+		at = new Vec3(0, 0.05f, -0.5f);
+		Text.Add(longText, Matrix.TR(at, r), style, TextAlign.TopLeft, TextAlign.TopLeft);
+		s = Text.SizeLayout(longText, style);
+		Mesh.Cube.Draw(Material.Unlit, Matrix.TS(at.x + s.x / 2, at.y - s.y / 2, at.z - 0.001f, new Vec3(s.x, s.y, 0.001f)), colLayout);
+		s = Text.SizeRender(s, style, out offset);
+		Mesh.Cube.Draw(Material.Unlit, Matrix.TS(at.x + s.x / 2, at.y - s.y / 2 + offset, at.z - 0.002f, new Vec3(s.x, s.y, 0.001f)), colRender);
+
+		Tests.Screenshot("Tests/TextSize.jpg", 1, 800, 500, 75, V.XYZ(s.x/2, 0.14f, -0.13f), V.XYZ(s.x/2, 0.14f, -0.5f));
 	}
 
 	static void DrawTextLineGuides(Vec3 at, float width, TextStyle style)
 	{
-		Color32 capHeight = new Color32(150, 255, 150, 255);
+		Color32 capHeight = new Color32( 50, 255,  50, 255);
 		Color32 baseline  = new Color32(255, 255, 255, 255);
-		Color32 ascender  = new Color32(255, 100, 100, 255);
-		Color32 descender = new Color32(100, 100, 255, 255);
+		Color32 ascender  = new Color32(255,  50,  50, 255);
+		Color32 descender = new Color32( 50,  50, 255, 255);
 
-		Lines.Add(at+V.XYZ(-0.01f, -style.LineHeight*style.Size, 0), at + V.XYZ(width+0.01f, -style.LineHeight*style.Size, 0), baseline, 0.0002f);
-		Lines.Add(at+V.XY0(0, 0                               ), at + V.XY0(width, 0                               ), ascender,  0.0002f);
-		Lines.Add(at+V.XY0(0, -style.Ascender                 ), at + V.XY0(width, -style.Ascender                 ), baseline,  0.0002f);
-		Lines.Add(at+V.XY0(0, -style.Ascender+style.CapHeight ), at + V.XY0(width, -style.Ascender+style.CapHeight ), capHeight, 0.0002f);
-		Lines.Add(at+V.XY0(0, -style.Size                     ), at + V.XY0(width, -style.Size                     ), descender, 0.0002f);
+		Lines.Add(at+V.XYZ(-0.01f, -style.LineHeightPct * style.TotalHeight, 0), at + V.XYZ(width+0.01f, -style.LineHeightPct * style.TotalHeight, 0), baseline, 0.002f);
+		Lines.Add(at+V.XY0(0, 0                              ), at + V.XY0(width, 0                              ), ascender,  0.002f);
+		Lines.Add(at+V.XY0(0, -style.Ascender                ), at + V.XY0(width, -style.Ascender                ), baseline,  0.002f);
+		Lines.Add(at+V.XY0(0, -style.Ascender+style.CapHeight), at + V.XY0(width, -style.Ascender+style.CapHeight), capHeight, 0.002f);
+		Lines.Add(at+V.XY0(0, -style.TotalHeight             ), at + V.XY0(width, -style.TotalHeight             ), descender, 0.002f);
 	}
 }

--- a/Examples/StereoKitTest/Tests/TestText.cs
+++ b/Examples/StereoKitTest/Tests/TestText.cs
@@ -3,7 +3,7 @@
 class TestText : ITest
 {
 	TextStyle style;
-	string    shortText = "Some short text.";
+	string    shortText = "Some shÖrt text, yes.";
 	string    longText  = "Twas brillig, and the slithy toves Did gyre and gimble in the wabe: All mimsy were the borogoves, And the mome raths outgrabe.\nBeware the Jabberwock, my son! The jaws that bite, the claws that catch! Beware the Jubjub bird, and shun The frumious Bandersnatch!";
 
 	public void Initialize() {
@@ -12,27 +12,35 @@ class TestText : ITest
 	public void Shutdown() { }
 	public void Step()
 	{
-		Quat r = Quat.FromAngles(0, 180, 0);
+		Quat r  = Quat.FromAngles(0, 180, 0);
 		Vec3 at = new Vec3(0,0,-0.5f);
 		Text.Add(shortText, Matrix.TR(at, r), style, TextAlign.TopLeft, TextAlign.TopLeft);
-		Vec2 s = Text.Size(shortText);
+		Vec2 s = Text.SizeLayout(shortText, style);
 		Mesh.Cube.Draw(Material.Unlit, Matrix.TS(at.x + s.x / 2, at.y - s.y / 2, at.z - 0.001f, new Vec3(s.x, s.y, 0.001f)), Color.Black);
+		s = Text.SizeRender(s, style, out float offset);
+		Mesh.Cube.Draw(Material.Unlit, Matrix.TS(at.x + s.x / 2, at.y - s.y / 2 + offset, at.z - 0.002f, new Vec3(s.x, s.y, 0.001f)), new Color(0.25f,0.5f,0.25f));
 
 		at = new Vec3(0, 0.1f, -0.5f);
 		Text.Add(longText, Matrix.TR(at, r), style, TextAlign.TopLeft, TextAlign.TopLeft);
-		s = Text.Size(longText);
-		Mesh.Cube.Draw(Material.Unlit, Matrix.TS(at.x + s.x / 2, at.y - s.y / 2, at.z - 0.001f, new Vec3(s.x, s.y, 0.001f)), Color.Black) ;
+		s = Text.SizeLayout(longText, style);
+		Mesh.Cube.Draw(Material.Unlit, Matrix.TS(at.x + s.x / 2, at.y - s.y / 2, at.z - 0.001f, new Vec3(s.x, s.y, 0.001f)), Color.Black);
+		s = Text.SizeRender(s, style, out offset);
+		Mesh.Cube.Draw(Material.Unlit, Matrix.TS(at.x + s.x / 2, at.y - s.y / 2 + offset, at.z - 0.002f, new Vec3(s.x, s.y, 0.001f)), new Color(0.25f, 0.5f, 0.25f));
 
 
-		at = new Vec3(0, 0.2f, -0.5f);
-		s = Text.Size(shortText, 0.5f);
+		at = new Vec3(0, 0.16f, -0.5f);
+		s = Text.SizeLayout(shortText, style, 0.5f);
 		Text.Add(shortText, Matrix.TR(at, r), new Vec2(0.5f, s.y), TextFit.Wrap, style, TextAlign.TopLeft, TextAlign.TopLeft);
 		Mesh.Cube.Draw(Material.Unlit, Matrix.TS(at.x + s.x / 2, at.y - s.y / 2, at.z - 0.001f, new Vec3(s.x, s.y, 0.001f)), Color.Black);
+		s = Text.SizeRender(s, style, out offset);
+		Mesh.Cube.Draw(Material.Unlit, Matrix.TS(at.x + s.x / 2, at.y - s.y / 2 + offset, at.z - 0.002f, new Vec3(s.x, s.y, 0.001f)), new Color(0.25f, 0.5f, 0.25f));
 
 		at = new Vec3(0, 0.5f, -0.5f);
-		s = Text.Size(longText, 0.5f);
+		s = Text.SizeLayout(longText, style, 0.5f);
 		Text.Add(longText, Matrix.TR(at, r), new Vec2(0.5f,s.y), TextFit.Wrap, style, TextAlign.TopLeft, TextAlign.TopLeft);
 		Mesh.Cube.Draw(Material.Unlit, Matrix.TS(at.x + s.x / 2, at.y - s.y / 2, at.z - 0.001f, new Vec3(s.x, s.y, 0.001f)), Color.Black);
+		s = Text.SizeRender(s, style, out offset);
+		Mesh.Cube.Draw(Material.Unlit, Matrix.TS(at.x + s.x / 2, at.y - s.y / 2 + offset, at.z - 0.002f, new Vec3(s.x, s.y, 0.001f)), new Color(0.25f, 0.5f, 0.25f));
 
 		Tests.Screenshot("Tests/TextSize.jpg", 1, 800, 300, 75, V.XYZ(0.85f, 0.3f, 0.0f), V.XYZ(0.85f, 0.3f, -0.5f));
 	}

--- a/StereoKit/Native/NativeAPI.cs
+++ b/StereoKit/Native/NativeAPI.cs
@@ -320,8 +320,14 @@ namespace StereoKit
 		[DllImport(dll, CharSet = CharSet.Unicode, CallingConvention = call)] public static extern Vec2      text_size_render               (Vec2 layout_size, TextStyle style, out float out_y_offset);
 
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr    text_style_get_material   (TextStyle style);
-		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern float     text_style_get_char_height(TextStyle style);
-		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void      text_style_set_char_height(TextStyle style, float height_meters);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern float     text_style_get_size       (TextStyle style);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void      text_style_set_size       (TextStyle style, float height_meters);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern float     text_style_get_line_height(TextStyle style);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void      text_style_set_line_height(TextStyle style, float height_percent);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern float     text_style_get_ascender   (TextStyle style);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern float     text_style_get_descender  (TextStyle style);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern float     text_style_get_cap_height (TextStyle style);
+
 
 		///////////////////////////////////////////
 

--- a/StereoKit/Native/NativeAPI.cs
+++ b/StereoKit/Native/NativeAPI.cs
@@ -310,13 +310,14 @@ namespace StereoKit
 
 		///////////////////////////////////////////
 
-		[DllImport(dll, CharSet = cSet,            CallingConvention = call)] public static extern TextStyle text_make_style       (IntPtr font, float character_height, Color color);
-		[DllImport(dll, CharSet = cSet,            CallingConvention = call)] public static extern TextStyle text_make_style_shader(IntPtr font, float character_height, IntPtr shader, Color color);
-		[DllImport(dll, CharSet = cSet,            CallingConvention = call)] public static extern TextStyle text_make_style_mat   (IntPtr font, float character_height, IntPtr material, Color color);
-		[DllImport(dll, CharSet = CharSet.Unicode, CallingConvention = call)] public static extern void      text_add_at_16        (string text, in Matrix transform, TextStyle style, TextAlign position, TextAlign align, float off_x, float off_y, float off_z, Color vertex_tint_linear);
-		[DllImport(dll, CharSet = CharSet.Unicode, CallingConvention = call)] public static extern float     text_add_in_16        (string text, in Matrix transform, Vec2 size, TextFit fit, TextStyle style, TextAlign position, TextAlign align, float off_x, float off_y, float off_z, Color vertex_tint_linear);
-		[DllImport(dll, CharSet = CharSet.Unicode, CallingConvention = call)] public static extern Vec2      text_size_16          (string text, TextStyle style);
-		[DllImport(dll, CharSet = CharSet.Unicode, CallingConvention = call)] public static extern Vec2      text_size_constrained_16 (string text, TextStyle style, float max_width);
+		[DllImport(dll, CharSet = cSet,            CallingConvention = call)] public static extern TextStyle text_make_style                (IntPtr font, float character_height, Color color);
+		[DllImport(dll, CharSet = cSet,            CallingConvention = call)] public static extern TextStyle text_make_style_shader         (IntPtr font, float character_height, IntPtr shader, Color color);
+		[DllImport(dll, CharSet = cSet,            CallingConvention = call)] public static extern TextStyle text_make_style_mat            (IntPtr font, float character_height, IntPtr material, Color color);
+		[DllImport(dll, CharSet = CharSet.Unicode, CallingConvention = call)] public static extern void      text_add_at_16                 (string text, in Matrix transform, TextStyle style, TextAlign position, TextAlign align, float off_x, float off_y, float off_z, Color vertex_tint_linear);
+		[DllImport(dll, CharSet = CharSet.Unicode, CallingConvention = call)] public static extern float     text_add_in_16                 (string text, in Matrix transform, Vec2 size, TextFit fit, TextStyle style, TextAlign position, TextAlign align, float off_x, float off_y, float off_z, Color vertex_tint_linear);
+		[DllImport(dll, CharSet = CharSet.Unicode, CallingConvention = call)] public static extern Vec2      text_size_layout_16            (string text, TextStyle style);
+		[DllImport(dll, CharSet = CharSet.Unicode, CallingConvention = call)] public static extern Vec2      text_size_layout_constrained_16(string text, TextStyle style, float max_width);
+		[DllImport(dll, CharSet = CharSet.Unicode, CallingConvention = call)] public static extern Vec2      text_size_render               (Vec2 layout_size, TextStyle style, out float out_y_offset);
 
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr    text_style_get_material   (TextStyle style);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern float     text_style_get_char_height(TextStyle style);

--- a/StereoKit/Native/NativeAPI.cs
+++ b/StereoKit/Native/NativeAPI.cs
@@ -319,14 +319,16 @@ namespace StereoKit
 		[DllImport(dll, CharSet = CharSet.Unicode, CallingConvention = call)] public static extern Vec2      text_size_layout_constrained_16(string text, TextStyle style, float max_width);
 		[DllImport(dll, CharSet = CharSet.Unicode, CallingConvention = call)] public static extern Vec2      text_size_render               (Vec2 layout_size, TextStyle style, out float out_y_offset);
 
-		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr    text_style_get_material   (TextStyle style);
-		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern float     text_style_get_size       (TextStyle style);
-		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void      text_style_set_size       (TextStyle style, float height_meters);
-		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern float     text_style_get_line_height(TextStyle style);
-		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void      text_style_set_line_height(TextStyle style, float height_percent);
-		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern float     text_style_get_ascender   (TextStyle style);
-		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern float     text_style_get_descender  (TextStyle style);
-		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern float     text_style_get_cap_height (TextStyle style);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern float     text_style_get_line_height_pct(TextStyle style);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void      text_style_set_line_height_pct(TextStyle style, float height_percent);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern float     text_style_get_layout_height  (TextStyle style);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void      text_style_set_layout_height  (TextStyle style, float height_meters);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern float     text_style_get_total_height   (TextStyle style);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void      text_style_set_total_height   (TextStyle style, float height_meters);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr    text_style_get_material       (TextStyle style);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern float     text_style_get_ascender       (TextStyle style);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern float     text_style_get_descender      (TextStyle style);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern float     text_style_get_cap_height     (TextStyle style);
 
 
 		///////////////////////////////////////////

--- a/StereoKit/Systems/Text.cs
+++ b/StereoKit/Systems/Text.cs
@@ -20,30 +20,59 @@ namespace StereoKit
 
 		/// <summary>Returns the maximum height of a text character using
 		/// this style, in meters.</summary>
+		[Obsolete("Use LayoutHeight")]
 		public float CharHeight
 		{
-			get => NativeAPI.text_style_get_size(this);
-			set => NativeAPI.text_style_set_size(this, value);
+			get => NativeAPI.text_style_get_layout_height(this);
+			set => NativeAPI.text_style_set_layout_height(this, value);
 		}
 
-		public float Size
+		/// <summary>(meters) Layout height is the height of the font's
+		/// ascender, which is used for calculating the vertical height of the
+		/// text when doing text layouts. This does _not_ include the height of
+		/// the descender (use TotalHeight), nor does it represent the maximum
+		/// possible height a glyph may extend upwards (use Text.SizeRender).
+		/// </summary>
+		public float LayoutHeight
 		{
-			get => NativeAPI.text_style_get_size(this);
-			set => NativeAPI.text_style_set_size(this, value);
+			get => NativeAPI.text_style_get_layout_height(this);
+			set => NativeAPI.text_style_set_layout_height(this, value);
 		}
 
+		/// <summary>(meters) Height from the layout descender to the layout
+		/// ascender. This is most equivalent to the 'font-size' in CSS or
+		/// other text layout tools. Since ascender and descenders can vary a
+		/// lot, using LayoutHeight in many cases can lead to more consistency
+		/// in the long run.</summary>
+		public float TotalHeight
+		{
+			get => NativeAPI.text_style_get_total_height(this);
+			set => NativeAPI.text_style_set_total_height(this, value);
+		}
+
+		/// <summary>(meters) The height of a standard captial letter, such as
+		/// 'H' or 'T'.</summary>
 		public float CapHeight => NativeAPI.text_style_get_cap_height(this);
+
+		/// <summary>(meters) The layout ascender of the font, this is the
+		/// height of the "tallest" glyphs as far as layout is concerned.
+		/// Characters such as 'l' typically rise above the CapHeight, and this
+		/// value usually matches this height. Some glyphs such as those with
+		/// hats or umlauts will almost always be taller than this height (see
+		/// Text.SizeRender), but this is not used when laying out characters.
+		/// </summary>
 		public float Ascender => NativeAPI.text_style_get_ascender(this);
+		/// <summary>(meters) The layout descender of the font, this is the positive height below the baseline</summary>
 		public float Descender => NativeAPI.text_style_get_descender(this);
 
 		/// <summary>This is the space a full line of text takes, from baseline
 		/// to baseline, as a 0-1 percentage of the font's character height.
 		/// This is similar to CSS line-height, a value of 1.0 means the line
 		/// takes _only_</summary>
-		public float LineHeight
+		public float LineHeightPct
 		{
-			get => NativeAPI.text_style_get_line_height(this);
-			set => NativeAPI.text_style_set_line_height(this, value);
+			get => NativeAPI.text_style_get_line_height_pct(this);
+			set => NativeAPI.text_style_set_line_height_pct(this, value);
 		}
 
 		/// <summary>This is the default text style used by StereoKit.</summary>
@@ -58,15 +87,16 @@ namespace StereoKit
 		/// on Default.ShaderFont.</summary>
 		/// <param name="font">Font asset you want attached to this style.
 		/// </param>
-		/// <param name="characterHeightMeters">Height of a text glyph in
-		/// meters. StereoKit currently bases this on the letter 'T'.</param>
+		/// <param name="layoutHeightMeters">Height of a text glyph in
+		/// meters. StereoKit currently bases this on layout ascender height.
+		/// </param>
 		/// <param name="colorGamma">The gamma space color of the text
 		/// style. This will be embedded in the vertex color of the text
 		/// mesh.</param>
 		/// <returns>A text style id for use with text rendering functions.
 		/// </returns>
-		public static TextStyle FromFont(Font font, float characterHeightMeters, Color colorGamma)
-			=> NativeAPI.text_make_style(font._inst, characterHeightMeters, colorGamma);
+		public static TextStyle FromFont(Font font, float layoutHeightMeters, Color colorGamma)
+			=> NativeAPI.text_make_style(font._inst, layoutHeightMeters, colorGamma);
 
 		/// <summary>Create a text style for use with other text functions! A
 		/// text style is a font plus size/color/material parameters, and are
@@ -77,8 +107,9 @@ namespace StereoKit
 		/// on the provided Shader.</summary>
 		/// <param name="font">Font asset you want attached to this style.
 		/// </param>
-		/// <param name="characterHeightMeters">Height of a text glyph in
-		/// meters. StereoKit currently bases this on the letter 'T'.</param>
+		/// <param name="layoutHeightMeters">Height of a text glyph in
+		/// meters. StereoKit currently bases this on layout ascender height.
+		/// </param>
 		/// <param name="shader">This style will create and use a unique
 		/// Material based on the Shader that you provide here.</param>
 		/// <param name="colorGamma">The gamma space color of the text
@@ -86,8 +117,8 @@ namespace StereoKit
 		/// mesh.</param>
 		/// <returns>A text style id for use with text rendering functions.
 		/// </returns>
-		public static TextStyle FromFont(Font font, float characterHeightMeters, Shader shader, Color colorGamma)
-			=> NativeAPI.text_make_style_shader(font._inst, characterHeightMeters, shader._inst, colorGamma);
+		public static TextStyle FromFont(Font font, float layoutHeightMeters, Shader shader, Color colorGamma)
+			=> NativeAPI.text_make_style_shader(font._inst, layoutHeightMeters, shader._inst, colorGamma);
 
 		/// <summary>Create a text style for use with other text functions! A
 		/// text style is a font plus size/color/material parameters, and are
@@ -101,8 +132,9 @@ namespace StereoKit
 		/// Shader, or takes neither a Shader nor a Material!</summary>
 		/// <param name="font">Font asset you want attached to this style.
 		/// </param>
-		/// <param name="characterHeightMeters">Height of a text glyph in
-		/// meters. StereoKit currently bases this on the letter 'T'.</param>
+		/// <param name="layoutHeightMeters">Height of a text glyph in
+		/// meters. StereoKit currently bases this on layout ascender height.
+		/// </param>
 		/// <param name="material">Which material should be used to render
 		/// the text with? Note that this does NOT duplicate the material, so
 		/// some parameters of this Material instance will get overwritten, 
@@ -114,8 +146,8 @@ namespace StereoKit
 		/// mesh.</param>
 		/// <returns>A text style id for use with text rendering functions.
 		/// </returns>
-		public static TextStyle FromFont(Font font, float characterHeightMeters, Material material, Color colorGamma)
-			=> NativeAPI.text_make_style_mat(font._inst, characterHeightMeters, material._inst, colorGamma);
+		public static TextStyle FromFont(Font font, float layoutHeightMeters, Material material, Color colorGamma)
+			=> NativeAPI.text_make_style_mat(font._inst, layoutHeightMeters, material._inst, colorGamma);
 	}
 
 	/// <summary>A collection of functions for rendering and working with text.

--- a/StereoKit/Systems/Text.cs
+++ b/StereoKit/Systems/Text.cs
@@ -22,9 +22,29 @@ namespace StereoKit
 		/// this style, in meters.</summary>
 		public float CharHeight
 		{
-			get => NativeAPI.text_style_get_char_height(this);
-			set => NativeAPI.text_style_set_char_height(this, value);
-		} 
+			get => NativeAPI.text_style_get_size(this);
+			set => NativeAPI.text_style_set_size(this, value);
+		}
+
+		public float Size
+		{
+			get => NativeAPI.text_style_get_size(this);
+			set => NativeAPI.text_style_set_size(this, value);
+		}
+
+		public float CapHeight => NativeAPI.text_style_get_cap_height(this);
+		public float Ascender => NativeAPI.text_style_get_ascender(this);
+		public float Descender => NativeAPI.text_style_get_descender(this);
+
+		/// <summary>This is the space a full line of text takes, from baseline
+		/// to baseline, as a 0-1 percentage of the font's character height.
+		/// This is similar to CSS line-height, a value of 1.0 means the line
+		/// takes _only_</summary>
+		public float LineHeight
+		{
+			get => NativeAPI.text_style_get_line_height(this);
+			set => NativeAPI.text_style_set_line_height(this, value);
+		}
 
 		/// <summary>This is the default text style used by StereoKit.</summary>
 		public static TextStyle Default { get => new TextStyle { _id = 0 }; }

--- a/StereoKit/Systems/Text.cs
+++ b/StereoKit/Systems/Text.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.InteropServices;
+﻿using System;
+using System.Runtime.InteropServices;
 
 namespace StereoKit
 {
@@ -283,16 +284,18 @@ namespace StereoKit
 		/// <param name="style">The visual style of the text, see
 		/// Text.MakeStyle or the TextStyle object for more details.</param>
 		/// <returns>The width and height of the text in meters.</returns>
+		[Obsolete("Use UI.SizeLayout")]
 		public static Vec2 Size(string text, TextStyle style)
-			=> NativeAPI.text_size_16(text, style);
+			=> NativeAPI.text_size_layout_16(text, style);
 
 		/// <summary>Sometimes you just need to know how much room some text
 		/// takes up! This finds the size of the text in meters when using the
 		/// default style!</summary>
 		/// <param name="text">Text you want to find the size of.</param>
 		/// <returns>The width and height of the text in meters.</returns>
+		[Obsolete("Use UI.SizeLayout")]
 		public static Vec2 Size(string text)
-			=> NativeAPI.text_size_16(text, TextStyle.Default);
+			=> NativeAPI.text_size_layout_16(text, TextStyle.Default);
 
 		/// <summary>Need to know how much space text will take when
 		/// constrained to a certain width? This will find it using the default
@@ -302,8 +305,9 @@ namespace StereoKit
 		/// <returns>The size that this text will take up, in meters! Width
 		/// will be the same as maxWidth as long as the text takes more than
 		/// one line, and height will be the total height of the text.</returns>
+		[Obsolete("Use UI.SizeLayout")]
 		public static Vec2 Size(string text, float maxWidth)
-			=> NativeAPI.text_size_constrained_16(text, TextStyle.Default, maxWidth);
+			=> NativeAPI.text_size_layout_constrained_16(text, TextStyle.Default, maxWidth);
 
 		/// <summary>Need to know how much space text will take when
 		/// constrained to a certain width? This will find it using the
@@ -313,7 +317,42 @@ namespace StereoKit
 		/// <returns>The size that this text will take up, in meters! Width
 		/// will be the same as maxWidth as long as the text takes more than
 		/// one line, and height will be the total height of the text.</returns>
+		[Obsolete("Use UI.SizeLayout")]
 		public static Vec2 Size(string text, TextStyle style, float maxWidth)
-			=> NativeAPI.text_size_constrained_16(text, style, maxWidth);
+			=> SizeLayout(text, style, maxWidth);
+
+		/// <summary>Sometimes you just need to know how much room some text
+		/// takes up! This finds the layout size of the text in meters when
+		/// using the indicated style!  This does not include ascender and
+		/// descender size, so rendering using this as a clipping size will
+		/// result in ascenders and descenders getting clipped.</summary>
+		/// <param name="text">Text you want to find the size of.</param>
+		/// <param name="style">The visual style of the text, see
+		/// Text.MakeStyle or the TextStyle object for more details.</param>
+		/// <returns>The width and height of the text in meters.</returns>
+		public static Vec2 SizeLayout(string text, TextStyle style)
+			=> NativeAPI.text_size_layout_16(text, style);
+
+		/// <summary>Need to know how much layout space text will take when
+		/// constrained to a certain width? This will find it using the
+		/// indicated text style! This does not include ascender and descender
+		/// size, so rendering using this as a clipping size will result in
+		/// ascenders and descenders getting clipped.</summary>
+		/// <param name="text">Text to measure the size of.</param>
+		/// <param name="maxWidth">Width of the available space in meters.</param>
+		/// <returns>The layoutsize that this text will take up, in meters!
+		/// Width will be the same as maxWidth as long as the text takes more
+		/// than one line, and height will be the total layout height of the
+		/// text.</returns>
+		public static Vec2 SizeLayout(string text, TextStyle style, float maxWidth)
+			=> NativeAPI.text_size_layout_constrained_16(text, style, maxWidth);
+
+		/// <summary>This modifies a text layout size with information related</summary>
+		/// <param name="sizeLayout"></param>
+		/// <param name="style"></param>
+		/// <param name="yOffset"></param>
+		/// <returns></returns>
+		public static Vec2 SizeRender(Vec2 sizeLayout, TextStyle style, out float yOffset)
+			=> NativeAPI.text_size_render(sizeLayout, style, out yOffset);
 	}
 }

--- a/StereoKitC/asset_types/font.cpp
+++ b/StereoKitC/asset_types/font.cpp
@@ -154,12 +154,12 @@ void font_source_load_data(font_source_t* font) {
 
 	int32_t ascender, descender, line_gap;
 	if (stbtt_GetFontVMetricsOS2(&font->info, &ascender, &descender, &line_gap)) {
-		font->ascender  = ceilf(ascender               * font->scale);
-		font->descender = ceilf(fabsf(descender)       * font->scale);
+		font->ascender  = ceilf(      ascender   * font->scale);
+		font->descender = ceilf(fabsf(descender) * font->scale);
 	} else {
 		stbtt_GetFontVMetrics(&font->info, &ascender, &descender, &line_gap);
-		font->ascender  = ceilf(ascender               * font->scale);
-		font->descender = ceilf(fabsf(descender)       * font->scale);
+		font->ascender  = ceilf(      ascender   * font->scale);
+		font->descender = ceilf(fabsf(descender) * font->scale);
 	}
 	font->total_height = font->ascender + font->descender;
 

--- a/StereoKitC/asset_types/font.h
+++ b/StereoKitC/asset_types/font.h
@@ -24,8 +24,6 @@ struct _font_t {
 	font_char_t characters[128];
 	float       character_ascend;
 	float       character_descend;
-	float       line_gap;
-	float       space_width;
 
 	hashmap_t<font_glyph_t, font_char_t> glyph_map;
 	hashmap_t<char32_t,     font_char_t> character_map;

--- a/StereoKitC/asset_types/font.h
+++ b/StereoKitC/asset_types/font.h
@@ -21,9 +21,11 @@ struct font_glyph_t {
 struct _font_t {
 	asset_header_t header;
 	tex_t       font_tex;
-	font_char_t characters[128];
-	float       character_ascend;
-	float       character_descend;
+	float       layout_ascend_pct;
+	float       layout_descend_pct;
+	float       render_ascend_pct;
+	float       render_descend_pct;
+	float       cap_height_pct;
 
 	hashmap_t<font_glyph_t, font_char_t> glyph_map;
 	hashmap_t<char32_t,     font_char_t> character_map;
@@ -32,6 +34,8 @@ struct _font_t {
 
 	rect_atlas_t   atlas;
 	uint8_t       *atlas_data;
+
+	font_char_t    characters[128];
 };
 
 font_t font_create_default();

--- a/StereoKitC/stereokit.h
+++ b/StereoKitC/stereokit.h
@@ -1360,7 +1360,7 @@ SK_MakeFlag(text_align_);
 typedef uint32_t text_style_t;
 
 SK_API text_style_t  text_make_style                (font_t font, float character_height,                      color128 color_gamma);
-SK_API text_style_t  text_make_style_shader         (font_t font, float character_height, shader_t shader,     color128 color_gamma);
+SK_API text_style_t  text_make_style_shader         (font_t font, float character_height, shader_t   shader,   color128 color_gamma);
 SK_API text_style_t  text_make_style_mat            (font_t font, float character_height, material_t material, color128 color_gamma);
 SK_API void          text_add_at                    (const char*     text_utf8,  const sk_ref(matrix)  transform, text_style_t style sk_default(0), text_align_ position sk_default(text_align_center), text_align_ align sk_default(text_align_center), float off_x sk_default(0), float off_y sk_default(0), float off_z sk_default(0), color128 vertex_tint_linear sk_default({1,1,1,1}));
 SK_API void          text_add_at_16                 (const char16_t* text_utf16, const sk_ref(matrix)  transform, text_style_t style sk_default(0), text_align_ position sk_default(text_align_center), text_align_ align sk_default(text_align_center), float off_x sk_default(0), float off_y sk_default(0), float off_z sk_default(0), color128 vertex_tint_linear sk_default({1,1,1,1}));
@@ -1375,8 +1375,13 @@ SK_API vec2          text_char_at                   (const char*     text_utf8, 
 SK_API vec2          text_char_at_16                (const char16_t* text_utf16, text_style_t style, int32_t char_index, vec2 *opt_size, text_fit_ fit, text_align_ position, text_align_ align);
 
 SK_API material_t    text_style_get_material        (text_style_t style);
-SK_API float         text_style_get_char_height     (text_style_t style);
-SK_API void          text_style_set_char_height     (text_style_t style, float height_meters);
+SK_API float         text_style_get_line_height     (text_style_t style);
+SK_API void          text_style_set_line_height     (text_style_t style, float height_percentage);
+SK_API float         text_style_get_size            (text_style_t style);
+SK_API void          text_style_set_size            (text_style_t style, float height_meters);
+SK_API float         text_style_get_ascender        (text_style_t style);
+SK_API float         text_style_get_descender       (text_style_t style);
+SK_API float         text_style_get_cap_height      (text_style_t style);
 
 ///////////////////////////////////////////
 

--- a/StereoKitC/stereokit.h
+++ b/StereoKitC/stereokit.h
@@ -1359,9 +1359,9 @@ SK_MakeFlag(text_align_);
 
 typedef uint32_t text_style_t;
 
-SK_API text_style_t  text_make_style                (font_t font, float character_height,                      color128 color_gamma);
-SK_API text_style_t  text_make_style_shader         (font_t font, float character_height, shader_t   shader,   color128 color_gamma);
-SK_API text_style_t  text_make_style_mat            (font_t font, float character_height, material_t material, color128 color_gamma);
+SK_API text_style_t  text_make_style                (font_t font, float layout_height,                      color128 color_gamma);
+SK_API text_style_t  text_make_style_shader         (font_t font, float layout_height, shader_t   shader,   color128 color_gamma);
+SK_API text_style_t  text_make_style_mat            (font_t font, float layout_height, material_t material, color128 color_gamma);
 SK_API void          text_add_at                    (const char*     text_utf8,  const sk_ref(matrix)  transform, text_style_t style sk_default(0), text_align_ position sk_default(text_align_center), text_align_ align sk_default(text_align_center), float off_x sk_default(0), float off_y sk_default(0), float off_z sk_default(0), color128 vertex_tint_linear sk_default({1,1,1,1}));
 SK_API void          text_add_at_16                 (const char16_t* text_utf16, const sk_ref(matrix)  transform, text_style_t style sk_default(0), text_align_ position sk_default(text_align_center), text_align_ align sk_default(text_align_center), float off_x sk_default(0), float off_y sk_default(0), float off_z sk_default(0), color128 vertex_tint_linear sk_default({1,1,1,1}));
 SK_API float         text_add_in                    (const char*     text_utf8,  const sk_ref(matrix)  transform, vec2 size, text_fit_ fit, text_style_t style sk_default(0), text_align_ position sk_default(text_align_center), text_align_ align sk_default(text_align_center), float off_x sk_default(0), float off_y sk_default(0), float off_z sk_default(0), color128 vertex_tint_linear sk_default({1,1,1,1}));
@@ -1374,11 +1374,13 @@ SK_API vec2          text_size_render               (vec2 layout_size,          
 SK_API vec2          text_char_at                   (const char*     text_utf8,  text_style_t style, int32_t char_index, vec2 *opt_size, text_fit_ fit, text_align_ position, text_align_ align);
 SK_API vec2          text_char_at_16                (const char16_t* text_utf16, text_style_t style, int32_t char_index, vec2 *opt_size, text_fit_ fit, text_align_ position, text_align_ align);
 
+SK_API float         text_style_get_line_height_pct (text_style_t style);
+SK_API void          text_style_set_line_height_pct (text_style_t style, float height_percentage);
+SK_API float         text_style_get_layout_height   (text_style_t style);
+SK_API void          text_style_set_layout_height   (text_style_t style, float height_meters);
+SK_API float         text_style_get_total_height    (text_style_t style);
+SK_API void          text_style_set_total_height    (text_style_t style, float height_meters);
 SK_API material_t    text_style_get_material        (text_style_t style);
-SK_API float         text_style_get_line_height     (text_style_t style);
-SK_API void          text_style_set_line_height     (text_style_t style, float height_percentage);
-SK_API float         text_style_get_size            (text_style_t style);
-SK_API void          text_style_set_size            (text_style_t style, float height_meters);
 SK_API float         text_style_get_ascender        (text_style_t style);
 SK_API float         text_style_get_descender       (text_style_t style);
 SK_API float         text_style_get_cap_height      (text_style_t style);

--- a/StereoKitC/stereokit.h
+++ b/StereoKitC/stereokit.h
@@ -1359,23 +1359,24 @@ SK_MakeFlag(text_align_);
 
 typedef uint32_t text_style_t;
 
-SK_API text_style_t  text_make_style               (font_t font, float character_height,                      color128 color_gamma);
-SK_API text_style_t  text_make_style_shader        (font_t font, float character_height, shader_t shader,     color128 color_gamma);
-SK_API text_style_t  text_make_style_mat           (font_t font, float character_height, material_t material, color128 color_gamma);
-SK_API void          text_add_at                   (const char*     text_utf8,  const sk_ref(matrix)  transform, text_style_t style sk_default(0), text_align_ position sk_default(text_align_center), text_align_ align sk_default(text_align_center), float off_x sk_default(0), float off_y sk_default(0), float off_z sk_default(0), color128 vertex_tint_linear sk_default({1,1,1,1}));
-SK_API void          text_add_at_16                (const char16_t* text_utf16, const sk_ref(matrix)  transform, text_style_t style sk_default(0), text_align_ position sk_default(text_align_center), text_align_ align sk_default(text_align_center), float off_x sk_default(0), float off_y sk_default(0), float off_z sk_default(0), color128 vertex_tint_linear sk_default({1,1,1,1}));
-SK_API float         text_add_in                   (const char*     text_utf8,  const sk_ref(matrix)  transform, vec2 size, text_fit_ fit, text_style_t style sk_default(0), text_align_ position sk_default(text_align_center), text_align_ align sk_default(text_align_center), float off_x sk_default(0), float off_y sk_default(0), float off_z sk_default(0), color128 vertex_tint_linear sk_default({1,1,1,1}));
-SK_API float         text_add_in_16                (const char16_t* text_utf16, const sk_ref(matrix)  transform, vec2 size, text_fit_ fit, text_style_t style sk_default(0), text_align_ position sk_default(text_align_center), text_align_ align sk_default(text_align_center), float off_x sk_default(0), float off_y sk_default(0), float off_z sk_default(0), color128 vertex_tint_linear sk_default({1,1,1,1}));
-SK_API vec2          text_size                     (const char*     text_utf8,  text_style_t style sk_default(0));
-SK_API vec2          text_size_16                  (const char16_t* text_utf16, text_style_t style sk_default(0));
-SK_API vec2          text_size_constrained         (const char*     text_utf8,  text_style_t style, float max_width);
-SK_API vec2          text_size_constrained_16      (const char16_t* text_utf16, text_style_t style, float max_width);
-SK_API vec2          text_char_at                  (const char*     text_utf8,  text_style_t style, int32_t char_index, vec2 *opt_size, text_fit_ fit, text_align_ position, text_align_ align);
-SK_API vec2          text_char_at_16               (const char16_t* text_utf16, text_style_t style, int32_t char_index, vec2 *opt_size, text_fit_ fit, text_align_ position, text_align_ align);
+SK_API text_style_t  text_make_style                (font_t font, float character_height,                      color128 color_gamma);
+SK_API text_style_t  text_make_style_shader         (font_t font, float character_height, shader_t shader,     color128 color_gamma);
+SK_API text_style_t  text_make_style_mat            (font_t font, float character_height, material_t material, color128 color_gamma);
+SK_API void          text_add_at                    (const char*     text_utf8,  const sk_ref(matrix)  transform, text_style_t style sk_default(0), text_align_ position sk_default(text_align_center), text_align_ align sk_default(text_align_center), float off_x sk_default(0), float off_y sk_default(0), float off_z sk_default(0), color128 vertex_tint_linear sk_default({1,1,1,1}));
+SK_API void          text_add_at_16                 (const char16_t* text_utf16, const sk_ref(matrix)  transform, text_style_t style sk_default(0), text_align_ position sk_default(text_align_center), text_align_ align sk_default(text_align_center), float off_x sk_default(0), float off_y sk_default(0), float off_z sk_default(0), color128 vertex_tint_linear sk_default({1,1,1,1}));
+SK_API float         text_add_in                    (const char*     text_utf8,  const sk_ref(matrix)  transform, vec2 size, text_fit_ fit, text_style_t style sk_default(0), text_align_ position sk_default(text_align_center), text_align_ align sk_default(text_align_center), float off_x sk_default(0), float off_y sk_default(0), float off_z sk_default(0), color128 vertex_tint_linear sk_default({1,1,1,1}));
+SK_API float         text_add_in_16                 (const char16_t* text_utf16, const sk_ref(matrix)  transform, vec2 size, text_fit_ fit, text_style_t style sk_default(0), text_align_ position sk_default(text_align_center), text_align_ align sk_default(text_align_center), float off_x sk_default(0), float off_y sk_default(0), float off_z sk_default(0), color128 vertex_tint_linear sk_default({1,1,1,1}));
+SK_API vec2          text_size_layout               (const char*     text_utf8,  text_style_t style sk_default(0));
+SK_API vec2          text_size_layout_16            (const char16_t* text_utf16, text_style_t style sk_default(0));
+SK_API vec2          text_size_layout_constrained   (const char*     text_utf8,  text_style_t style, float max_width);
+SK_API vec2          text_size_layout_constrained_16(const char16_t* text_utf16, text_style_t style, float max_width);
+SK_API vec2          text_size_render               (vec2 layout_size,           text_style_t style, float* out_y_offset);
+SK_API vec2          text_char_at                   (const char*     text_utf8,  text_style_t style, int32_t char_index, vec2 *opt_size, text_fit_ fit, text_align_ position, text_align_ align);
+SK_API vec2          text_char_at_16                (const char16_t* text_utf16, text_style_t style, int32_t char_index, vec2 *opt_size, text_fit_ fit, text_align_ position, text_align_ align);
 
-SK_API material_t    text_style_get_material       (text_style_t style);
-SK_API float         text_style_get_char_height    (text_style_t style);
-SK_API void          text_style_set_char_height    (text_style_t style, float height_meters);
+SK_API material_t    text_style_get_material        (text_style_t style);
+SK_API float         text_style_get_char_height     (text_style_t style);
+SK_API void          text_style_set_char_height     (text_style_t style, float height_meters);
 
 ///////////////////////////////////////////
 

--- a/StereoKitC/systems/defaults.cpp
+++ b/StereoKitC/systems/defaults.cpp
@@ -304,7 +304,10 @@ bool defaults_init() {
 		return false;
 	}
 	font_set_id(sk_default_font, default_id_font);
-	sk_default_text_style = text_make_style_mat(sk_default_font, 20 * mm2m, sk_default_material_font, color128{ 1,1,1,1 });
+	sk_default_text_style = text_make_style_mat(sk_default_font, 0.02f, sk_default_material_font, color128{ 1,1,1,1 });
+	// TODO: v0.4, switch these to something more intentional instead of backwards compatible
+	text_style_set_size       (sk_default_text_style, 0.02f * (0.02f / text_style_get_ascender(sk_default_text_style))); // This matches the original SK size for compat, for now.
+	text_style_set_line_height(sk_default_text_style, 1.2f);
 
 	// Sounds
 	sk_default_click = sound_generate([](float t){

--- a/StereoKitC/systems/defaults.cpp
+++ b/StereoKitC/systems/defaults.cpp
@@ -306,8 +306,8 @@ bool defaults_init() {
 	font_set_id(sk_default_font, default_id_font);
 	sk_default_text_style = text_make_style_mat(sk_default_font, 0.02f, sk_default_material_font, color128{ 1,1,1,1 });
 	// TODO: v0.4, switch these to something more intentional instead of backwards compatible
-	text_style_set_size       (sk_default_text_style, 0.02f * (0.02f / text_style_get_ascender(sk_default_text_style))); // This matches the original SK size for compat, for now.
-	text_style_set_line_height(sk_default_text_style, 1.2f);
+	// This matches the original SK line height for compat, for now.
+	text_style_set_line_height_pct(sk_default_text_style, 1.18f);
 
 	// Sounds
 	sk_default_click = sound_generate([](float t){

--- a/StereoKitC/systems/text.cpp
+++ b/StereoKitC/systems/text.cpp
@@ -209,13 +209,13 @@ void text_style_set_total_height(text_style_t style, float height_meters) {
 
 ///////////////////////////////////////////
 
-float text_style_get_layout_height_pct(text_style_t style) {
+float text_style_get_layout_height(text_style_t style) {
 	return text_styles[style].line_baseline * text_styles[style].scale;
 }
 
 ///////////////////////////////////////////
 
-void text_style_set_layout_height_pct(text_style_t style, float height_meters) {
+void text_style_set_layout_height(text_style_t style, float height_meters) {
 	text_styles[style].scale = height_meters / text_styles[style].line_baseline;
 }
 

--- a/StereoKitC/systems/text.cpp
+++ b/StereoKitC/systems/text.cpp
@@ -180,10 +180,8 @@ text_style_t text_make_style_mat(font_t font, float character_height, material_t
 	style.buffer_index    = (uint32_t)index;
 	style.color           = color_to_32( color_to_linear( color ) );
 	style.height          = character_height;
-	style.scale           = character_height;// / font->cap_height_pct;
+	style.scale           = character_height;
 	style.cap_height      = font->cap_height_pct;
-	//style.line_baseline   = font->cap_height_pct; //font->layout_ascend_pct;
-	//style.scender_extra   = font->layout_descend_pct + (font->layout_ascend_pct- font->cap_height_pct);//font->layout_descend_pct;
 	style.line_baseline   = font->layout_ascend_pct;
 	style.scender_extra   = font->layout_descend_pct;
 	style.line_spacing    = style.scender_extra + 0.4f;
@@ -209,7 +207,7 @@ float text_style_get_size(text_style_t style) {
 
 void text_style_set_size(text_style_t style, float height_meters) {
 	text_styles[style].height = height_meters;
-	text_styles[style].scale = height_meters;// / text_styles[style].font->cap_height_pct;
+	text_styles[style].scale = height_meters;
 }
 
 ///////////////////////////////////////////
@@ -233,7 +231,6 @@ float text_style_get_cap_height(text_style_t style) {
 ///////////////////////////////////////////
 
 float text_style_get_line_height(text_style_t style) {
-	//return (text_styles[style].line_spacing - text_styles[style].font->layout_descend_pct) + 1.0f;
 	return (text_styles[style].line_spacing - text_styles[style].scender_extra) + 1.0f;
 }
 

--- a/StereoKitC/systems/text.cpp
+++ b/StereoKitC/systems/text.cpp
@@ -23,8 +23,13 @@ struct _text_style_t {
 	font_t         font;
 	uint32_t       buffer_index;
 	color32        color;
-	float          char_height;
+	float          height;
+	float          ascender;
+	float          scender_extra;
+	float          cap_height;
+	float          scale;
 	float          line_spacing;
+	float          line_baseline;
 };
 
 struct text_buffer_t {
@@ -36,11 +41,6 @@ struct text_buffer_t {
 	int32_t        vert_count;
 	int32_t        vert_cap;
 	bool32_t       dirty_inds;
-};
-
-struct text_stepper_t {
-	bool32_t       wrap;
-	vec2           bounds;
 };
 
 ///////////////////////////////////////////
@@ -179,8 +179,14 @@ text_style_t text_make_style_mat(font_t font, float character_height, material_t
 	style.font            = font;
 	style.buffer_index    = (uint32_t)index;
 	style.color           = color_to_32( color_to_linear( color ) );
-	style.line_spacing    = 1.0f;
-	style.char_height     = character_height;
+	style.height          = character_height;
+	style.scale           = character_height;// / font->cap_height_pct;
+	style.cap_height      = font->cap_height_pct;
+	//style.line_baseline   = font->cap_height_pct; //font->layout_ascend_pct;
+	//style.scender_extra   = font->layout_descend_pct + (font->layout_ascend_pct- font->cap_height_pct);//font->layout_descend_pct;
+	style.line_baseline   = font->layout_ascend_pct;
+	style.scender_extra   = font->layout_descend_pct;
+	style.line_spacing    = style.scender_extra + 0.4f;
 	
 	return (text_style_t)text_styles.add(style);
 }
@@ -195,14 +201,46 @@ material_t text_style_get_material(text_style_t style) {
 
 ///////////////////////////////////////////
 
-float text_style_get_char_height(text_style_t style) {
-	return text_styles[style].char_height;
+float text_style_get_size(text_style_t style) {
+	return text_styles[style].height;
 }
 
 ///////////////////////////////////////////
 
-void text_style_set_char_height(text_style_t style, float height_meters) {
-	text_styles[style].char_height = height_meters;
+void text_style_set_size(text_style_t style, float height_meters) {
+	text_styles[style].height = height_meters;
+	text_styles[style].scale = height_meters;// / text_styles[style].font->cap_height_pct;
+}
+
+///////////////////////////////////////////
+
+float text_style_get_ascender(text_style_t style) {
+	return text_styles[style].font->layout_ascend_pct * text_styles[style].scale;
+}
+
+///////////////////////////////////////////
+
+float text_style_get_descender(text_style_t style) {
+	return text_styles[style].font->layout_descend_pct * text_styles[style].scale;
+}
+
+///////////////////////////////////////////
+
+float text_style_get_cap_height(text_style_t style) {
+	return text_styles[style].font->cap_height_pct * text_styles[style].scale;
+}
+
+///////////////////////////////////////////
+
+float text_style_get_line_height(text_style_t style) {
+	//return (text_styles[style].line_spacing - text_styles[style].font->layout_descend_pct) + 1.0f;
+	return (text_styles[style].line_spacing - text_styles[style].scender_extra) + 1.0f;
+}
+
+///////////////////////////////////////////
+
+void text_style_set_line_height(text_style_t style, float height_percentage) {
+	text_styles[style].line_spacing = (height_percentage + text_styles[style].scender_extra) - 1.0f;
 }
 
 ///////////////////////////////////////////
@@ -221,7 +259,7 @@ float text_step_line_length(const C *start, int32_t *out_char_count, const C **o
 		}
 		*out_char_count = ch == '\n' ? count + 1 : count;
 		*out_next_start = curr;
-		return width * style->char_height;
+		return width * style->scale;
 	}
 
 	// If we _are_ wrapping, we gotta do it the tricky way
@@ -253,7 +291,7 @@ float text_step_line_length(const C *start, int32_t *out_char_count, const C **o
 
 		// Advance by character width
 		const font_char_t *char_info  = font_get_glyph(style->font, curr);
-		float              next_width = char_info->xadvance*style->char_height + curr_width;
+		float              next_width = char_info->xadvance*style->scale + curr_width;
 
 		// Check if it steps out of bounds
 		if (!is_break && next_width > max_width) {
@@ -298,7 +336,7 @@ inline vec2 text_size_layout_constrained_g(const C* text, text_style_t style_id,
 		line_count += 1;
 	}
 
-	return {line_count > 1 ? max_width : largest_width, (line_count + (line_count - 1) * style->line_spacing) * style->char_height };
+	return {line_count > 1 ? max_width : largest_width, (line_count * style->line_baseline + (line_count - 1) * style->line_spacing) * style->scale };
 }
 
 vec2 text_size_layout_constrained   (const char     *text_utf8,  text_style_t style, float max_width) { return text_size_layout_constrained_g<char,     utf8_decode_fast_b >(text_utf8,  style, max_width); }
@@ -307,10 +345,11 @@ vec2 text_size_layout_constrained_16(const char16_t* text_utf16, text_style_t st
 ///////////////////////////////////////////
 
 template<typename C, bool (*char_decode_b_T)(const C *, const C **, char32_t *)>
-inline vec2 text_size_layout_g(const C *text, text_style_t style) {
+inline vec2 text_size_layout_g(const C *text, text_style_t style_id) {
 	if (text == nullptr) return {};
 
-	font_t      font  = text_styles[style].font;
+	const _text_style_t* style = &text_styles[style_id];
+	font_t      font  = style->font;
 	char32_t    curr  = 0;
 	float       x     = 0;
 	int         y     = 1;
@@ -320,13 +359,13 @@ inline vec2 text_size_layout_g(const C *text, text_style_t style) {
 
 		// Do spacing for whitespace characters
 		if (curr == '\n') {
-			if (x > max_x) max_x = x; 
+			if (x > max_x) max_x = x;
 			x  = 0;
 			y += 1;
-		} else x += ch->xadvance * text_styles[style].char_height;
+		} else x += ch->xadvance * style->scale;
 	}
 	if (x > max_x) max_x = x;
-	return vec2{ max_x, (y + (y - 1) * text_styles[style].line_spacing) * text_styles[style].char_height };
+	return vec2{ max_x, (y * style->line_baseline + (y - 1) * (style->line_spacing)) * style->scale };
 }
 
 vec2 text_size_layout   (const char     *text_utf8,  text_style_t style) { return text_size_layout_g<char,     utf8_decode_fast_b >(text_utf8,  style); }
@@ -335,10 +374,11 @@ vec2 text_size_layout_16(const char16_t *text_utf16, text_style_t style) { retur
 ///////////////////////////////////////////
 
 vec2 text_size_render(vec2 layout_size, text_style_t style_id, float* out_y_offset) {
-	_text_style_t* style  = &text_styles[style_id];
-	font_t         font   = style->font;
-	vec2           result = { layout_size.x, layout_size.y + (font->character_ascend + font->character_descend) * style->char_height };
-	if (out_y_offset) *out_y_offset = font->character_ascend * style->char_height;
+	_text_style_t* style        = &text_styles[style_id];
+	font_t         font         = style->font;
+	float          additional_y = font->render_ascend_pct - font->layout_ascend_pct;
+	vec2           result       = { layout_size.x, layout_size.y + (additional_y + font->render_descend_pct) * style->scale };
+	if (out_y_offset) *out_y_offset = additional_y * style->scale;
 	return result;
 }
 
@@ -358,7 +398,7 @@ float text_step_height(const C *text, int32_t *out_length, const _text_style_t *
 	}
 
 	*out_length = length;
-	return (height + (height-1)*style->line_spacing) * style->char_height;
+	return (height + (height-1)*style->line_spacing) * style->scale;
 }
 
 ///////////////////////////////////////////
@@ -371,7 +411,7 @@ void text_step_next_line(const C* start, const _text_style_t* style, text_align_
 	if (align & text_align_x_center) align_x = ((max_width - line_size) / 2.f);
 	if (align & text_align_x_right)  align_x = (max_width - line_size);
 	ref_pos->x = start_x - align_x;
-	ref_pos->y -= style->char_height;
+	ref_pos->y -= style->line_baseline * style->scale;
 }
 
 ///////////////////////////////////////////
@@ -381,12 +421,12 @@ void text_step_position(char32_t ch, const font_char_t* char_info, const C* next
 	*ref_line_remaining = *ref_line_remaining - 1;
 	if (*ref_line_remaining <= 0) {
 		text_step_next_line<C, char_decode_b_T>(next, style, align, wrap, max_width, start_x, ref_line_remaining, ref_pos);
-		ref_pos->y -= style->char_height * style->line_spacing;
+		ref_pos->y -= style->line_spacing * style->scale;
 		return;
 	}
 
 	if (ch != '\n') {
-		ref_pos->x -= char_info->xadvance * style->char_height;
+		ref_pos->x -= char_info->xadvance * style->scale;
 	}
 }
 
@@ -426,7 +466,7 @@ inline vec2 text_char_at_g(const C *text, text_style_t style_id, int32_t char_in
 		bounds.y = text_height;
 
 	// Align the start based on the size of the bounds
-	vec2 start = { 0, style->char_height };
+	vec2 start = { 0, style->scale };
 	if      (position & text_align_x_center) start.x += bounds.x / 2.f;
 	else if (position & text_align_x_right)  start.x += bounds.x;
 	if      (position & text_align_y_center) start.y += bounds.y / 2.f;
@@ -453,9 +493,9 @@ inline vec2 text_char_at_g(const C *text, text_style_t style_id, int32_t char_in
 		line_remaining--;
 		if (line_remaining <= 0 && *text != '\0') {
 			text_step_next_line<C, char_decode_b_T>(text, style, align, wrap, bounds.x, start.x, &line_remaining, &pos);
-			pos.y -= style->char_height * style->line_spacing;
+			pos.y -= style->line_spacing * style->scale;
 		} else if (c != '\n') {
-			pos.x -= char_info->xadvance * style->char_height;
+			pos.x -= char_info->xadvance * style->scale;
 		}
 		
 		count += 1;
@@ -470,10 +510,10 @@ vec2 text_char_at_16(const char16_t* text_utf16, text_style_t style, int32_t cha
 
 void text_add_quad(float x, float y, float off_z, const font_char_t *char_info, const _text_style_t *style_data, color32 color, text_buffer_t &buffer, vec3 base, vec3 normal, vec3 up, vec3 right) {
 	base -= normal * off_z;
-	vec3 x_min = base + (x - char_info->x0 * style_data->char_height) * right;
-	vec3 x_max = base + (x - char_info->x1 * style_data->char_height) * right;
-	vec3 y_min =        (y + char_info->y0 * style_data->char_height) * up;
-	vec3 y_max =        (y + char_info->y1 * style_data->char_height) * up;
+	vec3 x_min = base + (x - char_info->x0 * style_data->scale) * right;
+	vec3 x_max = base + (x - char_info->x1 * style_data->scale) * right;
+	vec3 y_min =        (y + char_info->y0 * style_data->scale) * up;
+	vec3 y_max =        (y + char_info->y1 * style_data->scale) * up;
 
 	buffer.verts[buffer.vert_count++] = { x_min + y_min, normal, vec2{ char_info->u0, char_info->v0 }, color };
 	buffer.verts[buffer.vert_count++] = { x_max + y_min, normal, vec2{ char_info->u1, char_info->v0 }, color };
@@ -484,10 +524,10 @@ void text_add_quad(float x, float y, float off_z, const font_char_t *char_info, 
 ///////////////////////////////////////////
 
 void text_add_quad_clipped(float x, float y, float off_z, vec2 bounds_min, vec2 bounds_max, const font_char_t *char_info, const _text_style_t *style_data, color32 color, text_buffer_t &buffer, const XMMATRIX &tr, vec3 normal, vec3 up, vec3 right) {
-	float x_max = x - char_info->x0 * style_data->char_height;
-	float x_min = x - char_info->x1 * style_data->char_height;
-	float y_max = y + char_info->y0 * style_data->char_height;
-	float y_min = y + char_info->y1 * style_data->char_height;
+	float x_max = x - char_info->x0 * style_data->scale;
+	float x_min = x - char_info->x1 * style_data->scale;
+	float y_max = y + char_info->y0 * style_data->scale;
+	float y_min = y + char_info->y1 * style_data->scale;
 
 	// Ditch out if it's completely out of bounds
 	if (x_min > bounds_max.x ||
@@ -637,7 +677,7 @@ float text_add_in_g(const C* text, const matrix& transform, vec2 size, text_fit_
 			text_step_position<C, char_decode_b_T>(c, char_info, text, style, align, wrap, bounds.x, start.x, &line_remaining, &pos);
 		}
 	}
-	return (start.y - pos.y) - style->char_height;
+	return (start.y - pos.y) - style->scale;
 }
 
 

--- a/StereoKitC/systems/text.cpp
+++ b/StereoKitC/systems/text.cpp
@@ -398,7 +398,7 @@ float text_step_height(const C *text, int32_t *out_length, const _text_style_t *
 	}
 
 	*out_length = length;
-	return (height + (height-1)*style->line_spacing) * style->scale;
+	return (height*style->line_baseline + (height-1)*style->line_spacing) * style->scale;
 }
 
 ///////////////////////////////////////////
@@ -593,15 +593,15 @@ float text_add_in_g(const C* text, const matrix& transform, vec2 size, text_fit_
 	vec3 normal = matrix_mul_direction(tr, vec3_forward);
 
 	// Debug draw bounds
-	/*vec2 dbg_start = step.start;
-	if      (position & text_align_x_center) dbg_start.x += step.bounds.x / 2.f;
-	else if (position & text_align_x_right)  dbg_start.x += step.bounds.x;
-	if      (position & text_align_y_center) dbg_start.y += step.bounds.y / 2.f;
-	else if (position & text_align_y_bottom) dbg_start.y += step.bounds.y;
-	line_add({ dbg_start.x, dbg_start.y,                 off_z }, { dbg_start.x - step.bounds.x, dbg_start.y, off_z }, { 255,0,255,255 }, { 255,0,255,255 }, 0.002f);
-	line_add({ dbg_start.x, dbg_start.y - step.bounds.y, off_z }, { dbg_start.x - step.bounds.x, dbg_start.y - step.bounds.y, off_z }, { 255,255,255,255 }, { 255,255,255,255 }, 0.002f);
-	line_add({ dbg_start.x, dbg_start.y,                 off_z }, { dbg_start.x,                 dbg_start.y - step.bounds.y, off_z }, { 255,255,255,255 }, { 255,255,255,255 }, 0.002f);
-	line_add({ dbg_start.x - step.bounds.x, dbg_start.y, off_z }, { dbg_start.x - step.bounds.x, dbg_start.y - step.bounds.y, off_z }, { 255,255,255,255 }, { 255,255,255,255 }, 0.002f);*/
+	/*vec3 dbg_start = matrix_transform_pt(transform, {off_x, off_y, off_z});
+	if      (position & text_align_x_center) dbg_start.x += size.x / 2.f;
+	else if (position & text_align_x_right)  dbg_start.x += size.x;
+	if      (position & text_align_y_center) dbg_start.y += size.y / 2.f;
+	else if (position & text_align_y_bottom) dbg_start.y += size.y;
+	line_add({ dbg_start.x,          dbg_start.y,          dbg_start.z }, { dbg_start.x - size.x, dbg_start.y,          dbg_start.z }, { 255,0,  255,255 }, { 255,0,255,  255 }, 0.0005f);
+	line_add({ dbg_start.x,          dbg_start.y - size.y, dbg_start.z }, { dbg_start.x - size.x, dbg_start.y - size.y, dbg_start.z }, { 255,255,255,255 }, { 255,255,255,255 }, 0.0005f);
+	line_add({ dbg_start.x,          dbg_start.y,          dbg_start.z }, { dbg_start.x,          dbg_start.y - size.y, dbg_start.z }, { 255,255,255,255 }, { 255,255,255,255 }, 0.0005f);
+	line_add({ dbg_start.x - size.x, dbg_start.y,          dbg_start.z }, { dbg_start.x - size.x, dbg_start.y - size.y, dbg_start.z }, { 255,255,255,255 }, { 255,255,255,255 }, 0.0005f);*/
 
 	// Ensure scale is right for our fit
 	vec2 bounds = size;

--- a/StereoKitC/tools/file_picker.cpp
+++ b/StereoKitC/tools/file_picker.cpp
@@ -426,7 +426,7 @@ void file_picker_update() {
 		// That's the fragment we'll start with
 		if (fp_path.fragments.count > 0) {
 			for (int32_t i = start; i >= 0; i--) {
-				float curr_size = fminf(max_width / 4, text_size(fp_path.fragments[i]).x + padding * 2);
+				float curr_size = fminf(max_width / 4, text_size_layout(fp_path.fragments[i]).x + padding * 2);
 				if (width + curr_size > max_width) {
 					break;
 				}
@@ -438,7 +438,7 @@ void file_picker_update() {
 		if (fp_path.fragments.count == 0) ui_layout_reserve(vec2{ max_width, line_height });
 		for (int32_t i = start; i < fp_path.fragments.count; i++) {
 			ui_push_idi(i);
-			vec2 curr_size = { fminf(max_width / 4, text_size(fp_path.fragments[i]).x + padding * 2), line_height };
+			vec2 curr_size = { fminf(max_width / 4, text_size_layout(fp_path.fragments[i]).x + padding * 2), line_height };
 			if (ui_button_sz(fp_path.fragments[i], curr_size) && i < fp_path.fragments.count - 1) {
 				char* new_path = string_copy(fp_path.folder);
 				for (int32_t p = i; p < fp_path.fragments.count - 1; p++)

--- a/StereoKitC/ui/stereokit_ui.cpp
+++ b/StereoKitC/ui/stereokit_ui.cpp
@@ -138,7 +138,7 @@ void ui_model_at(model_t model, vec3 start, vec3 size, color128 color) {
 void ui_hseparator() {
 	vec3 pos;
 	vec2 size;
-	ui_layout_reserve_sz({ 0, text_style_get_size(ui_get_text_style())*0.4f }, false, &pos, &size);
+	ui_layout_reserve_sz({ 0, text_style_get_ascender(ui_get_text_style())*0.4f }, false, &pos, &size);
 
 	ui_draw_element(ui_vis_separator, pos, vec3{ size.x, size.y, size.y / 2.0f }, 0);
 }
@@ -200,7 +200,7 @@ void _ui_button_img_surface(const C* text, sprite_t image, ui_btn_layout_ image_
 	vec2  text_size;
 	text_align_ text_align;
 	float aspect = image != nullptr ? sprite_get_aspect(image) : 1.0f;
-	float font_size = text_style_get_size(ui_get_text_style());
+	float font_size = text_style_get_ascender(ui_get_text_style());
 	switch (image_layout) {
 	default:
 	case ui_btn_layout_left:
@@ -255,17 +255,18 @@ void _ui_button_img_surface(const C* text, sprite_t image, ui_btn_layout_ image_
 
 template<typename C>
 vec2 _ui_button_img_size(const C* text, sprite_t image, ui_btn_layout_ image_layout) {
-	vec2  size      = {};
-	float font_size = text_style_get_size(ui_get_text_style());
-	if (image_layout == font_size || image_layout == ui_btn_layout_center_no_text) {
-		size = { font_size, font_size };
+	text_style_t style   = ui_get_text_style();
+	vec2         size    = {};
+	float        text_sz = text_style_get_ascender(style);
+	if (image_layout == ui_btn_layout_center_no_text) {
+		size = { text_sz, text_sz };
 	} else if (image_layout == ui_btn_layout_none) {
-		size = text_size_layout(text, ui_get_text_style());
+		size = text_size_layout(text, style);
 	} else {
-		vec2  txt_size   = text_size_layout(text, ui_get_text_style());
+		vec2  txt_size   = text_size_layout(text, style);
 		float aspect     = image != nullptr ? sprite_get_aspect(image) : 1;
-		float image_size = font_size * aspect;
-		size = vec2{ txt_size.x + image_size + skui_settings.gutter, font_size };
+		float image_size = text_sz * aspect;
+		size = vec2{ txt_size.x + image_size + skui_settings.gutter, text_sz };
 	}
 	return size;
 }
@@ -589,7 +590,7 @@ bool32_t ui_input_at_g(const C* id, C* buffer, int32_t buffer_size, vec3 window_
 
 		int32_t carat_at      = skui_input_carat;
 		vec2    carat_pos     = text_char_at_o(draw_text, style, carat_at, &text_bounds, text_fit_clip, text_align_top_left, text_align_center_left);
-		float   scroll_margin = text_bounds.x - text_style_get_size(ui_get_text_style());
+		float   scroll_margin = text_bounds.x - text_style_get_ascender(ui_get_text_style());
 		while (carat_pos.x < -scroll_margin && *draw_text != '\0' && carat_at >= 0) {
 			draw_text += 1;
 			carat_at  -= 1;

--- a/StereoKitC/ui/stereokit_ui.cpp
+++ b/StereoKitC/ui/stereokit_ui.cpp
@@ -138,7 +138,7 @@ void ui_model_at(model_t model, vec3 start, vec3 size, color128 color) {
 void ui_hseparator() {
 	vec3 pos;
 	vec2 size;
-	ui_layout_reserve_sz({ 0, text_style_get_char_height(ui_get_text_style())*0.4f }, false, &pos, &size);
+	ui_layout_reserve_sz({ 0, text_style_get_size(ui_get_text_style())*0.4f }, false, &pos, &size);
 
 	ui_draw_element(ui_vis_separator, pos, vec3{ size.x, size.y, size.y / 2.0f }, 0);
 }
@@ -200,7 +200,7 @@ void _ui_button_img_surface(const C* text, sprite_t image, ui_btn_layout_ image_
 	vec2  text_size;
 	text_align_ text_align;
 	float aspect = image != nullptr ? sprite_get_aspect(image) : 1.0f;
-	float font_size = text_style_get_char_height(ui_get_text_style());
+	float font_size = text_style_get_size(ui_get_text_style());
 	switch (image_layout) {
 	default:
 	case ui_btn_layout_left:
@@ -256,7 +256,7 @@ void _ui_button_img_surface(const C* text, sprite_t image, ui_btn_layout_ image_
 template<typename C>
 vec2 _ui_button_img_size(const C* text, sprite_t image, ui_btn_layout_ image_layout) {
 	vec2  size      = {};
-	float font_size = text_style_get_char_height(ui_get_text_style());
+	float font_size = text_style_get_size(ui_get_text_style());
 	if (image_layout == font_size || image_layout == ui_btn_layout_center_no_text) {
 		size = { font_size, font_size };
 	} else if (image_layout == ui_btn_layout_none) {
@@ -589,7 +589,7 @@ bool32_t ui_input_at_g(const C* id, C* buffer, int32_t buffer_size, vec3 window_
 
 		int32_t carat_at      = skui_input_carat;
 		vec2    carat_pos     = text_char_at_o(draw_text, style, carat_at, &text_bounds, text_fit_clip, text_align_top_left, text_align_center_left);
-		float   scroll_margin = text_bounds.x - text_style_get_char_height(ui_get_text_style());
+		float   scroll_margin = text_bounds.x - text_style_get_size(ui_get_text_style());
 		while (carat_pos.x < -scroll_margin && *draw_text != '\0' && carat_at >= 0) {
 			draw_text += 1;
 			carat_at  -= 1;

--- a/StereoKitC/ui/stereokit_ui.cpp
+++ b/StereoKitC/ui/stereokit_ui.cpp
@@ -145,8 +145,8 @@ void ui_hseparator() {
 
 ///////////////////////////////////////////
 
-vec2 text_size            (const char16_t* text_utf16, text_style_t style)                  { return text_size_16(text_utf16, style); }
-vec2 text_size_constrained(const char16_t* text_utf16, text_style_t style, float max_width) { return text_size_constrained_16(text_utf16, style, max_width); }
+vec2 text_size_layout            (const char16_t* text_utf16, text_style_t style)                  { return text_size_layout_16(text_utf16, style); }
+vec2 text_size_layout_constrained(const char16_t* text_utf16, text_style_t style, float max_width) { return text_size_layout_constrained_16(text_utf16, style, max_width); }
 
 float ui_text_in  (const char*     text, text_align_ position, text_align_ align, text_fit_ fit, vec3 start, vec2 size, vec2 offset) { return text_add_in   (text, matrix_t(start), size, fit, ui_get_text_style(), position, align, offset.x,offset.y,0, ui_is_enabled() ? color128{ 1, 1, 1, 1 } : color128{ .5f, .5f, .5f, 1 }); }
 float ui_text_in  (const char16_t* text, text_align_ position, text_align_ align, text_fit_ fit, vec3 start, vec2 size, vec2 offset) { return text_add_in_16(text, matrix_t(start), size, fit, ui_get_text_style(), position, align, offset.x,offset.y,0, ui_is_enabled() ? color128{ 1, 1, 1, 1 } : color128{ .5f, .5f, .5f, 1 }); }
@@ -167,8 +167,8 @@ void ui_label_sz_g(const C *text, vec2 size, bool32_t use_padding) {
 void ui_label_sz   (const char     *text, vec2 size, bool32_t use_padding) { ui_label_sz_g<char    >(text, size, use_padding); }
 void ui_label_sz_16(const char16_t *text, vec2 size, bool32_t use_padding) { ui_label_sz_g<char16_t>(text, size, use_padding); }
 
-void ui_label   (const char     *text, bool32_t use_padding) { ui_label_sz_g<char    >(text, text_size(text, ui_get_text_style()) + (use_padding ? vec2{ skui_settings.padding, skui_settings.padding }*2 : vec2{ 0, skui_settings.padding }*2), use_padding); }
-void ui_label_16(const char16_t *text, bool32_t use_padding) { ui_label_sz_g<char16_t>(text, text_size(text, ui_get_text_style()) + (use_padding ? vec2{ skui_settings.padding, skui_settings.padding }*2 : vec2{ 0, skui_settings.padding }*2), use_padding); }
+void ui_label   (const char     *text, bool32_t use_padding) { ui_label_sz_g<char    >(text, text_size_layout(text, ui_get_text_style()) + (use_padding ? vec2{ skui_settings.padding, skui_settings.padding }*2 : vec2{ 0, skui_settings.padding }*2), use_padding); }
+void ui_label_16(const char16_t *text, bool32_t use_padding) { ui_label_sz_g<char16_t>(text, text_size_layout(text, ui_get_text_style()) + (use_padding ? vec2{ skui_settings.padding, skui_settings.padding }*2 : vec2{ 0, skui_settings.padding }*2), use_padding); }
 
 ///////////////////////////////////////////
 
@@ -255,14 +255,14 @@ void _ui_button_img_surface(const C* text, sprite_t image, ui_btn_layout_ image_
 
 template<typename C>
 vec2 _ui_button_img_size(const C* text, sprite_t image, ui_btn_layout_ image_layout) {
-	vec2 size = {};
+	vec2  size      = {};
 	float font_size = text_style_get_char_height(ui_get_text_style());
 	if (image_layout == font_size || image_layout == ui_btn_layout_center_no_text) {
 		size = { font_size, font_size };
 	} else if (image_layout == ui_btn_layout_none) {
-		size = text_size(text, ui_get_text_style());
+		size = text_size_layout(text, ui_get_text_style());
 	} else {
-		vec2  txt_size   = text_size(text, ui_get_text_style());
+		vec2  txt_size   = text_size_layout(text, ui_get_text_style());
 		float aspect     = image != nullptr ? sprite_get_aspect(image) : 1;
 		float image_size = font_size * aspect;
 		size = vec2{ txt_size.x + image_size + skui_settings.gutter, font_size };
@@ -808,8 +808,8 @@ bool32_t ui_text_at_g(const C* text, vec2* opt_ref_scroll, ui_scroll_ scroll_dir
 		text_style_t style       = ui_get_text_style();
 
 		vec2 txt_size = (fit & text_fit_wrap) > 0
-			? text_size_constrained(text, style, size.x - scroll_size)
-			: text_size            (text, style);
+			? text_size_layout_constrained(text, style, size.x - scroll_size)
+			: text_size_layout            (text, style);
 
 		bool show_vertical   = txt_size.y > size.y && (scroll_direction & ui_scroll_vertical)   > 0;
 		bool show_horizontal = txt_size.x > size.x && (scroll_direction & ui_scroll_horizontal) > 0;
@@ -845,8 +845,8 @@ template<typename C>
 bool32_t ui_text_sz_g(const C* text, vec2* opt_ref_scroll, ui_scroll_ scroll_direction, vec2 size, text_align_ text_align, text_fit_ fit) {
 	if (size.x == 0) size.x = ui_layout_remaining().x;
 	if (size.y == 0) size.y = (fit & text_fit_wrap) > 0
-		? text_size_constrained(text, ui_get_text_style(), size.x).y
-		: text_size            (text, ui_get_text_style()).y;
+		? text_size_layout_constrained(text, ui_get_text_style(), size.x).y
+		: text_size_layout            (text, ui_get_text_style()).y;
 
 	vec3 final_pos;
 	vec2 final_size;
@@ -903,7 +903,7 @@ void ui_window_begin_g(const C *text, pose_t &pose, vec2 window_size, ui_win_ wi
 	if (win->type & ui_win_head) {
 		ui_layout_t* layout = ui_layout_curr();
 
-		vec2 txt_size = text_size(text, ui_get_text_style());
+		vec2 txt_size = text_size_layout(text, ui_get_text_style());
 		vec2 size     = vec2{ window_size.x == 0 ? txt_size.x : window_size.x-(skui_settings.margin*2), ui_line_height() };
 		vec3 at       = layout->offset - vec3{ skui_settings.padding, -(size.y+skui_settings.margin), 2*mm2m };
 

--- a/StereoKitC/ui/ui_layout.cpp
+++ b/StereoKitC/ui/ui_layout.cpp
@@ -415,7 +415,7 @@ ui_layout_t* ui_layout_curr() {
 ///////////////////////////////////////////
 
 float ui_line_height() {
-	return skui_settings.padding * 2 + text_style_get_char_height(ui_get_text_style());
+	return skui_settings.padding * 2 + text_style_get_ascender(ui_get_text_style());
 }
 
 ///////////////////////////////////////////

--- a/StereoKitC/ui/ui_theming.cpp
+++ b/StereoKitC/ui/ui_theming.cpp
@@ -1086,7 +1086,7 @@ void ui_theme_visuals_update() {
 
 	_ui_gen_quadrant_mesh(&theme_mesh_slider_pinch, ui_corner_all, fminf((ui_line_height() * 0.5f)/2.f, skui_settings.rounding), 5, false, true, lathe_slider_btn, _countof(lathe_slider_btn));
 	_ui_gen_quadrant_mesh(&theme_mesh_slider_push,  ui_corner_all, fminf((ui_line_height() * 0.55f)/2.f, skui_settings.rounding), 5, false, true, lathe_slider_btn, _countof(lathe_slider_btn));
-	_ui_gen_quadrant_mesh(&theme_mesh_separator,    ui_corner_all, fminf((text_style_get_size(ui_get_text_style()) * 0.4f)/2.f, skui_settings.rounding * 0.1f),  3, false, true, lathe_slider_btn, _countof(lathe_slider_btn));
+	_ui_gen_quadrant_mesh(&theme_mesh_separator,    ui_corner_all, fminf((text_style_get_ascender(ui_get_text_style()) * 0.4f)/2.f, skui_settings.rounding * 0.1f),  3, false, true, lathe_slider_btn, _countof(lathe_slider_btn));
 	
 	float aura_mesh_radius = skui_aura_radius * 0.75f;
 	ui_default_aura_mesh(&theme_mesh_aura, 0, fminf(ui_line_height(), skui_settings.rounding) + aura_mesh_radius, skui_aura_radius - aura_mesh_radius, 7, 5);

--- a/StereoKitC/ui/ui_theming.cpp
+++ b/StereoKitC/ui/ui_theming.cpp
@@ -106,8 +106,8 @@ void ui_theming_init() {
 	skui_font       = font_find(default_id_font);
 	text_style_t style = text_make_style_mat(skui_font, 0.01f, skui_font_mat, { 1,1,1,1 });
 	// TODO: v0.4, switch these to something more intentional instead of backwards compatible (like lineheight 1.4)
-	text_style_set_size       (style, 0.01f    * (0.01f / text_style_get_ascender(style))); // This matches the original SK size for compat, for now.
-	text_style_set_line_height(style, 1.2f);
+	// This matches the original SK size for compat, for now.
+	text_style_set_line_height_pct(style, 1.18f);
 	skui_font_stack.add(style);
 
 	// TODO: v0.4, this sets up default values when zeroed out, with a

--- a/StereoKitC/ui/ui_theming.cpp
+++ b/StereoKitC/ui/ui_theming.cpp
@@ -104,7 +104,11 @@ void ui_theming_init() {
 	skui_font_mat   = material_find(default_id_material_font);
 	material_set_queue_offset(skui_font_mat, -12);
 	skui_font       = font_find(default_id_font);
-	skui_font_stack.add(text_make_style_mat(skui_font, 10 * mm2m, skui_font_mat, {1,1,1,1}));
+	text_style_t style = text_make_style_mat(skui_font, 0.01f, skui_font_mat, { 1,1,1,1 });
+	// TODO: v0.4, switch these to something more intentional instead of backwards compatible (like lineheight 1.4)
+	text_style_set_size       (style, 0.01f    * (0.01f / text_style_get_ascender(style))); // This matches the original SK size for compat, for now.
+	text_style_set_line_height(style, 1.2f);
+	skui_font_stack.add(style);
 
 	// TODO: v0.4, this sets up default values when zeroed out, with a
 	// ui_get_settings, this isn't really necessary anymore!
@@ -1082,7 +1086,7 @@ void ui_theme_visuals_update() {
 
 	_ui_gen_quadrant_mesh(&theme_mesh_slider_pinch, ui_corner_all, fminf((ui_line_height() * 0.5f)/2.f, skui_settings.rounding), 5, false, true, lathe_slider_btn, _countof(lathe_slider_btn));
 	_ui_gen_quadrant_mesh(&theme_mesh_slider_push,  ui_corner_all, fminf((ui_line_height() * 0.55f)/2.f, skui_settings.rounding), 5, false, true, lathe_slider_btn, _countof(lathe_slider_btn));
-	_ui_gen_quadrant_mesh(&theme_mesh_separator,    ui_corner_all, fminf((text_style_get_char_height(ui_get_text_style()) * 0.4f)/2.f, skui_settings.rounding * 0.1f),  3, false, true, lathe_slider_btn, _countof(lathe_slider_btn));
+	_ui_gen_quadrant_mesh(&theme_mesh_separator,    ui_corner_all, fminf((text_style_get_size(ui_get_text_style()) * 0.4f)/2.f, skui_settings.rounding * 0.1f),  3, false, true, lathe_slider_btn, _countof(lathe_slider_btn));
 	
 	float aura_mesh_radius = skui_aura_radius * 0.75f;
 	ui_default_aura_mesh(&theme_mesh_aura, 0, fminf(ui_line_height(), skui_settings.rounding) + aura_mesh_radius, skui_aura_radius - aura_mesh_radius, 7, 5);


### PR DESCRIPTION
This reworks how some details of font rendering are implements. Results should be more pixel accurate, and a few more tools are provided for working with text. Impact to existing UI was minimized, but small differences in text size and width may be seen.

![TextStyleInfo](https://github.com/user-attachments/assets/63d36dd9-d36b-4f11-97d8-f28cd38f5e64)

Most importantly, this update clarifies the difference between layout sizes and render sizes. One issue previously encountered was that clipped text using `Text.Size` would cut off ascenders and descenders of the text. `Text.SizeRender` can now provide safe bounds that will not clip even the most extremely distant glyph elements, while `Text.SizeLayout` now clarifies that the size it provides is for calculating layout dimensions.

New APIs:
- `TextStyle.LineHeightPct` 
  - Allows control over space between text lines. Default TextStyles currently preserve their line height to stay as consistent as possible with previous behavior, but TextStyles now default to a much wider spacing, consistent with web accessibility guidance. This may be the largest visual difference. To restore previous spacing, try setting this to a value of `1.2`.
- `TextStyle.LayoutHeight`
- `TextStyle.TotalHeight`
  - This is the equivalent of 'size' provided by most text editing tools. 
- `TextStyle.CapHeight`
- `TextStyle.Ascender`
- `TextStyle.Descender`
- `Text.SizeLayout`
- `Text.SizeRender`

`TextStyle.CharHeight` is now obsolete, `TextStyle.LayoutHeight` should be used it most cases instead.
`Text.Size` is now obsolete, use `Text.SizeLayout`, or `Text.SizeRender` instead.