### PR TITLE
Fix issue with constrained text with too small a size.

### DIFF
--- a/Examples/StereoKitTest/Tests/TestTextConstraint.cs
+++ b/Examples/StereoKitTest/Tests/TestTextConstraint.cs
@@ -1,0 +1,25 @@
+﻿using StereoKit;
+using System;
+
+class TestTextConstraint : ITest
+{
+	public void Step()
+	{
+		Show("one\ntwo\nthree\nfour", new Vec2(0.1f, 0), 0.006f);
+		Show("one\n\ntwo\nthree",     new Vec2(0.2f, 0), 0.03f);
+		Show("Vvardenfell",           new Vec2(0,    0), 0.01f);
+
+		Tests.Screenshot("Tests\\TextConstraint.jpg", 200, 400, 30, new Vec3(0.1f,-0.25f,-1.2f), new Vec3(0.1f,-0.25f,0));
+	}
+
+	static void Show(string text, Vec2 at, float width)
+	{
+		Vec2 size = Text.SizeLayout(text, TextStyle.Default, width);
+		Text.Add(text, Matrix.T(at.x, at.y, 0), new Vec2(width, 0), TextFit.Wrap | TextFit.Clip, TextAlign.TopLeft, TextAlign.TopLeft);
+		Lines.Add(new Vec3(at.XY0), new Vec3(at.x, at.y - size.y,0), Color.Black, 0.001f);
+		Lines.Add(new Vec3(at.x-size.x, at.y, 0), new Vec3((at-size).XY0), Color.Black, 0.001f);
+	}
+
+	public void Initialize() { }
+	public void Shutdown() { }
+}

--- a/StereoKitC/systems/text.cpp
+++ b/StereoKitC/systems/text.cpp
@@ -281,18 +281,18 @@ float text_step_line_length(const C *start, int32_t *out_char_count, const C **o
 	const C *last_at    = start;
 	const C *ch         = start;
 	char32_t curr       = 0;
-	bool     was_break  = false;
+	bool     prev_break = false;
 	int32_t  count      = 0;
 
 	while (true) {
 		const C *next_char = start;
 		char_decode_b_T(ch, &next_char, &curr);
-		bool is_break = text_is_breakable(curr);
+		bool curr_break = text_is_breakable(curr);
 
-		// We prefer to line break at spaces and other breakable characters, 
+		// We prefer to line break at spaces and other breakable characters,
 		// rather than in the middle of words
-		if (is_break || curr == '\0') {
-			if (!was_break)
+		if (curr_break || curr == '\0') {
+			if (!prev_break)
 				last_width = curr_width;
 			last_at    = curr != '\0' ? next_char : ch;
 			last_count = curr != '\0' ? count + 1 : count;
@@ -306,12 +306,21 @@ float text_step_line_length(const C *start, int32_t *out_char_count, const C **o
 		float              next_width = char_info->xadvance*style->scale + curr_width;
 
 		// Check if it steps out of bounds
-		if (!is_break && next_width > max_width) {
-			// If there were no breaks in this line, set to the previous character
+		if (!curr_break && next_width > max_width) {
+			// If there were no breaks in this line, set to the previous
+			// character.
 			if (last_width == 0) {
-				last_width = curr_width;
-				last_at    = ch;
-				last_count = count;
+				// If there is no previous character, then use the current one
+				// to prevent infinite loops.
+				if (curr_width == 0) {
+					last_width = next_width;
+					last_at    = next_char;
+					last_count = count + 1;
+				} else {
+					last_width = curr_width;
+					last_at    = ch;
+					last_count = count;
+				}
 			}
 			// Exit the line
 			break;
@@ -319,7 +328,7 @@ float text_step_line_length(const C *start, int32_t *out_char_count, const C **o
 
 		// Next character!
 		curr_width = next_width;
-		was_break  = is_break;
+		prev_break = curr_break;
 		ch         = next_char;
 		count     += 1;
 	}


### PR DESCRIPTION
If the width was too small, line length calculation would bug out, causing either an infinite loop or a miscount of characters that wouldn't allocate enough memory for glyph meshes.