### PR TITLE
Fix validation issue with array texture file parsing code

### DIFF
--- a/Examples/StereoKitTest/Tests/TestTextures.cs
+++ b/Examples/StereoKitTest/Tests/TestTextures.cs
@@ -57,6 +57,8 @@ internal class TestTextures : ITest
 		Tests.Test(CheckTextureRead);
 		Tests.Test(CheckBlankTex);
 		Tests.Test(CheckBlockingSize);
+		Tests.Test(CheckArrayTex);
+		Tests.Test(CheckArrayCubemap);
 
 		Tests.Screenshot("TexFormats.jpg", 0, 400, 400, 50, V.XYZ(0,-0.15f, 0), V.XYZ(0,-0.15f,-0.5f) );
 	}
@@ -158,6 +160,20 @@ internal class TestTextures : ITest
 			return false;
 
 		return true;
+	}
+
+	bool CheckArrayTex()
+	{
+		Tex t = Tex.FromFiles(new string[]{"test.png", "test_normal.png", "metal_plate_diff.jpg", "metal_plate_metal.jpg" });
+		Assets.BlockForPriority(int.MaxValue);
+		return t.AssetState == AssetState.Loaded;
+	}
+
+	bool CheckArrayCubemap()
+	{
+		Tex t = Tex.FromCubemapFile(new string[] { "UVTex.png", "UVTex.png", "UVTex.png", "UVTex.png", "UVTex.png", "UVTex.png" });
+		Assets.BlockForPriority(int.MaxValue);
+		return t.AssetState == AssetState.Loaded;
 	}
 
 	public void Step()


### PR DESCRIPTION
Array textures were attempting to validate their texture count in an improper way.

New code validates the count properly. This also fixes a missed memory free on failure, as well as a missed error texture.

Added a test for this path, as well as a similar path for cubemaps that doesn't currently pass for some other reason.