### PR TITLE
Adds a `UI.SliderBehavior` to the public API

### DIFF
--- a/Examples/StereoKitTest/Docs/DocSliderBehavior.cs
+++ b/Examples/StereoKitTest/Docs/DocSliderBehavior.cs
@@ -1,0 +1,37 @@
+﻿using StereoKit;
+
+class DocSliderBehavior : ITest
+{
+	Vec2 touchPt    = new Vec2(0.5f,0.5f);
+	Pose windowPose = new Pose(0,0,-0.5f, Quat.FromAngles(0,180,0));
+	public void Step()
+	{
+		UI.WindowBegin("Slider Panel", ref windowPose, new Vec2(0.3f, 0f));
+
+		Vec2 size = V.XX(UI.LayoutRemaining.x);
+		UITouchPanel("touch panel", ref touchPt, size);
+		UI.Label($"{(int)(touchPt.x*100)}, {(int)(touchPt.y * 100)}");
+
+		UI.WindowEnd();
+	}
+
+	static bool UITouchPanel(string id, ref Vec2 pt, Vec2 size)
+	{
+		IdHash hash      = UI.StackHash(id);
+		float  depth     = UI.Settings.depth;
+		Bounds bounds    = UI.LayoutReserve(size, false, depth);
+		float  btnHeight = UI.LineHeight * 0.75f;
+		Vec3   btnSize   = new Vec3(btnHeight, btnHeight, depth);
+
+		Vec2 prev = pt;
+		UI.SliderBehavior(bounds.TLB, bounds.dimensions.XY, hash, ref pt, Vec2.Zero, Vec2.One, Vec2.Zero, btnSize.XY, Vec2.Zero, UIConfirm.Push, out UISliderData slider);
+		float focus = UI.GetAnimFocus(hash, slider.focusState, slider.activeState);
+		UI.DrawElement(UIVisual.SliderLine, bounds.TLB, new Vec3(bounds.dimensions.x, bounds.dimensions.y, depth*0.1f), slider.focusState.IsActive() ? 0.5f:0);
+		UI.DrawElement(UIVisual.SliderPush, slider.buttonCenter.XY0 + btnSize.XY0/2.0f, btnSize, focus);
+
+		return prev.x != pt.x || prev.y != pt.y;
+	}
+
+	public void Initialize() {}
+	public void Shutdown  () {}
+}

