### PR TITLE
Sound revamp

### DIFF
--- a/Examples/StereoKitTest/Tests/TestAudio.cs
+++ b/Examples/StereoKitTest/Tests/TestAudio.cs
@@ -1,0 +1,67 @@
+﻿using StereoKit;
+using System;
+using System.IO;
+
+class TestAudio : ITest
+{
+	Pose      winPose    = new Pose(0.2f, 0, -0.5f, Quat.FromAngles(0, 180, 0));
+	Sound     sound      = Sound.Generate((x) => (((float)Math.Sin(x * (91.3458)) * 47453.5453f)%1.0f)*2.0f-1.0f, 5);
+	SoundInst inst;
+	float     distance   = 1;
+	float     volume     = 80;
+	bool      rotate     = false;
+	bool      behind     = false;
+	float     rotateTime = 0;
+	float     intensity  = 0;
+
+	public void Initialize()
+	{
+		Renderer.SetClip(0.08f,250);
+	}
+
+	public void Shutdown()
+	{
+		inst.Stop();
+		Platform.FilePickerClose();
+	}
+
+	public void Step()
+	{
+		UI.WindowBegin("Sound Tester", ref winPose, new Vec2(0.3f,0));
+		if (UI.Button("Browse"))
+			Platform.FilePicker(PickerMode.Open, (f) => { sound = Sound.FromFile(f); sound.Decibels = volume; }, null, ".wav", ".mp3");
+		UI.SameLine();
+		UI.Label(Path.GetFileName( sound.Id ));
+
+		UI.Label($"Distance {distance}", new Vec2(0.1f,0));
+		UI.SameLine();
+		UI.HSlider("Distance", ref distance, 0.1f, 200.1f, 1);
+
+		UI.Label($"Volume {volume}", new Vec2(0.1f, 0));
+		UI.SameLine();
+		if (UI.HSlider("Volume", ref volume, 10, 200, 1))
+			sound.Decibels = volume;
+
+		if (UI.Button("Play")) inst = sound.Play(GetPos());
+		UI.SameLine();
+
+		if (UI.Toggle("Rotate", ref rotate)) { rotateTime = Time.Totalf; }
+		UI.SameLine();
+		UI.Toggle("Behind", ref behind);
+
+		UI.WindowEnd();
+
+		float scale = SKMath.Lerp(0.3f, 4, (volume / 200.0f) * (volume / 200.0f));
+		intensity = SKMath.Lerp(intensity, inst.Intensity, 0.1f);
+		Mesh.Sphere.Draw(Material.Unlit, Matrix.TS(GetPos(), SKMath.Lerp(0.1f, 1, intensity) * scale));
+		inst.Position = GetPos();
+	}
+
+	Vec3 GetPos()
+	{
+		float start = behind ? 270 : 90;
+		return rotate
+			? Vec3.AngleXZ((Time.Totalf-rotateTime) * 45 + start)*-distance
+			: Vec3.AngleXZ(start)*-distance;
+	}
+}

--- a/StereoKit/Assets/Sound.cs
+++ b/StereoKit/Assets/Sound.cs
@@ -33,6 +33,8 @@ namespace StereoKit
 		/// seconds.</summary>
 		public float Duration { get => NativeAPI.sound_duration(_inst); }
 
+		public float Decibels { get => NativeAPI.sound_get_decibels(_inst); set => NativeAPI.sound_set_decibels(_inst, value); }
+
 		/// <summary>This will return the total number of audio samples used
 		/// by the sound! StereoKit currently uses 48,000 samples per second
 		/// for all audio.</summary>

--- a/StereoKit/Assets/SoundInst.cs
+++ b/StereoKit/Assets/SoundInst.cs
@@ -29,6 +29,8 @@ namespace StereoKit
 			set => NativeAPI.sound_inst_set_volume(this, value);
 		}
 
+		public float Intensity => NativeAPI.sound_inst_get_intensity(this);
+
 		/// <summary>Is this Sound instance currently playing? For streaming
 		/// assets, this will be true even if they don't have any new data
 		/// in them, and they're just idling at the end of their data.</summary>

