### PR TITLE
Improve edges of the UI Box with Transparency.MSAA

### DIFF
--- a/StereoKitC/systems/defaults.cpp
+++ b/StereoKitC/systems/defaults.cpp
@@ -290,12 +290,9 @@ bool defaults_init() {
 	material_set_id(sk_default_material_ui_quadrant, default_id_material_ui_quadrant);
 	material_set_id(sk_default_material_ui_aura,     default_id_material_ui_aura);
 
-	material_set_texture(sk_default_material_font, "diffuse", sk_default_tex);
-	material_set_cull(sk_default_material_ui_box, cull_none);
-
-	// These can be paired with changes in the shader for antialiased edges.
-	// material_set_transparency(sk_default_material_ui_box, transparency_blend);
-	// material_set_depth_write(sk_default_material_ui_box, false);
+	material_set_texture     (sk_default_material_font, "diffuse", sk_default_tex);
+	material_set_cull        (sk_default_material_ui_box, cull_none);
+	material_set_transparency(sk_default_material_ui_box, transparency_msaa);
 
 	// Text!
 	sk_default_font = platform_default_font();


### PR DESCRIPTION
This removes jaggies from the UI box's harsh `discard`. It takes advantage of the recent Transparency.MSAA mode to do transparent AA without zbuffer artifacts.

This also uses the more recent "touch" visual effect, though slightly modified to work a bit better with alpha to coverage transparency. This looks a bit different on Android vs PC due to platform specific alpha to coverage dithering implementation differences. This may be a tweakable default that can be modified later!

![image](https://github.com/user-attachments/assets/ca73fa64-dd54-4ef7-ba52-f702d23bf7fd)