--- a/Examples/StereoKitTest/Program.cs
+++ b/Examples/StereoKitTest/Program.cs
@@ -200,14 +200,14 @@ class Program
 		TextStyle  style          = UI.TextStyle;
 		for (int i = 0; i < Tests.Count(testCategory); i++)
 		{
-			float width = Text.Size(Tests.GetTestName(testCategory,i), style).x + uiSettings.padding * 2;
+			float width = Text.SizeLayout(Tests.GetTestName(testCategory,i), style).x + uiSettings.padding * 2;
 			if (currWidthTotal + (width+uiSettings.gutter) > demoWinWidth)
 			{
 				float inflate = (demoWinWidth - (currWidthTotal-uiSettings.gutter+0.0001f)) / (i - start);
 				for (int t = start; t < i; t++)
 				{
 					string name      = Tests.GetTestName(testCategory,t);
-					float  currWidth = Text.Size(name, style).x + uiSettings.padding * 2 + inflate;
+					float  currWidth = Text.SizeLayout(name, style).x + uiSettings.padding * 2 + inflate;
 					if (UI.Radio(name, Tests.IsActive(testCategory,t),  null, null, UIBtnLayout.None, new Vec2(currWidth, 0) ))
 						Tests.SetTestActive(testCategory, t);
 					UI.SameLine();
@@ -221,7 +221,7 @@ class Program
 		for (int t = start; t < Tests.Count(testCategory); t++)
 		{
 			string name      = Tests.GetTestName(testCategory, t);
-			float  currWidth = Text.Size(name, style).x + uiSettings.padding * 2;
+			float  currWidth = Text.SizeLayout(name, style).x + uiSettings.padding * 2;
 			if (UI.Radio(name, Tests.IsActive(testCategory, t), null, null, UIBtnLayout.None, new Vec2(currWidth, 0)))
 				Tests.SetTestActive(testCategory, t);
 			UI.SameLine();

--- a/Examples/StereoKitTest/StereoKitTest_NetAndroid/StereoKitTest_NetAndroid.csproj
+++ b/Examples/StereoKitTest/StereoKitTest_NetAndroid/StereoKitTest_NetAndroid.csproj
@@ -46,6 +46,7 @@
 		<Compile Include="..\Demos\*.cs" Visible="false" />
 		<Compile Include="..\Tools\*.cs" Visible="false" />
 		<Compile Include="..\Tests\*.cs" Visible="false" />
+		<Compile Include="..\Docs\*.cs" Visible="false" />
 	</ItemGroup>
 
 </Project>

--- a/Examples/StereoKitTest/Tools/LogWindow.cs
+++ b/Examples/StereoKitTest/Tools/LogWindow.cs
@@ -206,7 +206,7 @@ namespace StereoKit.Framework
 				Text.Add(((int)min).ToString(), Matrix.TS(at.x-size.x, at.y-size.y, at.z, textScale), V.XY(labelWidth*textScale, 1), TextFit.Overflow, style, TextAlign.BottomLeft, TextAlign.BottomLeft);
 				Text.Add(label,                 Matrix.TS(at.x,        at.y,        at.z, textScale),                                                  style, TextAlign.TopLeft,    TextAlign.TopLeft);
 
-				Lines.Add(at+V.XY0(-Text.Size(label, style).x*textScale - 0.002f, 0), at + V.XY0(-size.x, 0), new Color32(255,255,255,20), 0.001f);
+				Lines.Add(at+V.XY0(-Text.SizeLayout(label, style).x*textScale - 0.002f, 0), at + V.XY0(-size.x, 0), new Color32(255,255,255,20), 0.001f);
 				Lines.Add(at+V.XY0(0, -size.y), at + V.XY0(-size.x, -size.y), new Color32(255, 255, 255, 20), 0.001f);
 
 				if (calcMin) min = frameMin;

--- a/StereoKit/Native/NativeAPI.cs
+++ b/StereoKit/Native/NativeAPI.cs
@@ -748,7 +748,7 @@ namespace StereoKit
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   ui_draw_element         (UIVisual element_visual,                         Vec3 start, Vec3 size, float focus);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   ui_draw_element_color   (UIVisual element_visual, UIVisual element_color, Vec3 start, Vec3 size, float focus);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern Color  ui_get_element_color    (UIVisual element_visual,                                                float focus);
-		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern float  ui_get_anim_focus       (ulong id, BtnState focus_state, BtnState activation_state);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern float  ui_get_anim_focus       (IdHash id, BtnState focus_state, BtnState activation_state);
 
 
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void ui_push_grab_aura        ([MarshalAs(UnmanagedType.Bool)] bool enabled);
@@ -768,10 +768,10 @@ namespace StereoKit
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void ui_pop_preserve_keyboard ();
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void ui_push_surface          (Pose surface_pose, Vec3 layout_start, Vec2 layout_dimensions);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void ui_pop_surface           ();
-		[DllImport(dll, CharSet = CharSet.Unicode, CallingConvention = call)] public static extern ulong ui_push_id_16   (string id);
-		[DllImport(dll, CharSet = cSet, CallingConvention = call)]            public static extern ulong ui_push_idi     (int id);
-		[DllImport(dll, CharSet = cSet, CallingConvention = call)]            public static extern void  ui_pop_id       ();
-		[DllImport(dll, CharSet = CharSet.Unicode, CallingConvention = call)] public static extern ulong ui_stack_hash_16(string str);
+		[DllImport(dll, CharSet = CharSet.Unicode, CallingConvention = call)] public static extern IdHash ui_push_id_16   (string id);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)]            public static extern IdHash ui_push_idi     (int id);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)]            public static extern void   ui_pop_id       ();
+		[DllImport(dll, CharSet = CharSet.Unicode, CallingConvention = call)] public static extern IdHash ui_stack_hash_16(string str);
 
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   ui_layout_area     (Vec3 start, Vec2 dimensions, [MarshalAs(UnmanagedType.Bool)] bool add_margin);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern Vec2   ui_layout_remaining();
@@ -794,9 +794,10 @@ namespace StereoKit
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   ui_hspace        (float horizontal_space);
 
 		[return: MarshalAs(UnmanagedType.Bool)]