--- a/StereoKit/Native/NativeAPI.cs
+++ b/StereoKit/Native/NativeAPI.cs
@@ -519,6 +519,8 @@ namespace StereoKit
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern ulong     sound_unread_samples(IntPtr sound);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern ulong     sound_total_samples (IntPtr sound);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern ulong     sound_cursor_samples(IntPtr sound);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern float     sound_get_decibels  (IntPtr sound);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void      sound_set_decibels  (IntPtr sound, float decibels);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern SoundInst sound_play          (IntPtr sound, Vec3 at, float volume);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern float     sound_duration      (IntPtr sound);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void      sound_release       (IntPtr sound);

--- a/StereoKit/Native/NativeAPI.cs
+++ b/StereoKit/Native/NativeAPI.cs
@@ -525,13 +525,14 @@ namespace StereoKit
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern float     sound_duration      (IntPtr sound);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void      sound_release       (IntPtr sound);
 
-		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void  sound_inst_stop      (SoundInst sound_inst);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void  sound_inst_stop         (SoundInst sound_inst);
 		[return: MarshalAs(UnmanagedType.Bool)]
-		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern bool  sound_inst_is_playing(SoundInst sound_inst);
-		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void  sound_inst_set_pos   (SoundInst sound_inst, Vec3 pos);
-		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern Vec3  sound_inst_get_pos   (SoundInst sound_inst);
-		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void  sound_inst_set_volume(SoundInst sound_inst, float volume);
-		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern float sound_inst_get_volume(SoundInst sound_inst);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern bool  sound_inst_is_playing   (SoundInst sound_inst);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void  sound_inst_set_pos      (SoundInst sound_inst, Vec3 pos);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern Vec3  sound_inst_get_pos      (SoundInst sound_inst);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void  sound_inst_set_volume   (SoundInst sound_inst, float volume);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern float sound_inst_get_volume   (SoundInst sound_inst);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern float sound_inst_get_intensity(SoundInst sound_inst);
 
 		///////////////////////////////////////////
 

