### PR TITLE
Fix for Vive XR Elite hand data.

### DIFF
--- a/StereoKitC/hands/hand_oxr_articulated.cpp
+++ b/StereoKitC/hands/hand_oxr_articulated.cpp
@@ -186,7 +186,19 @@ void hand_oxra_update_joints() {
 		bool valid_joints =
 			(locations.jointLocations[10].locationFlags & XR_SPACE_LOCATION_POSITION_VALID_BIT) > 0 ||
 			(locations.jointLocations[0 ].locationFlags & XR_SPACE_LOCATION_POSITION_VALID_BIT) > 0 ||
-			(locations.jointLocations[1 ].locationFlags & XR_SPACE_LOCATION_POSITION_VALID_BIT) > 0;
+			(locations.jointLocations[1] .locationFlags & XR_SPACE_LOCATION_POSITION_VALID_BIT) > 0;
+		// Vive XR Elite will mark joints as valid, but then send invalid joint
+		// data such as 0,0,0,0 quats which will crash math functions.
+		// Unfortunately, it seems impossible to restrict this to specific
+		// joints, so all joints must be checked.
+		for (uint32_t j = 0; j < locations.jointCount; j++) {
+			XrHandJointLocationEXT jt = locations.jointLocations[j];
+			float sum = jt.pose.orientation.x + jt.pose.orientation.y + jt.pose.orientation.z + jt.pose.orientation.w;
+			if (sum == 0) {
+				valid_joints = false;
+				break;
+			}
+		}
 		hand_t *inp_hand = input_hand_ref((handed_)h);
 		inp_hand->tracked_state = button_make_state((inp_hand->tracked_state & button_state_active) > 0, valid_joints);
 


### PR DESCRIPTION
Vive XR Elite's runtime was sending hand joint data that was flagged as valid, but contained bad quaternions that would crash DirectXMath. This adds a check to validate all hand quaternions every frame before considering the joint data valid.