-		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern bool ui_is_interacting (Handed hand);
-		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void ui_button_behavior(Vec3 window_relative_pos, Vec2 size, ulong id, out float finger_offset, out BtnState button_state, out BtnState focus_state, out int hand);
-		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void ui_button_behavior_depth(Vec3 window_relative_pos, Vec2 size, ulong id, float button_depth, float button_activation_depth, out float finger_offset, out BtnState button_state, out BtnState focus_state, out int hand);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern bool ui_is_interacting       (Handed hand);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void ui_button_behavior      (Vec3 window_relative_pos, Vec2 size, IdHash id, out float finger_offset, out BtnState button_state, out BtnState focus_state, out int hand);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void ui_button_behavior_depth(Vec3 window_relative_pos, Vec2 size, IdHash id, float button_depth, float button_activation_depth, out float finger_offset, out BtnState button_state, out BtnState focus_state, out int hand);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void ui_slider_behavior      (Vec3 window_relative_pos, Vec2 size, IdHash id, ref Vec2 value, Vec2 min, Vec2 max, Vec2 step, Vec2 button_size_visual, Vec2 button_size_interact, UIConfirm confirm_method, out UISliderData data);
 
 		[DllImport(dll, CharSet = CharSet.Unicode, CallingConvention = call)] public static extern BtnState ui_volume_at_16      (string id, Bounds bounds, UIConfirm interact_type, IntPtr out_opt_hand, IntPtr out_opt_focus_state);
 		[DllImport(dll, CharSet = CharSet.Unicode, CallingConvention = call)] public static extern BtnState ui_volume_at_16      (string id, Bounds bounds, UIConfirm interact_type, out Handed out_opt_hand, IntPtr out_opt_focus_state);

--- a/StereoKit/Native/NativeTypes.cs
+++ b/StereoKit/Native/NativeTypes.cs
@@ -891,4 +891,23 @@ namespace StereoKit
 		public override int GetHashCode()
 			=> id.GetHashCode();
 	}
+
+	[StructLayout(LayoutKind.Sequential)]
+	public struct IdHash
+	{
+		ulong hash;
+
+		public static implicit operator ulong(IdHash h) => h.hash;
+		public static implicit operator IdHash(ulong h) => new IdHash{ hash = h };
+	}
+
+	[StructLayout(LayoutKind.Sequential)]
+	public struct UISliderData
+	{
+		public Vec2     buttonCenter;
+		public float    fingerOffset;
+		public BtnState focusState;
+		public BtnState activeState;
+		public int      interactor;
+	}
 }

--- a/StereoKit/Systems/UI.cs
+++ b/StereoKit/Systems/UI.cs
@@ -1533,7 +1533,7 @@ namespace StereoKit
 		/// UI element.</param>
 		/// <returns>A focus value in the realm of 0-1, where 0 is unfocused,
 		/// and 1 is active.</returns>
-		public static float GetAnimFocus(ulong id, BtnState focusState, BtnState activationState)
+		public static float GetAnimFocus(IdHash id, BtnState focusState, BtnState activationState)
 			=> NativeAPI.ui_get_anim_focus(id, focusState, activationState);
 
 		/// <summary>This creates a Pose that is friendly towards UI popup
@@ -1674,5 +1674,41 @@ namespace StereoKit
 		/// This will be -1 if no interaction has occurred.</param>
 		public static void ButtonBehavior(Vec3 windowRelativePos, Vec2 size, string id, float buttonDepth, float buttonActivationDepth, out float fingerOffset, out BtnState buttonState, out BtnState focusState, out int hand)
 			=> NativeAPI.ui_button_behavior_depth(windowRelativePos, size, NativeAPI.ui_stack_hash_16(id), buttonDepth, buttonActivationDepth, out fingerOffset, out buttonState, out focusState, out hand);
