### PR TITLE
Building Windows .exe with GNU toochain on linux & windows (& probably Mac)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,7 +207,9 @@ add_compile_definitions(BASISD_SUPPORT_ATC=0)
 add_compile_definitions(BASISD_SUPPORT_ETC2_EAC_A8=0)
 add_compile_definitions(BASISD_SUPPORT_BC7=0)
 add_compile_definitions(BASISD_SUPPORT_BC7_MODE5=0)
-
+if (__MINGW32__)
+  add_compile_definitions(PAL_STDCPP_COMPAT="needed for mingw")
+endif()
 CPMAddPackage( # We're scraping the comment after the NAME for some other scripts
   NAME sk_gpu # 2024.9.26
   URL https://github.com/StereoKit/sk_gpu/releases/download/v2024.9.26/sk_gpu.v2024.9.26.zip

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,13 +141,14 @@ elseif(WIN32)
     set(SK_SHADER_TARGETS "x")
   endif()
   add_definitions("-D_CRT_SECURE_NO_WARNINGS")
-  set(WINDOWS_LIBS
+  if (MSVC)
+    set(WINDOWS_LIBS
     Comdlg32
     DXGI
     D3D11)
-    if (MSVC)
-      list(APPEND WINDOWS_LIBS WindowsApp) # Required for ISAC spatial audio code
-    endif()
+
+    list(APPEND WINDOWS_LIBS WindowsApp) # Required for ISAC spatial audio code
+  endif()
 endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -624,7 +624,7 @@ add_custom_command(TARGET StereoKitC POST_BUILD
   COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/StereoKitC/stereokit.h" "${CMAKE_CURRENT_SOURCE_DIR}/StereoKitC/stereokit_ui.h" "${CMAKE_CURRENT_SOURCE_DIR}/${SK_DISTRIBUTE_FOLDER}/include/" )
 add_custom_command(TARGET StereoKitC POST_BUILD
   COMMAND ${CMAKE_COMMAND} -E copy_directory "${sk_gpu_SOURCE_DIR}/tools" "${CMAKE_CURRENT_SOURCE_DIR}/tools/skshaderc" )
-if (SK_SEPARATE_DBG)
+if (SK_SEPARATE_DBG AND EXISTS "$<TARGET_FILE_DIR:StereoKitC>/$<TARGET_FILE_BASE_NAME:StereoKitC>${SK_BIN_DEBUG_EXT}")
   add_custom_command(TARGET StereoKitC POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE_DIR:StereoKitC>/$<TARGET_FILE_BASE_NAME:StereoKitC>${SK_BIN_DEBUG_EXT}" "${CMAKE_CURRENT_SOURCE_DIR}/${SK_DISTRIBUTE_FOLDER}/bin/${SK_BIN_OS}/${SK_ARCH}/$<CONFIG>/${SK_LIB_PREFIX}$<TARGET_FILE_BASE_NAME:StereoKitC>${SK_BIN_DEBUG_EXT}" )
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -544,9 +544,15 @@ target_link_libraries( StereoKitC
 
 # Compiler options for all the targets, now that they're all present
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
-  set(SK_RELEASE_COMPILE -g -O3 -fdata-sections -ffunction-sections -flto)
-  set(SK_RELEASE_LINK    -Wl,--gc-sections -Wl,--build-id -flto)
-  set(SK_WARNING_FLAG    -w)
+  if (__MINGW32__)
+    set(SK_RELEASE_COMPILE -g -O3 -fdata-sections -ffunction-sections )
+    set(SK_RELEASE_LINK    -Wl,--gc-sections -Wl,--build-id )
+    set(SK_WARNING_FLAG    -w)
+  else()
+    set(SK_RELEASE_COMPILE -g -O3 -fdata-sections -ffunction-sections -flto)
+    set(SK_RELEASE_LINK    -Wl,--gc-sections -Wl,--build-id -flto)
+    set(SK_WARNING_FLAG    -w)
+  endif()
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
   # /OPT settings need to be specified explicitly because we're also generating
   # /DEBUG pdbs, which disables them by default.

--- a/StereoKitC/lib/include_no_win/sal.h
+++ b/StereoKitC/lib/include_no_win/sal.h
@@ -142,12 +142,6 @@
    specifying a _Success_ annotation locally.
 
 ============================================================================*/
-
-#ifdef __MINGW32__ 
-    #undef _GLIBCXX_USE_STD_SPEC_FUNCS 
-    #define PAL_STDCPP_COMPAT "we don't want an empty __null"
-#endif
-
 #define __ATTR_SAL
 
 #ifndef _SAL_VERSION /*IFSTRIP=IGN*/

--- a/StereoKitC/lib/include_no_win/sal.h
+++ b/StereoKitC/lib/include_no_win/sal.h
@@ -143,6 +143,11 @@
 
 ============================================================================*/
 
+#ifdef __MINGW32__ 
+    #undef _GLIBCXX_USE_STD_SPEC_FUNCS 
+    #define PAL_STDCPP_COMPAT "we don't want an empty __null"
+#endif
+
 #define __ATTR_SAL
 
 #ifndef _SAL_VERSION /*IFSTRIP=IGN*/

--- a/StereoKitC/lib/include_no_win/sal.h
+++ b/StereoKitC/lib/include_no_win/sal.h
@@ -142,6 +142,7 @@
    specifying a _Success_ annotation locally.
 
 ============================================================================*/
+
 #define __ATTR_SAL
 
 #ifndef _SAL_VERSION /*IFSTRIP=IGN*/

--- a/StereoKitC/stereokit.h
+++ b/StereoKitC/stereokit.h
@@ -397,7 +397,7 @@ typedef enum standby_mode_ {
 	  without flooding the CPU with polling work while vsync is no longer the
 	  throttle. This will not disable sound.*/
 	standby_mode_none = 3
-};
+} standby_mode_;
 
 typedef struct sk_settings_t {
 	const char    *app_name;

--- a/StereoKitC/ui/ui_layout.cpp
+++ b/StereoKitC/ui/ui_layout.cpp
@@ -367,15 +367,15 @@ void ui_layout_pop() {
 	float max_x = fmaxf(layout->child_max.x, layout->offset_initial.x) + layout->margin;
 	float min_y = fminf(layout->child_min.y, layout->furthest.y      ) - layout->margin;
 	float max_y = fmaxf(layout->child_max.y, layout->offset_initial.y) + layout->margin;
-	if (layout->parent != -1) {
+	if (layout->parent != -1 && skui_layouts.count > 0) {
 		ui_layout_t* parent = &skui_layouts[layout->parent];
 		if (min_x < parent->child_min.x) parent->child_min.x = min_x;
 		if (max_x > parent->child_max.x) parent->child_max.x = max_x;
 		if (max_y > parent->child_max.y) parent->child_max.y = max_y;
 		if (min_y < parent->child_min.y) parent->child_min.y = min_y;
 	}
-
-	if (layout->window != -1) {
+	
+	if (layout->window > -1  && skui_windows.count > 0) {
 		ui_window_t* win        = &skui_windows[layout->window];
 		vec2         final_size = {
 			layout->size.x == 0 ? layout->offset_initial.x - layout->furthest.x : layout->size.x,


### PR DESCRIPTION
CMakeLists.txt:
Line 144: The problem here is linux case sensitivity. Mingw uses  libcomdlg33.a, libdxgi.a (see our build.rs) ... And it's now possible to create more precise WINDOW_LIBS for opengl.

Line 210: Setting PAL_STDCPP_COMPAT  because we don't want __null to be define with nothing in sal.h

line 549: lto is a problem for release version https://github.com/rust-lang/rust/issues/132226#issuecomment-2451493001
