### PR TITLE
Add `SKSettings.standbyMode` to make SK's standby behavior configurable.

### DIFF
--- a/StereoKit/Native/NativeEnums.cs
+++ b/StereoKit/Native/NativeEnums.cs
@@ -261,6 +261,31 @@ namespace StereoKit
 		Copy,
 	}
 
+	/// <summary>When the device StereoKit is running on goes into standby mode, how should
+	/// StereoKit react? Typically the app should pause, stop playing sound, and
+	/// consume as little power as possible, but some scenarios such as multiplayer
+	/// games may need the app to continue running.</summary>
+	public enum StandbyMode {
+		/// <summary>This will let StereoKit pick a mode based on its own preferences. On v0.3
+		/// and lower, this will be Slow, and on v0.4 and higher, this will be Pause.</summary>
+		Default      = 0,
+		/// <summary>The entire main thread will pause, and wait until the device has come out
+		/// of standby. This is the most power efficient mode for the device to take
+		/// when the device is in standby, and is recommended for the vast majority
+		/// of apps. This will also disable sound.</summary>
+		Pause        = 1,
+		/// <summary>The main thread will continue to execute, but with 100ms sleeps each
+		/// frame. This allows the app to continue polling and processing, but
+		/// reduces power consumption by throttling a bit. This will not disable
+		/// sound. In the Simulator, this will behave as Slow.</summary>
+		Slow         = 2,
+		/// <summary>The main thread will continue to execute, but with a very short sleep
+		/// each frame. This allows the app to continue polling and processing, but
+		/// without flooding the CPU with polling work while vsync is no longer the
+		/// throttle. This will not disable sound.</summary>
+		None         = 3,
+	}
+
 	/// <summary>Provides a reason on why StereoKit has quit.</summary>
 	public enum QuitReason {
 		/// <summary>Default state when SK has not quit.</summary>

--- a/StereoKit/Native/NativeTypes.cs
+++ b/StereoKit/Native/NativeTypes.cs
@@ -72,6 +72,7 @@ namespace StereoKit
 		/// power while the app is out-of-focus, but may not always be
 		/// desired. In particular, running multiple copies of a SK app for
 		/// testing networking code may benefit from this setting.</summary>
+		[Obsolete("Use SKSettings.standbyMode with StandbyMode.None instead.")]
 		public bool disableUnfocusedSleep { get { return _disableUnfocusedSleep > 0; } set { _disableUnfocusedSleep = value ? 1 : 0; } }
 		private int _disableUnfocusedSleep;
 
@@ -101,6 +102,12 @@ namespace StereoKit
 		/// skips submitting a projection layer to OpenXR entirely.</summary>
 		public bool omitEmptyFrames { get { return _omitEmptyFrames > 0; } set { _omitEmptyFrames = value ? 1 : 0; } }
 		private int _omitEmptyFrames;
+
+		/// <summary>Configures StereoKit's behavior during device standby. By
+		/// default in v0.4, SK will completely pause the main thread and
+		/// disable audio. In v0.3, SK will continue to execute at a throttled
+		/// pace, and audio will remain on.</summary>
+		public StandbyMode standbyMode;
 
 		/// <summary>A pointer to the JNI's JavaVM structure, only used for
 		/// Android applications. This is optional, even for Android.</summary>

--- a/StereoKitC/stereokit.cpp
+++ b/StereoKitC/stereokit.cpp
@@ -103,7 +103,15 @@ bool32_t sk_init(sk_settings_t settings) {
 	if (local.settings.flatscreen_height  == 0      ) local.settings.flatscreen_height  = 720;
 	if (local.settings.render_scaling     == 0      ) local.settings.render_scaling     = 1;
 	if (local.settings.mode               == app_mode_none) local.settings.mode         = app_mode_xr;
-
+#if SK_VERSION_MINOR >= 4
+	if (local.settings.standby_mode == standby_mode_default) local.settings.standby_mode = standby_mode_pause;
+#else
+	if (local.settings.standby_mode == standby_mode_default)
+		local.settings.standby_mode = local.settings.disable_unfocused_sleep
+			? standby_mode_none
+			: standby_mode_slow;
+#endif
+	
 	// HoloLens (UWP) can't handle MSAA and a resolve, so we set MSAA to 1 by
 	// default there. Fortunately it looks great without it, so we don't really
 	// need MSAA there. This setting is still explicitly assignable.
@@ -224,7 +232,7 @@ bool32_t sk_step_end() {
 
 	systems_step_partial(system_run_from, local.app_system_idx+1);
 
-	if (device_display_get_type() == display_type_flatscreen && local.focus != app_focus_active && !local.settings.disable_unfocused_sleep)
+	if (device_display_get_type() == display_type_flatscreen && local.focus != app_focus_active && local.settings.standby_mode != standby_mode_none)
 		platform_sleep(100);
 	local.in_step = false;
 	return local.running;

--- a/StereoKitC/stereokit.h
+++ b/StereoKitC/stereokit.h
@@ -373,6 +373,32 @@ typedef enum memory_ {
 	memory_copy,
 } memory_;
 
+/*When the device StereoKit is running on goes into standby mode, how should
+  StereoKit react? Typically the app should pause, stop playing sound, and
+  consume as little power as possible, but some scenarios such as multiplayer
+  games may need the app to continue running.*/
+typedef enum standby_mode_ {
+	/*This will let StereoKit pick a mode based on its own preferences. On v0.3
+	  and lower, this will be Slow, and on v0.4 and higher, this will be Pause.
+	  */
+	standby_mode_default = 0,
+	/*The entire main thread will pause, and wait until the device has come out
+	  of standby. This is the most power efficient mode for the device to take
+	  when the device is in standby, and is recommended for the vast majority
+	  of apps. This will also disable sound.*/
+	standby_mode_pause = 1,
+	/*The main thread will continue to execute, but with 100ms sleeps each
+	  frame. This allows the app to continue polling and processing, but
+	  reduces power consumption by throttling a bit. This will not disable
+	  sound. In the Simulator, this will behave as Slow.*/
+	standby_mode_slow = 2,
+	/*The main thread will continue to execute, but with a very short sleep
+	  each frame. This allows the app to continue polling and processing, but
+	  without flooding the CPU with polling work while vsync is no longer the
+	  throttle. This will not disable sound.*/
+	standby_mode_none = 3
+};
+
 typedef struct sk_settings_t {
 	const char    *app_name;
 	const char    *assets_folder;
@@ -393,6 +419,7 @@ typedef struct sk_settings_t {
 	int32_t        render_multisample;
 	origin_mode_   origin;
 	bool32_t       omit_empty_frames;
+	standby_mode_  standby_mode;
 
 	void          *android_java_vm;  // JavaVM*
 	void          *android_activity; // jobject

--- a/StereoKitC/xr_backends/openxr.cpp
+++ b/StereoKitC/xr_backends/openxr.cpp
@@ -982,33 +982,38 @@ void openxr_step_end() {
 	// This happens at the end of step_end so that the app still can receive a
 	// message about the app going into a hidden state.
 	if (xr_session_state == XR_SESSION_STATE_IDLE && sk_is_running()) {
-		log_diagf("Sleeping until OpenXR session wakes");
+		const sk_settings_t* settings = sk_get_settings_ref();
+		if (settings->standby_mode == standby_mode_pause) {
+			log_diagf("Sleeping until OpenXR session wakes");
 #if defined(SK_OS_ANDROID)
-		if (xr_ext.KHR_android_thread_settings == xr_ext_active) {
-			xr_extensions.xrSetAndroidApplicationThreadKHR(xr_session, XR_ANDROID_THREAD_TYPE_APPLICATION_WORKER_KHR, gettid());
-		}
+			if (xr_ext.KHR_android_thread_settings == xr_ext_active) {
+				xr_extensions.xrSetAndroidApplicationThreadKHR(xr_session, XR_ANDROID_THREAD_TYPE_APPLICATION_WORKER_KHR, gettid());
+			}
 #endif
-		// Add a small delay before pausing audio since the sleeping path can
-		// be triggered by a regular shutdown, and it would be a waste to stop
-		// and resume audio when we're just going to shut down later.
-		int32_t       timer      = 0;
-		const int32_t timer_time = 5; // timer_time * 100ms == 500ms
+			// Add a small delay before pausing audio since the sleeping path can
+			// be triggered by a regular shutdown, and it would be a waste to stop
+			// and resume audio when we're just going to shut down later.
+			int32_t       timer      = 0;
+			const int32_t timer_time = 5; // timer_time * 100ms == 500ms
 
-		while (xr_session_state == XR_SESSION_STATE_IDLE && sk_is_running()) {
-			if (timer == timer_time) audio_pause();
-			timer += 1;
+			while (xr_session_state == XR_SESSION_STATE_IDLE && sk_is_running()) {
+				if (timer == timer_time) audio_pause();
+				timer += 1;
 
-			platform_sleep(100);
-			openxr_poll_events();
-		}
-		if (timer > timer_time) audio_resume();
+				platform_sleep(100);
+				openxr_poll_events();
+			}
+			if (timer > timer_time) audio_resume();
 
 #if defined(SK_OS_ANDROID)
-		if (xr_ext.KHR_android_thread_settings == xr_ext_active) {
-			xr_extensions.xrSetAndroidApplicationThreadKHR(xr_session, XR_ANDROID_THREAD_TYPE_RENDERER_MAIN_KHR, gettid());
-		}
+			if (xr_ext.KHR_android_thread_settings == xr_ext_active) {
+				xr_extensions.xrSetAndroidApplicationThreadKHR(xr_session, XR_ANDROID_THREAD_TYPE_RENDERER_MAIN_KHR, gettid());
+			}
 #endif
-		log_diagf("Resuming from sleep");
+			log_diagf("Resuming from sleep");
+		} else if (settings->standby_mode == standby_mode_slow) {
+			platform_sleep(77);
+		}
 	}
 }
 


### PR DESCRIPTION
This makes `disableUnfocusedSleep` obsolete, and wraps that behavior into `SKSettings.standbyMode`. To recreate `disableUnfocusedSleep`'s behavior with `SKSettings.standbyMode`, set it to `StandbyMode.None`.