+
+		/// <summary>This is the core functionality of StereoKit's slider
+		/// elements, without any of the rendering parts! If you're trying to
+		/// create your own sliding UI elements, or do more extreme
+		/// customization of the look and feel of slider UI elements, then this
+		/// function will provide a lot of complex pressing functionality for
+		/// you!</summary>
+		/// <param name="windowRelativePos">The layout position of the
+		/// pressable area.</param>
+		/// <param name="size">The size of the pressable area.</param>
+		/// <param name="id">The id for this pressable element to track its
+		/// state with.</param>
+		/// <param name="value">The value that the slider will store slider
+		/// state in.</param>
+		/// <param name="min">The minimum value the slider can set, left side
+		/// of the slider.</param>
+		/// <param name="max">The maximum value the slider can set, right 
+		/// side of the slider.</param>
+		/// <param name="step">Locks the value to increments of step. Starts
+		/// at min, and increments by step. 0 is valid, and means "don't lock
+		/// to increments".</param>
+		/// <param name="buttonSizeVisual">This is the visual size of the
+		/// element representing the touchable area of the slider. This is used
+		/// to calculate the center of the button's placement without going
+		/// outside the provided bounds.</param>
+		/// <param name="buttonSizeInteract">The size of the interactive touch
+		/// element of the slider. Set this to zero to use the entire area as a
+		/// touchable surface.</param>
+		/// <param name="confirmMethod">How should the slider be activated?
+		/// Push will be a push-button the user must press first, and pinch
+		/// will be a tab that the user must pinch and drag around.</param>
+		/// <param name="data">This is data about the slider interaction, you
+		/// can use this for visualizing the slider behavior, or reacting to
+		/// its events.</param>
+		public static void SliderBehavior(Vec3 windowRelativePos, Vec2 size, IdHash id, ref Vec2 value, Vec2 min, Vec2 max, Vec2 step, Vec2 buttonSizeVisual, Vec2 buttonSizeInteract, UIConfirm confirmMethod, out UISliderData data)
+			=> NativeAPI.ui_slider_behavior(windowRelativePos, size, id, ref value, min, max, step, buttonSizeVisual, buttonSizeInteract, confirmMethod, out data);
 	}
 }

--- a/StereoKitC/stereokit_ui.h
+++ b/StereoKitC/stereokit_ui.h
@@ -146,6 +146,14 @@ typedef struct ui_settings_t {
 	float backplate_border;
 } ui_settings_t;
 
+typedef struct ui_slider_data_t {
+	vec2          button_center;
+	float         finger_offset;
+	button_state_ focus_state;
+	button_state_ active_state;
+	int32_t       interactor;
+} ui_slider_data_t;
+
 typedef uint64_t id_hash_t;
 
 SK_API void     ui_quadrant_size_verts  (vert_t *ref_vertices, int32_t vertex_count, float overflow_percent);
@@ -220,6 +228,7 @@ SK_API float    ui_line_height   (void);
 SK_API bool32_t ui_is_interacting       (handed_ hand);
 SK_API void     ui_button_behavior      (vec3 window_relative_pos, vec2 size, id_hash_t id, sk_ref(float) out_finger_offset, sk_ref(button_state_) out_button_state, sk_ref(button_state_) out_focus_state, int32_t* out_opt_hand sk_default(nullptr));
 SK_API void     ui_button_behavior_depth(vec3 window_relative_pos, vec2 size, id_hash_t id, float button_depth, float button_activation_depth, sk_ref(float) out_finger_offset, sk_ref(button_state_) out_button_state, sk_ref(button_state_) out_focus_state, int32_t* out_opt_hand sk_default(nullptr));
+SK_API void     ui_slider_behavior      (vec3 window_relative_pos, vec2 size, id_hash_t id, vec2* value, vec2 min, vec2 max, vec2 step, vec2 button_size_visual, vec2 button_size_interact, ui_confirm_ confirm_method, ui_slider_data_t* out);
 
 SK_API button_state_ ui_volume_at        (const char     *id, bounds_t bounds, ui_confirm_ interact_type, handed_ *out_opt_hand sk_default(nullptr), button_state_ *out_opt_focus_state sk_default(nullptr));
 SK_API button_state_ ui_volume_at_16     (const char16_t *id, bounds_t bounds, ui_confirm_ interact_type, handed_ *out_opt_hand sk_default(nullptr), button_state_ *out_opt_focus_state sk_default(nullptr));

--- a/StereoKitC/ui/stereokit_ui.cpp
+++ b/StereoKitC/ui/stereokit_ui.cpp
@@ -729,32 +729,28 @@ bool32_t ui_slider_at_g(ui_dir_ bar_direction, const C *id_text, float &value, f
 			? vec2{ size_min, size_min / 2 }
 			: vec2{ size_min / 2, size_min});
 
-	button_state_ active_state;
-	button_state_ focus_state;
-	int32_t       interactor;
-	vec2          button_center;
-	float         finger_offset;
-	float         old_value = value;
+	float old_value = value;
+	ui_slider_data_t slider;
 
 	vec2 vmin, vmax, vstep, vval;
 	if (bar_direction == ui_dir_vertical) { vmin = { 0,min }; vmax = { 0,max }; vstep = { 0,step }; vval = { 0,value }; }
 	else                                  { vmin = { min,0 }; vmax = { max,0 }; vstep = { step,0 }; vval = { value,0 }; }