--- a/StereoKitC/asset_types/sound.cpp
+++ b/StereoKitC/asset_types/sound.cpp
@@ -224,7 +224,8 @@ sound_inst_t sound_play(sound_t sound, vec3 at, float volume) {
 
 	for (size_t i = 0; i < _countof(au_active_sounds); i++) {
 		if (au_active_sounds[i].sound == sound) {
-			au_active_sounds[i] = {sound, au_active_sounds[i].id, at, decibels_to_signal(sound->decibels * volume) };
+			//au_active_sounds[i] = {sound, au_active_sounds[i].id, at, decibels_to_signal(sound->decibels * volume) };
+			au_active_sounds[i] = {sound, au_active_sounds[i].id, at, volume };
 
 			result._id   = au_active_sounds[i].id;
 			result._slot = (int16_t)i;
@@ -235,7 +236,8 @@ sound_inst_t sound_play(sound_t sound, vec3 at, float volume) {
 	for (size_t i = 0; i < _countof(au_active_sounds); i++) {
 		if (au_active_sounds[i].sound == nullptr) {
 			sound_addref(sound);
-			au_active_sounds[i] = { sound, (uint16_t)(au_active_sounds[i].id+1), at, decibels_to_signal(sound->decibels * volume) };
+			//au_active_sounds[i] = { sound, (uint16_t)(au_active_sounds[i].id+1), at, decibels_to_signal(sound->decibels * volume) };
+			au_active_sounds[i] = { sound, (uint16_t)(au_active_sounds[i].id+1), at, volume };
 
 			result._id   = au_active_sounds[i].id;
 			result._slot = (int16_t)i;

--- a/StereoKitC/asset_types/sound.cpp
+++ b/StereoKitC/asset_types/sound.cpp
@@ -361,4 +361,11 @@ float sound_inst_get_volume(sound_inst_t sound_inst) {
 	return au_active_sounds[sound_inst._slot].volume;
 }
 
+///////////////////////////////////////////
+
+float sound_inst_get_intensity(sound_inst_t sound_inst) {
+	if (sound_inst._slot < 0 || au_active_sounds[sound_inst._slot].id != sound_inst._id) return 0;
+	return au_active_sounds[sound_inst._slot].intensity_max_frame;
+}
+
 }

--- a/StereoKitC/asset_types/sound.cpp
+++ b/StereoKitC/asset_types/sound.cpp
@@ -60,6 +60,8 @@ sound_t sound_create(const char *filename) {
 		assets_releaseref(&result->header);
 		return nullptr;
 	}
+
+	result->decibels = 80;
 	return result;
 }
 
@@ -75,6 +77,7 @@ sound_t sound_create_stream(float buffer_duration) {
 	memset(result->buffer.data, 0, (size_t)(result->buffer.capacity * sizeof(float)));
 	ma_pcm_rb_init(AU_SAMPLE_FORMAT, 1, (ma_uint32)result->buffer.capacity, result->buffer.data, nullptr, &result->stream_buffer);
 
+	result->decibels = 80;
 	return result;
 }
 
@@ -89,6 +92,7 @@ sound_t sound_create_samples(const float *samples_at_48000s, uint64_t sample_cou
 	result->buffer.data     = sk_malloc_t(float, (size_t)sample_count);
 	memcpy(result->buffer.data, samples_at_48000s, (size_t)(sample_count * sizeof(float)));
 
+	result->decibels = 80;
 	return result;
 }
 
@@ -105,6 +109,7 @@ sound_t sound_generate(float (*function)(float sample_time), float duration) {
 		result->buffer.data[i] = function((float)i / (float)AU_SAMPLE_RATE);
 	}
 
+	result->decibels = 80;
 	return result;
 }
 
@@ -176,6 +181,39 @@ uint64_t sound_unread_samples(sound_t sound) {
 
 ///////////////////////////////////////////
 
+float sound_get_decibels(sound_t sound) {
+	return sound->decibels;
+}
+
+///////////////////////////////////////////
+
+void sound_set_decibels(sound_t sound, float decibels) {
+	sound->decibels = decibels;
+}
+
+///////////////////////////////////////////
+
+float decibels_to_signal(float decibel) {
+	// North American standard uses reference levels of 83db as -20dbfs, which
+	// basically means that an 83db sound will result in a dbfs of -20, which
+	// in turn is a digital signal value of 0.1. A dbfs of 0 will result in a
+	// digital signal value of 1, and a -inf will result in a digital signal of
+	// 0. The -20 reference level then provides a 20db headroom above 83 before
+	// clipping starts happening.
+	const float reference_dbfs = -20;
+	const float reference_db   =  83;
+	float dbfs = reference_dbfs + (decibel - reference_db);
+
+	// This converts dbfs to a digital signal +-1 representation
+	// return powf(10, dbfs / 20.0f);
+
+	// This is the same as the powf call, but faster
+	const float LN10_DIV_20 = 0.115129254f;
+	return expf(dbfs * LN10_DIV_20);
+}
+
+///////////////////////////////////////////
+
 sound_inst_t sound_play(sound_t sound, vec3 at, float volume) {
 	ma_decoder_seek_to_pcm_frame(&sound->decoder, 0);
 	sound->buffer.cursor = 0;
@@ -186,7 +224,7 @@ sound_inst_t sound_play(sound_t sound, vec3 at, float volume) {
 
 	for (size_t i = 0; i < _countof(au_active_sounds); i++) {
 		if (au_active_sounds[i].sound == sound) {
-			au_active_sounds[i] = {sound, au_active_sounds[i].id, at, volume };
+			au_active_sounds[i] = {sound, au_active_sounds[i].id, at, decibels_to_signal(sound->decibels * volume) };
 
 			result._id   = au_active_sounds[i].id;
 			result._slot = (int16_t)i;
@@ -197,7 +235,7 @@ sound_inst_t sound_play(sound_t sound, vec3 at, float volume) {
 	for (size_t i = 0; i < _countof(au_active_sounds); i++) {
 		if (au_active_sounds[i].sound == nullptr) {
 			sound_addref(sound);
-			au_active_sounds[i] = { sound, (uint16_t)(au_active_sounds[i].id+1), at, volume };
+			au_active_sounds[i] = { sound, (uint16_t)(au_active_sounds[i].id+1), at, decibels_to_signal(sound->decibels * volume) };
 
 			result._id   = au_active_sounds[i].id;
 			result._slot = (int16_t)i;

--- a/StereoKitC/asset_types/sound.h
+++ b/StereoKitC/asset_types/sound.h
@@ -23,6 +23,7 @@ typedef enum sound_type_ {
 struct _sound_t {
 	asset_header_t header;
 	sound_type_    type;
+	float          decibels;
 	ma_decoder     decoder;
 	buffer_t       buffer;
 	ma_pcm_rb      stream_buffer;

--- a/StereoKitC/stereokit.h
+++ b/StereoKitC/stereokit.h
@@ -1665,6 +1665,8 @@ SK_API uint64_t     sound_read_samples   (sound_t sound, float       *out_arr_sa
 SK_API uint64_t     sound_unread_samples (sound_t sound);
 SK_API uint64_t     sound_total_samples  (sound_t sound);
 SK_API uint64_t     sound_cursor_samples (sound_t sound);
+SK_API float        sound_get_decibels   (sound_t sound);
+SK_API void         sound_set_decibels   (sound_t sound, float decibels);
 SK_API sound_inst_t sound_play           (sound_t sound, vec3 at, float volume);
 SK_API float        sound_duration       (sound_t sound);
 SK_API void         sound_addref         (sound_t sound);

--- a/StereoKitC/stereokit.h
+++ b/StereoKitC/stereokit.h
@@ -1672,12 +1672,13 @@ SK_API float        sound_duration       (sound_t sound);
 SK_API void         sound_addref         (sound_t sound);
 SK_API void         sound_release        (sound_t sound);
 
-SK_API void         sound_inst_stop      (sound_inst_t sound_inst);
-SK_API bool32_t     sound_inst_is_playing(sound_inst_t sound_inst);
-SK_API void         sound_inst_set_pos   (sound_inst_t sound_inst, vec3 pos);
-SK_API vec3         sound_inst_get_pos   (sound_inst_t sound_inst);
-SK_API void         sound_inst_set_volume(sound_inst_t sound_inst, float volume);
-SK_API float        sound_inst_get_volume(sound_inst_t sound_inst);
+SK_API void         sound_inst_stop         (sound_inst_t sound_inst);
+SK_API bool32_t     sound_inst_is_playing   (sound_inst_t sound_inst);
+SK_API void         sound_inst_set_pos      (sound_inst_t sound_inst, vec3 pos);
+SK_API vec3         sound_inst_get_pos      (sound_inst_t sound_inst);
+SK_API void         sound_inst_set_volume   (sound_inst_t sound_inst, float volume);
+SK_API float        sound_inst_get_volume   (sound_inst_t sound_inst);
+SK_API float        sound_inst_get_intensity(sound_inst_t sound_inst);
 
 ///////////////////////////////////////////
 

--- a/StereoKitC/systems/audio.cpp
+++ b/StereoKitC/systems/audio.cpp
@@ -89,7 +89,7 @@ ma_uint32 read_and_mix_pcm_frames_f32(_sound_inst_t &inst, float *output, ma_uin
 	// frequencies and high frequencies drop at different rates in head shadow,
 	// but we're using a single simple approximate instead. (low freq 10-20%
 	// loss, high freq 50-60% loss?)
-	const float pan_loss = 0.4f;
+	const float pan_loss = 0.6f;
 	float pan_volume[2] = { fminf(1,1+(dot_pan*pan_loss)) * volume, fminf(1,1-(dot_pan*pan_loss)) * volume };
 
 	// Make sure we have enough room for all our samples.
@@ -160,13 +160,11 @@ ma_uint32 read_and_mix_pcm_frames_f32(_sound_inst_t &inst, float *output, ma_uin
 
 	// Sounds behind the user should get a low pass filter
 	float prev   = au_mix_temp[maxi(0, new_at - 1)];
-	//float cutoff = 2500;
 	float cutoff = fminf(
 		fmaxf(1000, -4000.f * log(fmaxf(1,dist-3.5f)) + 22200), // distance diminishes higher frequencies: https://www.desmos.com/calculator/h5tssewqbl
 		math_lerp(2500, 30000, fminf(1, 1 + dot_front))); // So does being behind the listener
 	float RC     = 1.0f / (2.0f * 3.14159265359f * cutoff);
 	float dt     = 1.0f / AU_SAMPLE_RATE;
-	//float alpha  = math_lerp(dt / (RC + dt), 1, fminf(1, 1 + dot_front));
 	float alpha  = dt / (RC + dt);
 	for (int32_t i = new_at; i < total; i++) {
 		if (inst.intensity_max_last_read < au_mix_temp[i])

--- a/StereoKitC/systems/audio.cpp
+++ b/StereoKitC/systems/audio.cpp
@@ -453,6 +453,11 @@ bool audio_init() {
 void audio_step() {
 	matrix head = pose_matrix(*input_head());
 	matrix_inverse(head, au_head_transform);
+
+	for (size_t i = 0; i < _countof(au_active_sounds); i++) {
+		au_active_sounds[i].intensity_max_frame     = au_active_sounds[i].intensity_max_last_read;
+		au_active_sounds[i].intensity_max_last_read = 0;
+	}
 }
 
 ///////////////////////////////////////////

--- a/StereoKitC/systems/audio.cpp
+++ b/StereoKitC/systems/audio.cpp
@@ -91,13 +91,16 @@ ma_uint32 read_and_mix_pcm_frames_f32(_sound_inst_t &inst, float *output, ma_uin
 
 		//// Mix the sound samples in
 
-		// Calculate the volume based on distance using the 1/d^2 law
+		// Calculate the volume based on distance using 1/d. While sound
+		// "intensity" is best modeled with 1/d^2, sound percieved loudness
+		// comes from sound amplitude/pressure, which falls off as 1/d.
 		vec3  dir    = head_pos - inst.position;
 		float dist2  = vec3_magnitude_sq(dir);
-		float volume = fminf(1,(1.f / dist2) * inst.volume);
+		float dist   = sqrtf(dist2);
+		float volume = fminf(1,(1.f / dist) * inst.volume);
 
 		// Find the direction of the sound in relation to the head
-		dir = dir / sqrtf(dist2);
+		dir = dir / dist;
 		float dot = vec3_dot(dir, head_right);
 
 		// Calculate a panning volume where a sound source directly in front

--- a/StereoKitC/systems/audio.cpp
+++ b/StereoKitC/systems/audio.cpp
@@ -15,7 +15,7 @@ namespace sk {
 
 _sound_inst_t     au_active_sounds[8] = {};
 matrix            au_head_transform;
-const int32_t     au_mix_temp_size = 4096;
+int32_t           au_mix_temp_size = 4096;
 float*            au_mix_temp;
 
 ma_context        au_context        = {};
@@ -50,94 +50,123 @@ void audio_set_default_device_in(const wchar_t *device_id) {
 ///////////////////////////////////////////
 
 ma_uint32 read_and_mix_pcm_frames_f32(_sound_inst_t &inst, float *output, ma_uint64 frame_count) {
-	const uint64_t channel_count = 2;
-
-	// The way mixing works is that we just read into a temporary buffer, 
+	// The way mixing works is that we just read into a temporary buffer,
 	// then take the contents of that buffer and mix it with the contents of
 	// the output buffer by simply adding the samples together.
-	vec3      head_pos          = input_head()->position;
-	vec3      head_right        = vec3_normalize(input_head()->orientation * vec3_right);
-	ma_uint64 frame_cap         = au_mix_temp_size / channel_count;
-	ma_uint64 total_frames_read = 0;
+	vec3 head_pos   = input_head()->position;
+	vec3 head_right = vec3_normalize(input_head()->orientation * vec3_right);
 
-	while (total_frames_read < frame_count) {
-		ma_uint64 frames_remaining = frame_count - total_frames_read;
-		ma_uint64 frames_to_read   = frame_cap;
-		if (frames_to_read > frames_remaining) {
-			frames_to_read = frames_remaining;
-		}
+	// Calculate the volume based on distance using 1/d. While sound
+	// "intensity" is best modeled with 1/d^2, sound percieved loudness
+	// comes from sound amplitude/pressure, which falls off as 1/d.
+	vec3  dir    = head_pos - inst.position;
+	float dist2  = vec3_magnitude_sq(dir);
+	float dist   = fmaxf(0.001f,sqrtf(dist2));
+	float volume = fminf(1,(1.f / dist) * inst.volume);
 
-		// Grab sound samples!
-		ma_uint64 frames_read = 0;
-		switch (inst.sound->type) {
-		case sound_type_decode: {
-			if (ma_decoder_read_pcm_frames(&inst.sound->decoder, au_mix_temp, frames_to_read, &frames_read) != MA_SUCCESS) {
-				log_err("Failed to read PCM frames for mixing!");
-			}
-		} break;
-		case sound_type_stream: {
-			frames_read = sound_read_samples(inst.sound, au_mix_temp, frames_to_read);
-		} break;
-		case sound_type_buffer: {
-			frames_read = mini(frames_to_read, inst.sound->buffer.count - inst.sound->buffer.cursor);
-			memcpy(au_mix_temp, inst.sound->buffer.data+inst.sound->buffer.cursor, (size_t)frames_read * sizeof(float));
-			inst.sound->buffer.cursor += frames_read;
-		} break;
-		case sound_type_none: {
-			log_errf("Got a sound_type_none?");
-		} break;
-		}
-		if (frames_read <= 1) break;
+	// Find the direction of the sound in relation to the head
+	dir = dir / dist;
+	float dot = vec3_dot(dir, head_right);
 
-		//// Mix the sound samples in
+	// Calculate a panning volume where a sound source directly in front
+	// will have a volume of 1 for both ears, and a sound directly to
+	// either side will have a volume of 40% opposite it. Technically low
+	// frequencies and high frequencies drop at different rates in head shadow,
+	// but we're using a single simple approximate instead. (low freq 10-20%
+	// loss, high freq 50-60% loss?)
+	const float pan_loss = 0.6f;
+	float pan_volume[2] = { fminf(1,1+(dot*pan_loss)) * volume, fminf(1,1-(dot*pan_loss)) * volume };
 
-		// Calculate the volume based on distance using 1/d. While sound
-		// "intensity" is best modeled with 1/d^2, sound percieved loudness
-		// comes from sound amplitude/pressure, which falls off as 1/d.
-		vec3  dir    = head_pos - inst.position;
-		float dist2  = vec3_magnitude_sq(dir);
-		float dist   = sqrtf(dist2);
-		float volume = fminf(1,(1.f / dist) * inst.volume);
-
-		// Find the direction of the sound in relation to the head
-		dir = dir / dist;
-		float dot = vec3_dot(dir, head_right);
-
-		// Calculate a panning volume where a sound source directly in front
-		// will have a volume of 1 for both ears, and a sound directly to 
-		// either side will have a volume of zero opposite it
-		float channel[2] = { fminf(1,dot+1), fminf(1,2-(dot+1)) };
-
-		// Create a sample offset to simulate sound arrival time difference
-		// between left and right ears.
-		// NOTE: This needs a buffer of 10 samples before and after the
-		// relevant range, otherwise it sparkles!!
-		// The speed of sound is 343 m/s, and average head width is .15m
-		// (head_width/speed_of_sound)*48,000 samples/s = 21 audio samples wide
-		//int64_t offset[2] = { (int64_t)(10 * dot), (int64_t)(-10 * dot) };
-
-		// Mix the frames together.
-		for (ma_uint64 sample = 0; sample < frames_read; ++sample) {
-			ma_uint64 i = total_frames_read * channel_count + sample*channel_count;
-			float     s = au_mix_temp[sample] * volume;
-
-			// Right channel
-			//float     s = au_mix_temp[mini((int64_t)_countof(au_mix_temp)-1,maxi((int64_t)0,sample+offset[c]))] * volume *  channel[0];
-			output[i] = fmaxf(-1, fminf(1, output[i] + s*channel[0]));
-
-			// Left channel
-			//s = au_mix_temp[mini((int64_t)_countof(au_mix_temp)-1,maxi((int64_t)0,sample+offset[c]))] * volume *  channel[1];
-			i += 1;
-			output[i] = fmaxf(-1, fminf(1, output[i] + s*channel[1]));
-		}
-
-		total_frames_read += frames_read;
-		if (frames_read < frames_to_read) {
-			break;  // Reached EOF.
-		}
+	// Make sure we have enough room for all our samples.
+	if (au_mix_temp_size < frame_count + AU_SAMPLE_BUFFER_SIZE * 2) {
+		au_mix_temp_size = frame_count + AU_SAMPLE_BUFFER_SIZE * 2;
+		sk_free(au_mix_temp);
+		au_mix_temp = sk_malloc_t(float, au_mix_temp_size);
 	}
 
-	return (ma_uint32)total_frames_read;
+	// Reading samples is a bit odd here because we can only read forward from
+	// some of our audio sources, and we need about 10 extra samples on either
+	// side of our audio in order to do proper 3D audio panning. So we cache a
+	// few samples from the previous read, and read a bit extra at the end as
+	// well.
+	//
+	// Here, | is the audio start/end, O is the extra padding at the end, and v
+	// is pulled from the last step's cache.
+	// 
+	// |====O         |
+	// |   vv===O     |
+	// |       vv===O |
+	// |           vv=|
+	int64_t new_at   = 0;
+	int64_t start_at = 0;
+	if (inst.prev_buffer_ct > 0) {
+		memcpy(au_mix_temp, inst.prev_buffer, sizeof(float) * inst.prev_buffer_ct);
+		new_at   = inst.prev_buffer_ct;
+		start_at = mini(inst.prev_buffer_ct, AU_SAMPLE_BUFFER_SIZE);
+	}
+
+	// Grab sound samples!
+	ma_uint64 frames_read   = 0;
+	ma_uint64 frames_needed = (frame_count+AU_SAMPLE_BUFFER_SIZE) - (new_at-start_at);
+	switch (inst.sound->type) {
+	case sound_type_decode: {
+		if (ma_decoder_read_pcm_frames(&inst.sound->decoder, &au_mix_temp[new_at], frames_needed, &frames_read) != MA_SUCCESS) {
+			log_err("Failed to read PCM frames for mixing!");
+		}
+	} break;
+	case sound_type_stream: {
+		frames_read = sound_read_samples(inst.sound, &au_mix_temp[new_at], frames_needed);
+	} break;
+	case sound_type_buffer: {
+		frames_read = mini(frames_needed, inst.sound->buffer.count - inst.sound->buffer.cursor);
+		memcpy(&au_mix_temp[new_at], inst.sound->buffer.data+inst.sound->buffer.cursor, (size_t)frames_read * sizeof(float));
+		inst.sound->buffer.cursor += frames_read;
+	} break;
+	case sound_type_none: {
+		log_errf("Got a sound_type_none?");
+	} break;
+	}
+
+	int64_t mix_count = mini((int64_t)frame_count, (int64_t)(new_at+frames_read) - start_at);
+	int64_t end_at    = start_at + mix_count;
+	int64_t total     = new_at + frames_read;
+
+	// Create a sample offset to simulate sound arrival time difference
+	// between left and right ears.
+	// NOTE: This needs a buffer of 10 samples before and after the
+	// relevant range, otherwise it sparkles!!
+	// The speed of sound is 343 m/s, and average head width is .15m
+	// (head_width/speed_of_sound)*48,000 samples/s = 21 audio samples wide
+	int64_t offset[2] = { (int64_t)(10 * dot), (int64_t)(-10 * dot) };
+	int64_t start [2] = { maxi((int64_t)0, start_at + (int64_t)inst.prev_offset[0]), maxi((int64_t)0, start_at + (int64_t)inst.prev_offset[1]) };
+	int64_t end   [2] = { mini(total,      end_at   + offset[0]),                    mini(total,      end_at   + offset[1]) };
+	float   step  [2] = { (float)(end[0]-start[0]) / frame_count, (float)(end[1]-start[1]) / frame_count };
+	float   curr  [2] = { (float)start[0], (float)start[1] };
+
+	// Mix the frames together.
+	for (int64_t sample = 0; sample < mix_count; ++sample) {
+		int64_t i = sample*2;
+
+		// Right channel
+		float s = au_mix_temp[(int32_t)curr[0]];
+		output[i] = fmaxf(-1, fminf(1, output[i] + s*pan_volume[0]));
+
+		// Left channel
+		s = au_mix_temp[(int32_t)curr[1]];
+		i += 1;
+		output[i] = fmaxf(-1, fminf(1, output[i] + s*pan_volume[1]));
+
+		curr[0] += step[0];
+		curr[1] += step[1];
+	}
+
+	int64_t count = mini((int64_t)AU_SAMPLE_BUFFER_SIZE*2, (int64_t)(new_at+frames_read));
+	memcpy(inst.prev_buffer, &au_mix_temp[(new_at + frames_read) - count], count * sizeof(float));
+	inst.prev_buffer_ct = count;
+	inst.prev_offset[0] = offset[0];
+	inst.prev_offset[1] = offset[1];
+
+	return (ma_uint32)mix_count;
 }
 
 ///////////////////////////////////////////

--- a/StereoKitC/systems/audio.h
+++ b/StereoKitC/systems/audio.h
@@ -4,14 +4,18 @@
 
 namespace sk {
 
-#define AU_SAMPLE_RATE   48000
-#define AU_SAMPLE_FORMAT ma_format_f32
+#define AU_SAMPLE_RATE        48000
+#define AU_SAMPLE_BUFFER_SIZE 10
+#define AU_SAMPLE_FORMAT      ma_format_f32
 
 struct _sound_inst_t {
 	sound_t  sound;
 	uint16_t id;
 	vec3     position;
 	float    volume;
+	float    prev_buffer[AU_SAMPLE_BUFFER_SIZE*2];
+	int32_t  prev_buffer_ct;
+	int32_t  prev_offset[2];
 };
 
 bool audio_init    ();

--- a/StereoKitC/systems/audio.h
+++ b/StereoKitC/systems/audio.h
@@ -16,6 +16,8 @@ struct _sound_inst_t {
 	float    prev_buffer[AU_SAMPLE_BUFFER_SIZE*2];
 	int32_t  prev_buffer_ct;
 	int32_t  prev_offset[2];
+	float    intensity_max_frame;
+	float    intensity_max_last_read;
 };
 
 bool audio_init    ();


### PR DESCRIPTION
This is an update to help improve StereoKit's default 3D sound implementation.

- Sound falloff now uses 1/d instead of 1/d^2, this is a more appropriate falloff for loudness.
- Added phase shifting for stronger directional cues. A sound played to the listener's right will be heard by the right ear just a bit sooner than the left, since sound takes time to travel the distance of the head.
- Added a low pass filter for audio off in the distance, or behind the listener. Atmosphere will absorb higher frequency parts of the sound.
- Added `SoundInst.Intensity` that tells the instance's maximum sample value since the last frame (before spatializing).