### PR TITLE
Check pending skytex _after_ app step to prevent single frame delay.

### DIFF
--- a/StereoKitC/systems/render.cpp
+++ b/StereoKitC/systems/render.cpp
@@ -171,8 +171,6 @@ skg_buffer_t *render_fill_inst_buffer (const array_t<render_transform_buffer_t>*
 void          render_reset_buffer_pool();
 void          render_save_to_file     (color32* color_buffer, int width, int height, void* context);
 
-void          _render_check_pending_skytex();
-
 void          render_list_prep        (render_list_t list);
 void          render_list_add         (const render_item_t *item);
 void          render_list_add_to      (render_list_t list, const render_item_t *item);
@@ -302,7 +300,6 @@ void render_step() {
 	render_reset_buffer_pool();
 
 	hierarchy_step();
-	_render_check_pending_skytex();
 
 	if (local.sky_show && device_display_get_blend() == display_blend_opaque) {
 		render_add_mesh(local.sky_mesh, local.sky_mat, matrix_identity, {1,1,1,1}, render_layer_vfx);
@@ -527,7 +524,7 @@ void render_set_sim_head(pose_t pose) {
 
 ///////////////////////////////////////////
 
-void _render_check_pending_skytex() {
+void render_check_pending_skytex() {
 	if (local.sky_pending_tex == nullptr) return;
 
 	asset_state_ state = tex_asset_state(local.sky_pending_tex);
@@ -569,7 +566,7 @@ void render_set_skytex(tex_t sky_texture) {
 
 	// This is also checked every step, but if the texture is already valid, we
 	// can set it up right away and avoid any potential frame delays.
-	_render_check_pending_skytex();
+	render_check_pending_skytex();
 }
 
 ///////////////////////////////////////////

--- a/StereoKitC/systems/render.h
+++ b/StereoKitC/systems/render.h
@@ -39,6 +39,7 @@ void          render_set_sim_head         (pose_t pose);
 void          render_draw_queue           (render_list_t list, const matrix* views, const matrix* projections, int32_t eye_offset, int32_t view_count, render_layer_ filter);
 void          render_check_screenshots    ();
 void          render_check_viewpoints     ();
+void          render_check_pending_skytex ();
 
 void          render_list_destroy         (      render_list_t list);
 void          render_list_execute         (      render_list_t list, render_layer_ filter, uint32_t view_count, int32_t queue_start, int32_t queue_end);

--- a/StereoKitC/systems/render_pipeline.cpp
+++ b/StereoKitC/systems/render_pipeline.cpp
@@ -34,6 +34,7 @@ static render_pipeline_state_t local = {};
 ///////////////////////////////////////////
 
 void render_pipeline_begin() {
+	render_check_pending_skytex();
 	skg_event_begin("Setup");
 	{
 		skg_draw_begin();


### PR DESCRIPTION
Skytex changes were happening with one frame delay due to recent changes, even with a call to `Assets.BlockForPriority`. The `SkyTex` asset would be available, but the renderer wouldn't pick it up until the next frame, due to the check being before the App step where the `BlockForPriority` occured.