-	ui_slider_behavior(id, &vval, vmin, vmax, vstep, window_relative_pos, size, button_size, button_size + vec2{skui_settings.padding, skui_settings.padding}*2, confirm_method, & button_center, & finger_offset, & focus_state, & active_state, & interactor);
+	ui_slider_behavior(window_relative_pos, size, id, &vval, vmin, vmax, vstep, button_size, button_size + vec2{skui_settings.padding, skui_settings.padding}*2, confirm_method, &slider);
 	value = bar_direction == ui_dir_vertical ? vval.y : vval.x;
 
 	// Draw the UI
 	float percent   = (value - min) / (max - min);
-	float vis_focus = ui_get_anim_focus(id, focus_state, active_state);
+	float vis_focus = ui_get_anim_focus(id, slider.focus_state, slider.active_state);
 	ui_progress_bar_at_ex(percent, window_relative_pos, size, vis_focus, bar_direction, false);
 	ui_draw_element(confirm_method == ui_confirm_push ? ui_vis_slider_push : ui_vis_slider_pinch,
-		vec3{ button_center.x+button_size.x/2, button_center.y+button_size.y/2, window_relative_pos.z },
-		vec3{ button_size.x, button_size.y, fmaxf(finger_offset,rule_size * skui_pressed_depth + mm2m) },
+		vec3{ slider.button_center.x+button_size.x/2, slider.button_center.y+button_size.y/2, window_relative_pos.z },
+		vec3{ button_size.x, button_size.y, fmaxf(slider.finger_offset,rule_size * skui_pressed_depth + mm2m) },
 		vis_focus);
 	
-	if (active_state & button_state_just_active)
-		ui_play_sound_on_off(ui_vis_slider_pinch, id, hierarchy_to_world_point({ button_center.x, button_center.y,0 }));
+	if (slider.active_state & button_state_just_active)
+		ui_play_sound_on_off(ui_vis_slider_pinch, id, hierarchy_to_world_point({ slider.button_center.x, slider.button_center.y,0 }));
 
-	if (notify_on == ui_notify_finalize) return active_state & button_state_just_inactive;
+	if (notify_on == ui_notify_finalize) return slider.active_state & button_state_just_inactive;
 	else                                 return old_value != value;
 }
 bool32_t ui_hslider_at       (const char     *id_text, float  &value, float  min, float  max, float  step, vec3 window_relative_pos, vec2 size, ui_confirm_ confirm_method, ui_notify_ notify_on) { return ui_slider_at_g<char    >(ui_dir_horizontal, id_text, value, min, max, step, window_relative_pos, size, confirm_method, notify_on); }

--- a/StereoKitC/ui/ui_core.h
+++ b/StereoKitC/ui/ui_core.h
@@ -77,7 +77,6 @@ void             ui_core_shutdown           ();
 void             ui_box_interaction_1h      (id_hash_t id, interactor_event_ event_mask, vec3 box_unfocused_start, vec3 box_unfocused_size, vec3 box_focused_start, vec3 box_focused_size, button_state_* out_focus_candidacy, int32_t* out_interactor);
 void             interactor_plate_1h        (id_hash_t id, interactor_event_ event_mask, vec3 plate_start, vec3 plate_size, button_state_* out_focus_candidacy, int32_t* out_interactor, vec3* out_interaction_at_local);
 bool32_t         _ui_handle_begin           (id_hash_t id, pose_t& handle_pose, bounds_t handle_bounds, bool32_t draw, ui_move_ move_type, ui_gesture_ allowed_gestures);
-void             ui_slider_behavior         (id_hash_t id, vec2* value, vec2 min, vec2 max, vec2 step, vec3 window_relative_pos, vec2 size, vec2 button_size_visual, vec2 button_size_interact, ui_confirm_ confirm_method, vec2* out_button_center, float* out_finger_offset, button_state_* out_focus_state, button_state_* out_active_state, int32_t* out_interactor);
 
 bool32_t         ui_id_focused              (id_hash_t id);
 button_state_    ui_id_focus_state          (id_hash_t id);


### PR DESCRIPTION
This is the core code used to implement elements such as `UI.HSlider`, see DocSliderBehavior for how to use it.

This also switches UI id hashes over to their own type, `IdHash` in C#.