### PR TITLE
Support cubemaps from arbitrary texture files.

### DIFF
--- a/Examples/StereoKitTest/Demos/DemoLighting.cs
+++ b/Examples/StereoKitTest/Demos/DemoLighting.cs
@@ -170,7 +170,7 @@ class DemoLighting : ITest
 	void LoadSkyImage(string file)
 	{
 		cubemapFile = Path.GetFileName(file);
-		cubemap     = Tex.FromCubemapEquirectangular(file);
+		cubemap     = Tex.FromCubemap(file);
 
 		Renderer.SkyTex = cubemap;
 		cubelightDirty  = true;

--- a/Examples/StereoKitTest/Demos/DemoMaterial.cs
+++ b/Examples/StereoKitTest/Demos/DemoMaterial.cs
@@ -39,8 +39,8 @@ class DemoMaterial : ITest
 		/// great way to instantly get a particular feel to your scene! A neat
 		/// place to find compatible equirectangular images for this is
 		/// [Poly Haven](https://polyhaven.com/hdris)
-		Renderer.SkyTex   = Tex.FromCubemapEquirectangular("old_depot.hdr", out SphericalHarmonics lighting);
-		Renderer.SkyLight = lighting;
+		Renderer.SkyTex   = Tex.FromCubemap("old_depot.hdr");
+		Renderer.SkyLight = Renderer.SkyTex.CubemapLighting;
 		/// And here's what it looks like applied to the default Material!
 		/// ![Default Material example]({{site.screen_url}}/MaterialDefault.jpg)
 		/// :End:

--- a/Examples/StereoKitTest/Demos/DemoPBR.cs
+++ b/Examples/StereoKitTest/Demos/DemoPBR.cs
@@ -26,7 +26,7 @@ class DemoPBR : ITest
 		oldSkyTex   = Renderer.SkyTex;
 		oldSkyLight = Renderer.SkyLight;
 		sphereMesh  = Mesh.GenerateSphere(1, 7);
-		Renderer.SkyTex = Tex.FromCubemapEquirectangular(@"old_depot.hdr");
+		Renderer.SkyTex = Tex.FromCubemap(@"old_depot.hdr");
 		Renderer.SkyTex.OnLoaded += t => Renderer.SkyLight = t.CubemapLighting;
 		selectionMat = new Material("interactable.hlsl");
 		selectionMat.Transparency = Transparency.Add;

--- a/StereoKit/Assets/Tex.cs
+++ b/StereoKit/Assets/Tex.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
-using static System.Net.Mime.MediaTypeNames;
 
 namespace StereoKit
 {

--- a/StereoKit/Assets/Tex.cs
+++ b/StereoKit/Assets/Tex.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
+using static System.Net.Mime.MediaTypeNames;
 
 namespace StereoKit
 {
@@ -468,9 +469,29 @@ namespace StereoKit
 		/// in the async loading system. Lower values mean loading sooner.
 		/// </param>
 		/// <returns>A Cubemap texture asset!</returns>
+		[Obsolete("Use FromCubemap instead")]
 		public static Tex FromCubemapEquirectangular(string equirectangularCubemap, bool sRGBData = true, int loadPriority = 10)
+			=> FromCubemap(equirectangularCubemap, sRGBData, loadPriority);
+
+		/// <summary>Creates a cubemap texture from a single file! This will
+		/// load KTX2 files with 6 surfaces, or convert equirectangular images
+		/// into cubemap images. KTX2 files are the _fastest_ way to load a
+		/// cubemap, but equirectangular images can be acquired quite easily!
+		/// Equirectangular images look like an unwrapped globe with the poles
+		/// all stretched out, and are sometimes referred to as HDRIs.</summary>
+		/// <param name="cubemapFile">Filename of the cubemap image.</param>
+		/// <param name="sRGBData">Is this image color data in sRGB format,
+		/// or is it normal/metal/rough/data that's not for direct display?
+		/// sRGB colors get converted to linear color space on the graphics
+		/// card, so getting this right can have a big impact on visuals.
+		/// </param>
+		/// <param name="loadPriority">The priority sort order for this asset
+		/// in the async loading system. Lower values mean loading sooner.
+		/// </param>
+		/// <returns>A Cubemap texture asset!</returns>
+		public static Tex FromCubemap(string cubemapFile, bool sRGBData = true, int loadPriority = 10)
 		{
-			IntPtr tex = NativeAPI.tex_create_cubemap_file(NativeHelper.ToUtf8(equirectangularCubemap), sRGBData, IntPtr.Zero, loadPriority);
+			IntPtr tex = NativeAPI.tex_create_cubemap_file(NativeHelper.ToUtf8(cubemapFile), sRGBData, loadPriority);
 			return tex == IntPtr.Zero ? null : new Tex(tex);
 		}
 
@@ -493,10 +514,13 @@ namespace StereoKit
 		/// in the async loading system. Lower values mean loading sooner.
 		/// </param>
 		/// <returns>A Cubemap texture asset!</returns>
+		[Obsolete("Use overload without lightingInfo, then use Tex.CubemapLighting, preferably after async tex loading has finished")]
 		public static Tex FromCubemapEquirectangular(string equirectangularCubemap, out SphericalHarmonics lightingInfo, bool sRGBData = true, int loadPriority = 10)
 		{
-			IntPtr tex = NativeAPI.tex_create_cubemap_file(NativeHelper.ToUtf8(equirectangularCubemap), sRGBData, out lightingInfo, loadPriority);
-			return tex == IntPtr.Zero ? null : new Tex(tex);
+			IntPtr tex    = NativeAPI.tex_create_cubemap_file(NativeHelper.ToUtf8(equirectangularCubemap), sRGBData, loadPriority);
+			Tex    result = tex == IntPtr.Zero ? null : new Tex(tex);
+			lightingInfo = result == null ? default : result.CubemapLighting;
+			return result;
 		}
 
 		/// <summary>Loads an image file directly into a texture! Supported
@@ -640,7 +664,7 @@ namespace StereoKit
 		{
 			if (cubeFaceFiles_xxyyzz.Length != 6)
 				Log.Err("To create a cubemap, you must have exactly 6 images!");
-			IntPtr inst = NativeAPI.tex_create_cubemap_files(cubeFaceFiles_xxyyzz, sRGBData, IntPtr.Zero, priority);
+			IntPtr inst = NativeAPI.tex_create_cubemap_files(cubeFaceFiles_xxyyzz, sRGBData, priority);
 			return inst == IntPtr.Zero ? null : new Tex(inst);
 		}
 
@@ -662,12 +686,15 @@ namespace StereoKit
 		/// the async loading system. Lower values mean loading sooner.</param>
 		/// <returns>A Tex asset from the given files, or null if any failed 
 		/// to load.</returns>
+		[Obsolete("Use overload without lightingInfo, then use Tex.CubemapLighting, preferably after async tex loading has finished")]
 		public static Tex FromCubemapFile(string[] cubeFaceFiles_xxyyzz, out SphericalHarmonics lightingInfo, bool sRGBData = true, int priority = 10)
 		{
 			if (cubeFaceFiles_xxyyzz.Length != 6)
 				Log.Err("To create a cubemap, you must have exactly 6 images!");
-			IntPtr inst = NativeAPI.tex_create_cubemap_files(cubeFaceFiles_xxyyzz, sRGBData, out lightingInfo, priority);
-			return inst == IntPtr.Zero ? null : new Tex(inst);
+			IntPtr inst   = NativeAPI.tex_create_cubemap_files(cubeFaceFiles_xxyyzz, sRGBData, priority);
+			Tex    result = inst == IntPtr.Zero ? null : new Tex(inst);
+			lightingInfo = result == null ? default : result.CubemapLighting;
+			return result;
 		}
 
 		/// <summary>This will assemble a texture ready for rendering to! It

--- a/StereoKit/Native/NativeAPI.cs
+++ b/StereoKit/Native/NativeAPI.cs
@@ -176,10 +176,8 @@ namespace StereoKit
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr tex_create_mem          ([In] byte[] data, UIntPtr data_size, [MarshalAs(UnmanagedType.Bool)] bool srgb_data, int priority);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr tex_create_file         ([In] byte[] file_utf8, [MarshalAs(UnmanagedType.Bool)] bool srgb_data, int priority);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr tex_create_file_arr     (string[] files, int file_count, [MarshalAs(UnmanagedType.Bool)] bool srgb_data, int priority);
-		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr tex_create_cubemap_file ([In] byte[] equirectangular_file_utf8, [MarshalAs(UnmanagedType.Bool)] bool srgb_data, IntPtr lighting_info, int priority);
-		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr tex_create_cubemap_file ([In] byte[] equirectangular_file_utf8, [MarshalAs(UnmanagedType.Bool)] bool srgb_data, out SphericalHarmonics lighting_info, int priority);
-		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr tex_create_cubemap_files(string[] cube_face_file_xxyyzz, [MarshalAs(UnmanagedType.Bool)] bool srgb_data, IntPtr lighting_info, int priority);
-		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr tex_create_cubemap_files(string[] cube_face_file_xxyyzz, [MarshalAs(UnmanagedType.Bool)] bool srgb_data, out SphericalHarmonics lighting_info, int priority);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr tex_create_cubemap_file ([In] byte[] cubemap_file_utf8,  [MarshalAs(UnmanagedType.Bool)] bool srgb_data, int priority);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr tex_create_cubemap_files(string[] cube_face_file_xxyyzz, [MarshalAs(UnmanagedType.Bool)] bool srgb_data, int priority);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   tex_set_id              (IntPtr texture, string id);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr tex_get_id              (IntPtr texture);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   tex_set_fallback        (IntPtr texture, IntPtr fallback);

--- a/StereoKitC/asset_types/texture.cpp
+++ b/StereoKitC/asset_types/texture.cpp
@@ -34,6 +34,7 @@ void  _tex_set_options    (skg_tex_t* texture, tex_sample_ sample, tex_address_ 
 
 const char *tex_msg_load_failed           = "Texture file failed to load: %s";
 const char *tex_msg_invalid_fmt           = "Texture invalid format: %s";
+const char *tex_msg_invalid_cubemap       = "Texture not recognized as valid cubemap format: %s";
 const char *tex_msg_nested_arrays         = "Texture array cannot contain nested array texture: %s";
 const char *tex_msg_mismatched_images     = "Texture array mismatched format or size: %s";
 const char *tex_msg_inconsistent_parse    = "Texture data doesn't match earlier parse: %s";
@@ -48,18 +49,19 @@ tex_t tex_loading_texture = nullptr;
 ///////////////////////////////////////////
 
 struct tex_load_t {
-	bool32_t  is_srgb;
-	char    **file_names;
-	int32_t   file_count;
+	bool32_t    is_srgb;
+	char      **file_names;
+	int32_t     file_count;
 
-	void    **file_data;
-	size_t   *file_sizes;
+	void      **file_data;
+	size_t     *file_sizes;
 
-	void    **color_data;
-	int32_t   color_width;
-	int32_t   color_height;
-	int32_t   color_array_count;
-	int32_t   color_mip_count;
+	void      **color_data;
+	int32_t     color_width;
+	int32_t     color_height;
+	int32_t     color_array_count;
+	int32_t     color_mip_count;
+	tex_format_ color_format;
 };
 
 ///////////////////////////////////////////
@@ -81,7 +83,7 @@ void tex_load_free(asset_header_t *, void *job_data) {
 
 ///////////////////////////////////////////
 
-bool32_t tex_load_arr_files(asset_task_t *task, asset_header_t *asset, void *job_data) {
+bool32_t tex_load_arr_files_shared(asset_task_t* task, asset_header_t* asset, void* job_data) {
 	tex_load_t* data = (tex_load_t*)job_data;
 	tex_t       tex  = (tex_t)asset;
 
@@ -144,9 +146,23 @@ bool32_t tex_load_arr_files(asset_task_t *task, asset_header_t *asset, void *job
 	data->color_height      = final_height;
 	data->color_array_count = final_array_count * data->file_count;
 	data->color_mip_count   = final_mip_count;
+	data->color_format      = final_format;
+	return true;
+}
 
-	tex_set_meta(tex, data->color_width, data->color_height, final_format);
-	assets_task_set_complexity(task, data->color_width * data->color_width * data->color_array_count);
+///////////////////////////////////////////
+
+bool32_t tex_load_arr_files(asset_task_t *task, asset_header_t *asset, void *job_data) {
+	bool32_t result = tex_load_arr_files_shared(task, asset, job_data);
+
+	if (!result)
+		return false;
+
+	tex_load_t* data = (tex_load_t*)job_data;
+	tex_t       tex  = (tex_t)asset;
+
+	tex_set_meta(tex, data->color_width, data->color_height, data->color_format);
+	assets_task_set_complexity(task, data->color_width * data->color_height * data->color_array_count);
 	return true;
 }
 
@@ -191,134 +207,6 @@ bool32_t tex_load_arr_parse(asset_task_t *, asset_header_t *asset, void *job_dat
 		sk_free(data->file_data[i]);
 	}
 	tex->header.state = asset_state_loaded_meta;
-	return true;
-}
-
-///////////////////////////////////////////
-
-bool32_t tex_load_equirect_file(asset_task_t *task, asset_header_t *asset, void *job_data) {
-	tex_load_t* data = (tex_load_t*)job_data;
-	tex_t       tex  = (tex_t)asset;
-
-	data->file_data  = sk_malloc_t(void *, data->file_count);
-	data->file_sizes = sk_malloc_t(size_t, data->file_count);
-
-	if (!platform_read_file(data->file_names[0], &data->file_data[0], &data->file_sizes[0])) {
-		log_warnf(tex_msg_load_failed, data->file_names[0]);
-		tex->header.state = asset_state_error_not_found;
-		return false;
-	}
-
-	tex_format_ format;
-	if (!tex_load_image_info(data->file_data[0], data->file_sizes[0], data->is_srgb, &tex->type, &format, &data->color_width, &data->color_height, &data->color_array_count, &data->color_mip_count)) {
-		log_warnf(tex_msg_invalid_fmt, data->file_names[0]);
-		tex->header.state = asset_state_error_unsupported;
-		return false;
-	}
-
-	int32_t tex_size = data->color_height / 2;
-	tex_set_meta(tex, tex_size, tex_size, format);
-	assets_task_set_complexity(task, tex_size * 6);
-	return true;
-}
-
-///////////////////////////////////////////
-
-bool32_t tex_load_equirect_parse(asset_task_t *, asset_header_t *asset, void *job_data) {
-	tex_load_t *data = (tex_load_t *)job_data;
-	tex_t       tex  = (tex_t)asset;
-
-	if (data->color_array_count != 1) {
-		log_warnf(tex_msg_invalid_fmt, data->file_names[0]);
-		tex->header.state = asset_state_error_unsupported;
-		return false;
-	}
-
-	data->color_data = sk_malloc_t(void*, 1);
-
-	tex_format_ format      = tex_format_none;
-	int32_t     array_count = 0;
-	int32_t     mip_count   = 0;
-	if (!tex_load_image_data(data->file_data[0], data->file_sizes[0], data->is_srgb, &tex->type, &format, &data->color_width, &data->color_height, &array_count, &mip_count, &data->color_data[0])) {
-		log_warnf(tex_msg_invalid_fmt, data->file_names[0]);
-		tex->header.state = asset_state_error_unsupported;
-		return false;
-	}
-
-	// Release file memory as soon as we're done with it
-	sk_free(data->file_data[0]);
-
-	return true;
-}
-
-///////////////////////////////////////////
-
-bool32_t tex_load_equirect_upload(asset_task_t *, asset_header_t *asset, void *job_data) {
-	tex_load_t *data = (tex_load_t *)job_data;
-	tex_t       tex  = (tex_t)asset;
-
-	const vec3 up   [6] = { vec3_up, vec3_up, -vec3_forward, vec3_forward, vec3_up, vec3_up };
-	const vec3 fwd  [6] = { {1,0, 0}, {-1,0,0}, {0,-1,0}, {0,1,0}, {0,0,1}, { 0,0,-1} };
-	const vec3 right[6] = { {0,0,-1}, { 0,0,1}, {1, 0,0}, {1,0,0}, {1,0,0}, {-1,0, 0} };
-
-	tex_t equirect = tex_create(tex_type_image_nomips, tex->format);
-	tex_set_color_arr(equirect, data->color_width, data->color_height, data->color_data, data->file_count);
-	tex_set_address  (equirect, tex_address_clamp);
-	
-	material_t convert_material = material_find(default_id_material_equirect);
-	material_set_texture(convert_material, "source", equirect);
-
-	tex_t    face         = tex_create(tex_type_rendertarget, equirect->format);
-	void    *face_data[6] = {};
-	size_t   size         = tex_format_size(equirect->format, tex->width, tex->height);
-	tex_set_colors(face, tex->width, tex->height, nullptr);
-	for (int32_t i = 0; i < 6; i++) {
-		material_set_vector4(convert_material, "up",      { up   [i].x, up   [i].y, up   [i].z, 0 });
-		material_set_vector4(convert_material, "right",   { right[i].x, right[i].y, right[i].z, 0 });
-		material_set_vector4(convert_material, "forward", { fwd  [i].x, fwd  [i].y, fwd  [i].z, 0 });
-
-		face_data[i] = sk_malloc(size);
-
-		// Blit conversion _definitely_ needs executed on the GPU thread
-		struct blit_t {
-			tex_t      face;
-			material_t material;
-			void      *face_data;
-			size_t     size;
-		};
-		blit_t blit_data = { face, convert_material, face_data[i], size };
-		assets_execute_gpu([](void *data) {
-			blit_t *blit_data = (blit_t *)data;
-			render_blit (blit_data->face, blit_data->material);
-			tex_get_data(blit_data->face, blit_data->face_data, blit_data->size);
-			return (bool32_t)true;
-		}, &blit_data);
-		
-		
-#if defined(SKG_OPENGL)
-		size_t line_size = tex_format_pitch(equirect->format, tex->width);
-		void*  tmp       = sk_malloc(line_size);
-		for (int32_t y = 0; y < tex->height/2; y++) {
-			void *top_line = ((uint8_t*)face_data[i]) + line_size * y;
-			void *bot_line = ((uint8_t*)face_data[i]) + line_size * ((tex->height-1) - y);
-			memcpy(tmp,      top_line, line_size);
-			memcpy(top_line, bot_line, line_size);
-			memcpy(bot_line, tmp,      line_size);
-		}
-		sk_free(tmp);
-#endif
-	}
-
-	tex_release(face);
-	material_release(convert_material);
-	tex_release(equirect);
-
-	tex_set_color_arr(tex, tex->width, tex->height, (void**)&face_data, 6);
-	for (int32_t i = 0; i < 6; i++) {
-		sk_free(face_data[i]);
-	}
-
-	tex->header.state = asset_state_loaded;
 	return true;
 }
 
@@ -568,7 +456,7 @@ tex_t tex_create_color128(color128 *data, int32_t width, int32_t height, bool32_
 
 ///////////////////////////////////////////
 
-tex_t _tex_create_file_arr(tex_type_ type, const char **files, int32_t file_count, bool32_t srgb_data, spherical_harmonics_t *out_sh_lighting_info, int32_t priority) {
+tex_t _tex_create_file_arr(tex_type_ type, const char **files, int32_t file_count, bool32_t srgb_data, int32_t priority) {
 	// Hash the names of all of the files together
 	uint64_t hash = HASH_FNV64_START;
 	for (int32_t i = 0; i < file_count; i++) {
@@ -580,8 +468,6 @@ tex_t _tex_create_file_arr(tex_type_ type, const char **files, int32_t file_coun
 	// And see if it's already been loaded
 	tex_t result = tex_find(file_id);
 	if (result != nullptr) {
-		if (out_sh_lighting_info != nullptr)
-			*out_sh_lighting_info = tex_get_cubemap_lighting(result);
 		return result;
 	}
 
@@ -604,10 +490,6 @@ tex_t _tex_create_file_arr(tex_type_ type, const char **files, int32_t file_coun
 	};
 	assets_add_task( tex_make_loading_task(result, load_data, actions, _countof(actions), priority, 0) );
 
-	// NOTE: this will block execution if it occurs, as it requires the cubemap
-	// to be loaded!
-	if (out_sh_lighting_info != nullptr)
-		*out_sh_lighting_info = tex_get_cubemap_lighting(result);
 
 	return result;
 }
@@ -615,51 +497,151 @@ tex_t _tex_create_file_arr(tex_type_ type, const char **files, int32_t file_coun
 ///////////////////////////////////////////
 
 tex_t tex_create_file_arr(const char **files, int32_t file_count, bool32_t srgb_data, int32_t priority) {
-	return _tex_create_file_arr(tex_type_image, files, file_count, srgb_data, nullptr, priority);
+	return _tex_create_file_arr(tex_type_image, files, file_count, srgb_data, priority);
 }
-
 ///////////////////////////////////////////
 
-tex_t tex_create_cubemap_file(const char *equirectangular_file, bool32_t srgb_data, spherical_harmonics_t *out_sh_lighting_info, int32_t priority) {
-	char equirect_id[64];
-	snprintf(equirect_id, sizeof(equirect_id), "sk/tex/equirect/%" PRIu64, hash_fnv64_string(equirectangular_file));
+tex_t tex_create_cubemap_file(const char *cubemap_file, bool32_t srgb_data, int32_t priority) {
+	char cubemap_id[64];
+	snprintf(cubemap_id, sizeof(cubemap_id), "sk/tex/cubemap/%" PRIu64, hash_fnv64_string(cubemap_file));
 
-	tex_t result = tex_find(equirect_id);
+	tex_t result = tex_find(cubemap_id);
 	if (result != nullptr) {
-		if (out_sh_lighting_info != nullptr)
-			*out_sh_lighting_info = tex_get_cubemap_lighting(result);
 		return result;
 	}
 
 	result = tex_create(tex_type_image | tex_type_cubemap);
-	tex_set_id(result, equirect_id);
+	tex_set_id(result, cubemap_id);
 	result->header.state = asset_state_loading;
 
 	tex_load_t *load_data = sk_malloc_zero_t(tex_load_t, 1);
 	load_data->is_srgb       = srgb_data;
 	load_data->file_count    = 1;
 	load_data->file_names    = sk_malloc_t(char *, 1);
-	load_data->file_names[0] = string_copy(equirectangular_file);
+	load_data->file_names[0] = string_copy(cubemap_file);
+
+	///////////////////////////////////////////
+
+	bool32_t (*load)(asset_task_t*, asset_header_t*, void*) = [](asset_task_t* task, asset_header_t* asset, void* job_data) {
+		if (!tex_load_arr_files_shared(task, asset, job_data))
+			return (bool32_t)false;
+
+		tex_load_t* data = (tex_load_t*)job_data;
+		tex_t       tex = (tex_t)asset;
+
+		int32_t size_w, size_h;
+		if (data->color_array_count == 6) { // file contains a pre-built cubemap
+			size_w = data->color_width;
+			size_h = data->color_height;
+		/*} else if (data->color_array_count == 1 && data->color_width / 4 == data->color_height / 3) { // Cubemap crosses are 4x3 aspect ratio
+			size_w = size_h = data->color_height / 3;
+		} else if (data->color_array_count == 1 && data->color_width / 6 == data->color_height    ) { // Cubemap lists are 6x1 aspect ratio
+			size_w = size_h = data->color_height;*/
+		} else if (data->color_array_count == 1) { // We'll treat this like an equirect, generally they're 2x1, but anything could work.
+			size_w = size_h = data->color_height / 2;
+		} else {
+			log_warnf(tex_msg_invalid_cubemap, data->file_names[0]);
+			tex->header.state = asset_state_error_unsupported;
+			return (bool32_t)false;
+		}
+
+		tex_set_meta(tex, size_w, size_h, data->color_format);
+		assets_task_set_complexity(task, size_w * size_h * 6);
+		return (bool32_t)true;
+	};
+
+	///////////////////////////////////////////
+
+	bool32_t(*upload)(asset_task_t*, asset_header_t*, void*) = [](asset_task_t* task, asset_header_t * asset, void* job_data) {
+		tex_load_t *data = (tex_load_t *)job_data;
+		tex_t       tex  = (tex_t)asset;
+
+		// If this is already a cubemap, we don't need to do anything fancy
+		// here, just pass it along to our normal texture upload code.
+		if (data->color_array_count == 6) {
+			return tex_load_arr_upload(task, asset, job_data);
+		}
+
+		const vec3 up   [6] = { vec3_up, vec3_up, -vec3_forward, vec3_forward, vec3_up, vec3_up };
+		const vec3 fwd  [6] = { {1,0, 0}, {-1,0,0}, {0,-1,0}, {0,1,0}, {0,0,1}, { 0,0,-1} };
+		const vec3 right[6] = { {0,0,-1}, { 0,0,1}, {1, 0,0}, {1,0,0}, {1,0,0}, {-1,0, 0} };
+
+		tex_t equirect = tex_create(tex_type_image_nomips, tex->format);
+		tex_set_color_arr(equirect, data->color_width, data->color_height, data->color_data, data->file_count);
+		tex_set_address  (equirect, tex_address_clamp);
+	
+		material_t convert_material = material_find(default_id_material_equirect);
+		material_set_texture(convert_material, "source", equirect);
+
+		tex_t    face         = tex_create(tex_type_rendertarget, equirect->format);
+		void    *face_data[6] = {};
+		size_t   size         = tex_format_size(equirect->format, tex->width, tex->height);
+		tex_set_colors(face, tex->width, tex->height, nullptr);
+		for (int32_t i = 0; i < 6; i++) {
+			material_set_vector4(convert_material, "up",      { up   [i].x, up   [i].y, up   [i].z, 0 });
+			material_set_vector4(convert_material, "right",   { right[i].x, right[i].y, right[i].z, 0 });
+			material_set_vector4(convert_material, "forward", { fwd  [i].x, fwd  [i].y, fwd  [i].z, 0 });
+
+			face_data[i] = sk_malloc(size);
+
+			// Blit conversion _definitely_ needs executed on the GPU thread
+			struct blit_t {
+				tex_t      face;
+				material_t material;
+				void      *face_data;
+				size_t     size;
+			};
+			blit_t blit_data = { face, convert_material, face_data[i], size };
+			assets_execute_gpu([](void *data) {
+				blit_t *blit_data = (blit_t *)data;
+				render_blit (blit_data->face, blit_data->material);
+				tex_get_data(blit_data->face, blit_data->face_data, blit_data->size);
+				return (bool32_t)true;
+			}, &blit_data);
+
+#if defined(SKG_OPENGL)
+			size_t line_size = tex_format_pitch(equirect->format, tex->width);
+			void*  tmp       = sk_malloc(line_size);
+			for (int32_t y = 0; y < tex->height/2; y++) {
+				void *top_line = ((uint8_t*)face_data[i]) + line_size * y;
+				void *bot_line = ((uint8_t*)face_data[i]) + line_size * ((tex->height-1) - y);
+				memcpy(tmp,      top_line, line_size);
+				memcpy(top_line, bot_line, line_size);
+				memcpy(bot_line, tmp,      line_size);
+			}
+			sk_free(tmp);
+#endif
+		}
+
+		tex_release(face);
+		material_release(convert_material);
+		tex_release(equirect);
+
+		tex_set_color_arr(tex, tex->width, tex->height, (void**)&face_data, 6);
+		for (int32_t i = 0; i < 6; i++) {
+			sk_free(face_data[i]);
+		}
+
+		tex->header.state = asset_state_loaded;
+		return (bool32_t)true;
+	};
+
+	///////////////////////////////////////////
 
 	static const asset_load_action_t actions[] = {
-		asset_load_action_t {tex_load_equirect_file,   asset_thread_asset},
-		asset_load_action_t {tex_load_equirect_parse,  asset_thread_asset},
-		asset_load_action_t {tex_load_equirect_upload, backend_graphics_get() == backend_graphics_d3d11 ? asset_thread_asset : asset_thread_gpu },
+		asset_load_action_t {load,               asset_thread_asset},
+		asset_load_action_t {tex_load_arr_parse, asset_thread_asset},
+		asset_load_action_t {upload,             backend_graphics_get() == backend_graphics_d3d11 ? asset_thread_asset : asset_thread_gpu },
 	};
 	assets_add_task( tex_make_loading_task(result, load_data, actions, _countof(actions), priority, 0) );
-
-	// NOTE: this will block execution if it occurs, as it requires the cubemap
-	// to be loaded!
-	if (out_sh_lighting_info != nullptr)
-		*out_sh_lighting_info = tex_get_cubemap_lighting(result);
 
 	return result;
 }
 
 ///////////////////////////////////////////
 
-tex_t tex_create_cubemap_files(const char **cube_face_file_xxyyzz, bool32_t srgb_data, spherical_harmonics_t *out_sh_lighting_info, int32_t priority) {
-	return _tex_create_file_arr(tex_type_image | tex_type_cubemap, cube_face_file_xxyyzz, 6, srgb_data, out_sh_lighting_info, priority);
+tex_t tex_create_cubemap_files(const char **cube_face_file_xxyyzz, bool32_t srgb_data, int32_t priority) {
+	return _tex_create_file_arr(tex_type_image | tex_type_cubemap, cube_face_file_xxyyzz, 6, srgb_data, priority);
 }
 
 ///////////////////////////////////////////

--- a/StereoKitC/asset_types/texture_compression.cpp
+++ b/StereoKitC/asset_types/texture_compression.cpp
@@ -158,7 +158,7 @@ bool ktx2_decode(void* data, size_t data_size, tex_type_ *ref_image_type, tex_fo
 		out_data_arr[i] = sk_malloc(layer_size);
 	}
 
-	ktx2_transcoder_state state = {};
+	ktx2_transcoder_state state;
 	state.clear();
 	ktx_transcoder.start_transcoding();
 	bool    success    = true;

--- a/StereoKitC/stereokit.h
+++ b/StereoKitC/stereokit.h
@@ -1034,8 +1034,8 @@ SK_API tex_t        tex_create_color128     (color128 *in_arr_data, int32_t widt
 SK_API tex_t        tex_create_mem          (void *data, size_t data_size,                  bool32_t srgb_data sk_default(true), int32_t priority sk_default(10));
 SK_API tex_t        tex_create_file         (const char *file_utf8,                         bool32_t srgb_data sk_default(true), int32_t priority sk_default(10));
 SK_API tex_t        tex_create_file_arr     (const char **in_arr_files, int32_t file_count, bool32_t srgb_data sk_default(true), int32_t priority sk_default(10));
-SK_API tex_t        tex_create_cubemap_file (const char *equirectangular_file_utf8,         bool32_t srgb_data sk_default(true), spherical_harmonics_t *out_sh_lighting_info sk_default(nullptr), int32_t priority sk_default(10));
-SK_API tex_t        tex_create_cubemap_files(const char **in_arr_cube_face_file_xxyyzz,     bool32_t srgb_data sk_default(true), spherical_harmonics_t *out_sh_lighting_info sk_default(nullptr), int32_t priority sk_default(10));
+SK_API tex_t        tex_create_cubemap_file (const char *cubemap_file_utf8,                 bool32_t srgb_data sk_default(true), int32_t priority sk_default(10));
+SK_API tex_t        tex_create_cubemap_files(const char **in_arr_cube_face_file_xxyyzz,     bool32_t srgb_data sk_default(true), int32_t priority sk_default(10));
 SK_API void         tex_set_id              (tex_t texture, const char *id);
 SK_API const char*  tex_get_id              (const tex_t texture);
 SK_API void         tex_set_fallback        (tex_t texture, tex_t fallback);

--- a/StereoKitC/systems/input.cpp
+++ b/StereoKitC/systems/input.cpp
@@ -43,7 +43,6 @@ pose_t input_eyes_pose_world;
 ///////////////////////////////////////////
 
 void input_mouse_update();
-void input_hand_update_fallback_meshes(hand_mesh_t hand_mesh_2[]);
 
 ///////////////////////////////////////////
 


### PR DESCRIPTION
`Tex.FromCubemapEquirectangular` is now deprecated, as it could not load KTX cubemaps. This generic loading of cubemap files to be somewhat cumbersome, as two different functions were necessary, and knowledge about what type of cubemap file was needed in advance of loading.

This now adds `Tex.FromCubemap`, a single function which will load a KTX cubemap if present, and will also convert non-cubemap source images as if they were equirectangular images. In the future, this function could also be modified to add support for cubemap strips (6x1 aspect) or crosses (4x3 aspect).