### PR TITLE
Update `RenderList` to be an `IAsset`

### DIFF
--- a/Examples/StereoKitTest/Demos/DemoAssets.cs
+++ b/Examples/StereoKitTest/Demos/DemoAssets.cs
@@ -151,7 +151,7 @@ class DemoAssets : ITest
 		/// Assets! Here's a quick example of iterating through all assets and
 		/// dumping a quick summary to the log.
 		foreach (var asset in Assets.All)
-			Log.Info($"{asset.GetType().Name} - {asset.Id}");
+			Log.Info($"{asset.GetType().Name,-10} - {asset.Id}");
 		/// :End:
 
 		Tests.RunForFrames(2);

--- a/StereoKit/Assets/Anchor.cs
+++ b/StereoKit/Assets/Anchor.cs
@@ -26,7 +26,7 @@ namespace StereoKit {
 		internal IntPtr _inst;
 
 		/// <summary>Gets or sets the unique identifier of this asset resource!
-		/// This can be helpful for debugging, managine your assets, or finding
+		/// This can be helpful for debugging, managing your assets, or finding
 		/// them later on! This is StereoKit's asset ID, and not the system's
 		/// unique Name for the anchor.</summary>
 		public string Id

--- a/StereoKit/Assets/Font.cs
+++ b/StereoKit/Assets/Font.cs
@@ -13,7 +13,7 @@ namespace StereoKit {
 		internal IntPtr _inst;
 
 		/// <summary>Gets or sets the unique identifier of this asset resource!
-		/// This can be helpful for debugging, managine your assets, or finding
+		/// This can be helpful for debugging, managing your assets, or finding
 		/// them later on!</summary>
 		public string Id
 		{

--- a/StereoKit/Assets/IAsset.cs
+++ b/StereoKit/Assets/IAsset.cs
@@ -6,7 +6,7 @@
 	public interface IAsset
 	{
 		/// <summary>Gets or sets the unique identifier of this asset resource!
-		/// This can be helpful for debugging, managine your assets, or finding
+		/// This can be helpful for debugging, managing your assets, or finding
 		/// them later on!</summary>
 		string Id { get; set; }
 	}

--- a/StereoKit/Assets/Material.cs
+++ b/StereoKit/Assets/Material.cs
@@ -196,7 +196,7 @@ namespace StereoKit
 			get => new Shader(NativeAPI.material_get_shader(_inst));
 			set => NativeAPI.material_set_shader(_inst, value?._inst ?? IntPtr.Zero); }
 		/// <summary>Gets or sets the unique identifier of this asset resource!
-		/// This can be helpful for debugging, managine your assets, or finding
+		/// This can be helpful for debugging, managing your assets, or finding
 		/// them later on!</summary>
 		public string Id { 
 			get => Marshal.PtrToStringAnsi(NativeAPI.material_get_id(_inst));

--- a/StereoKit/Assets/Mesh.cs
+++ b/StereoKit/Assets/Mesh.cs
@@ -23,7 +23,7 @@ namespace StereoKit
 		internal IntPtr _inst;
 
 		/// <summary>Gets or sets the unique identifier of this asset resource!
-		/// This can be helpful for debugging, managine your assets, or finding
+		/// This can be helpful for debugging, managing your assets, or finding
 		/// them later on!</summary>
 		public string Id
 		{

--- a/StereoKit/Assets/Mesh.cs
+++ b/StereoKit/Assets/Mesh.cs
@@ -466,7 +466,7 @@ namespace StereoKit
 			=> new Mesh(NativeAPI.mesh_gen_cylinder(diameter, depth, direction, subdivisions));
 
 		/// <summary>Finds the Mesh with the matching id, and returns a 
-		/// reference to it. If no Mesh it found, it returns null.</summary>
+		/// reference to it. If no Mesh is found, it returns null.</summary>
 		/// <param name="meshId">Id of the Mesh we're looking for.</param>
 		/// <returns>A Mesh with a matching id, or null if none is found.
 		/// </returns>

--- a/StereoKit/Assets/Model.cs
+++ b/StereoKit/Assets/Model.cs
@@ -29,7 +29,7 @@ namespace StereoKit
 		private ModelAnimCollection   _animCollection;
 
 		/// <summary>Gets or sets the unique identifier of this asset resource!
-		/// This can be helpful for debugging, managine your assets, or finding
+		/// This can be helpful for debugging, managing your assets, or finding
 		/// them later on!</summary>
 		public string Id
 		{

--- a/StereoKit/Assets/RenderList.cs
+++ b/StereoKit/Assets/RenderList.cs
@@ -16,7 +16,7 @@ namespace StereoKit
 		internal IntPtr _inst;
 
 		/// <summary>Gets or sets the unique identifier of this asset resource!
-		/// This can be helpful for debugging, managine your assets, or finding
+		/// This can be helpful for debugging, managing your assets, or finding
 		/// them later on!</summary>
 		public string Id
 		{

--- a/StereoKit/Assets/RenderList.cs
+++ b/StereoKit/Assets/RenderList.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.InteropServices;
 
 namespace StereoKit
 {
@@ -10,9 +11,18 @@ namespace StereoKit
 	/// Manually working with a RenderList can be useful for "baking down
 	/// matrices" or caching a scene of objects. Or for drawing a separate
 	/// scene to an offscreen surface, like for thumbnails of Models.</summary>
-	public class RenderList
+	public class RenderList : IAsset
 	{
 		internal IntPtr _inst;
+
+		/// <summary>Gets or sets the unique identifier of this asset resource!
+		/// This can be helpful for debugging, managine your assets, or finding
+		/// them later on!</summary>
+		public string Id
+		{
+			get => Marshal.PtrToStringAnsi(NativeAPI.render_list_get_id(_inst));
+			set => NativeAPI.render_list_set_id(_inst, value);
+		}
 
 		/// <summary>The number of Mesh/Material pairs that have been submitted
 		/// to the render list so far this frame.</summary>
@@ -28,9 +38,9 @@ namespace StereoKit
 		{
 			_inst = NativeAPI.render_list_create();
 		}
-		internal RenderList(IntPtr material)
+		internal RenderList(IntPtr list)
 		{
-			_inst = material;
+			_inst = list;
 			if (_inst == IntPtr.Zero)
 				Log.Err("Received an empty RenderList!");
 		}
@@ -132,5 +142,18 @@ namespace StereoKit
 		/// <summary>This removes the current top of the RenderList stack,
 		/// making the next list as active</summary>
 		public static void Pop() => NativeAPI.render_list_pop();
+
+		/// <summary>Finds the RenderList with the matching id, and returns a
+		/// reference to it. If no RenderList is found, it returns null.
+		/// </summary>
+		/// <param name="listId">Id of the RenderList we're looking for.
+		/// </param>
+		/// <returns>A RenderList with a matching id, or null if none is found.
+		/// </returns>
+		public static RenderList Find(string listId)
+		{
+			IntPtr list = NativeAPI.render_list_find(listId);
+			return list == IntPtr.Zero ? null : new RenderList(list);
+		}
 	}
 }

--- a/StereoKit/Assets/Shader.cs
+++ b/StereoKit/Assets/Shader.cs
@@ -17,7 +17,7 @@ namespace StereoKit
 		internal IntPtr _inst;
 
 		/// <summary>Gets or sets the unique identifier of this asset resource!
-		/// This can be helpful for debugging, managine your assets, or finding
+		/// This can be helpful for debugging, managing your assets, or finding
 		/// them later on!</summary>
 		public string Id
 		{

--- a/StereoKit/Assets/Sound.cs
+++ b/StereoKit/Assets/Sound.cs
@@ -21,7 +21,7 @@ namespace StereoKit
 		internal IntPtr _inst;
 
 		/// <summary>Gets or sets the unique identifier of this asset resource!
-		/// This can be helpful for debugging, managine your assets, or finding
+		/// This can be helpful for debugging, managing your assets, or finding
 		/// them later on!</summary>
 		public string Id
 		{

--- a/StereoKit/Assets/Sprite.cs
+++ b/StereoKit/Assets/Sprite.cs
@@ -28,7 +28,7 @@ namespace StereoKit
 		internal IntPtr _inst;
 
 		/// <summary>Gets or sets the unique identifier of this asset resource!
-		/// This can be helpful for debugging, managine your assets, or finding
+		/// This can be helpful for debugging, managing your assets, or finding
 		/// them later on!</summary>
 		public string Id
 		{

--- a/StereoKit/Assets/Sprite.cs
+++ b/StereoKit/Assets/Sprite.cs
@@ -87,8 +87,8 @@ namespace StereoKit
 
 		/// <summary>Finds a sprite that matches the given id! Check out the
 		/// DefaultIds static class for some built-in ids. Sprites will auto-id
-		/// themselves using this pattern if single sprites: {Tex.Id}/spr, and
-		/// this pattern if atlased sprites: atlas_spr/{atlas}/{Tex.Id}.
+		/// themselves using this pattern if single sprites: {Tex.Id}/sprite,
+		/// and this pattern if atlased sprites: {Tex.Id}/sprite/atlas/{atlasId}.
 		/// </summary>
 		/// <param name="id">Id of the sprite asset.</param>
 		/// <returns>A Sprite asset with the given id, or null if none is

--- a/StereoKit/Assets/Tex.cs
+++ b/StereoKit/Assets/Tex.cs
@@ -18,7 +18,7 @@ namespace StereoKit
 		private  List<Assets.CallbackData> _callbacks;
 
 		/// <summary>Gets or sets the unique identifier of this asset resource!
-		/// This can be helpful for debugging, managine your assets, or finding
+		/// This can be helpful for debugging, managing your assets, or finding
 		/// them later on!</summary>
 		public string Id
 		{

--- a/StereoKit/Native/NativeAPI.cs
+++ b/StereoKit/Native/NativeAPI.cs
@@ -469,7 +469,10 @@ namespace StereoKit
 
 		///////////////////////////////////////////
 
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr             render_list_find         (string id);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr             render_list_create       ();
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void               render_list_set_id       (IntPtr list, string id);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr             render_list_get_id       (IntPtr list);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void               render_list_addref       (IntPtr list);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void               render_list_release      (IntPtr list);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void               render_list_clear        (IntPtr list);

--- a/StereoKit/Systems/Assets.cs
+++ b/StereoKit/Systems/Assets.cs
@@ -49,15 +49,17 @@ namespace StereoKit
 		{
 			switch (t)
 			{
-				case Type _ when t == typeof(Font    ): return AssetType.Font;
-				case Type _ when t == typeof(Material): return AssetType.Material;
-				case Type _ when t == typeof(Mesh    ): return AssetType.Mesh;
-				case Type _ when t == typeof(Model   ): return AssetType.Model;
-				case Type _ when t == typeof(Shader  ): return AssetType.Shader;
-				case Type _ when t == typeof(Sound   ): return AssetType.Sound;
-				case Type _ when t == typeof(Sprite  ): return AssetType.Sprite;
-				case Type _ when t == typeof(Tex     ): return AssetType.Tex;
-				case Type _ when t == typeof(IAsset  ): return AssetType.None;
+				case Type _ when t == typeof(Font      ): return AssetType.Font;
+				case Type _ when t == typeof(Material  ): return AssetType.Material;
+				case Type _ when t == typeof(Mesh      ): return AssetType.Mesh;
+				case Type _ when t == typeof(Model     ): return AssetType.Model;
+				case Type _ when t == typeof(Shader    ): return AssetType.Shader;
+				case Type _ when t == typeof(Sound     ): return AssetType.Sound;
+				case Type _ when t == typeof(Sprite    ): return AssetType.Sprite;
+				case Type _ when t == typeof(Tex       ): return AssetType.Tex;
+				case Type _ when t == typeof(Anchor    ): return AssetType.Anchor;
+				case Type _ when t == typeof(RenderList): return AssetType.RenderList;
+				case Type _ when t == typeof(IAsset    ): return AssetType.None;
 				default: throw new ArgumentException("Not a valid asset type!");
 			}
 		}
@@ -66,14 +68,16 @@ namespace StereoKit
 		{
 			switch ( currType )
 			{
-				case AssetType.Font:     return new Font    (inst);
-				case AssetType.Material: return new Material(inst);
-				case AssetType.Mesh:     return new Mesh    (inst);
-				case AssetType.Model:    return new Model   (inst);
-				case AssetType.Shader:   return new Shader  (inst);
-				case AssetType.Sound:    return new Sound   (inst);
-				case AssetType.Sprite:   return new Sprite  (inst);
-				case AssetType.Tex:      return new Tex     (inst);
+				case AssetType.Font:      return new Font      (inst);
+				case AssetType.Material:  return new Material  (inst);
+				case AssetType.Mesh:      return new Mesh      (inst);
+				case AssetType.Model:     return new Model     (inst);
+				case AssetType.Shader:    return new Shader    (inst);
+				case AssetType.Sound:     return new Sound     (inst);
+				case AssetType.Sprite:    return new Sprite    (inst);
+				case AssetType.Tex:       return new Tex       (inst);
+				case AssetType.Anchor:    return new Anchor    (inst);
+				case AssetType.RenderList:return new RenderList(inst);
 				default: Log.Err("Found an invalid asset type!"); return null;
 			}
 		}

--- a/StereoKitC/asset_types/assets.cpp
+++ b/StereoKitC/asset_types/assets.cpp
@@ -151,8 +151,9 @@ void *assets_allocate(asset_type_ type) {
 
 void assets_set_id(asset_header_t *header, const char *id) {
 	assets_set_id(header, hash_fnv64_string(id));
-	sk_free(header->id_text);
+	char* old_text = header->id_text;
 	header->id_text = string_copy(id);
+	sk_free(old_text);
 }
 
 ///////////////////////////////////////////

--- a/StereoKitC/stereokit.h
+++ b/StereoKitC/stereokit.h
@@ -1623,11 +1623,15 @@ SK_API void                  render_screenshot_viewpoint(void (*render_on_screen
 SK_API void                  render_to             (tex_t to_rendertarget, const sk_ref(matrix) camera, const sk_ref(matrix) projection, render_layer_ layer_filter sk_default(render_layer_all), render_clear_ clear sk_default(render_clear_all), rect_t viewport sk_default({}));
 SK_API void                  render_material_to    (tex_t to_rendertarget, material_t override_material, const sk_ref(matrix) camera, const sk_ref(matrix) projection, render_layer_ layer_filter sk_default(render_layer_all), render_clear_ clear sk_default(render_clear_all), rect_t viewport sk_default({}));
 SK_API void                  render_get_device     (void **device, void **context);
-SK_API render_list_t         render_get_primary_list();
+SK_API render_list_t         render_get_primary_list(void);
 
 ///////////////////////////////////////////
 
-SK_API render_list_t         render_list_create       ();
+
+SK_API render_list_t         render_list_find         (const char* id);
+SK_API render_list_t         render_list_create       (void);
+SK_API void                  render_list_set_id       (      render_list_t list, const char* id);
+SK_API const char*           render_list_get_id       (const render_list_t list);
 SK_API void                  render_list_addref       (      render_list_t list);
 SK_API void                  render_list_release      (      render_list_t list);
 SK_API void                  render_list_clear        (      render_list_t list);
@@ -1639,7 +1643,7 @@ SK_API void                  render_list_add_model_mat(      render_list_t list,
 SK_API void                  render_list_draw_now     (      render_list_t list, tex_t to_rendertarget, matrix camera, matrix projection, rect_t viewport_px sk_default({}), render_layer_ layer_filter sk_default(render_layer_all), render_clear_ clear sk_default(render_clear_all));
 
 SK_API void                  render_list_push         (      render_list_t list);
-SK_API void                  render_list_pop          ();
+SK_API void                  render_list_pop          (void);
 
 ///////////////////////////////////////////
 

--- a/StereoKitC/systems/render.cpp
+++ b/StereoKitC/systems/render.cpp
@@ -246,7 +246,8 @@ bool render_init() {
 	tex_release(sky_cubemap);
 	
 	local.list_primary = render_list_create();
-	render_list_push(local.list_primary);
+	render_list_set_id(local.list_primary, "sk/render/primary_renderlist");
+	render_list_push  (local.list_primary);
 
 	radix_sort_init();
 	hierarchy_init();
@@ -1201,9 +1202,32 @@ void render_get_device(void **device, void **context) {
 // Render List                           //
 ///////////////////////////////////////////
 
+render_list_t render_list_find(const char* id) {
+	render_list_t result = (render_list_t)assets_find(id, asset_type_render_list);
+	if (result != nullptr) {
+		render_list_addref(result);
+		return result;
+	}
+	return nullptr;
+}
+
+///////////////////////////////////////////
+
 render_list_t render_list_create() {
 	render_list_t result = (render_list_t)assets_allocate(asset_type_render_list);
 	return result;
+}
+
+///////////////////////////////////////////
+
+void render_list_set_id(render_list_t list, const char* id) {
+	assets_set_id(&list->header, id);
+}
+
+///////////////////////////////////////////
+
+const char* render_list_get_id(const render_list_t list) {
+	return list->header.id_text;
 }
 
 ///////////////////////////////////////////


### PR DESCRIPTION
`RenderList` was missing `id` related functions for `get` `set` and `find`, so these were added as well.
Updated commentdocs for some spelling issues and drift.