### PR TITLE
fix: force the prior ARM32 version for UWP CMake builds

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -58,7 +58,7 @@
       "description":  "Debug build for UWP ARM32",
       "inherits":     "Uwp_Debug",
       "hidden":       false,
-      "architecture": "ARM",
+      "architecture": "ARM,version=10.0.22621.0",
       "binaryDir":    "${sourceDir}/bin/intermediate/UWP_ARM"
     },    
     {
@@ -123,7 +123,7 @@
       "description":  "Release build for UWP ARM32",
       "inherits":     "Uwp_Release",
       "hidden":       false,
-      "architecture": "ARM",
+      "architecture": "ARM,version=10.0.22621.0",
       "binaryDir":    "${sourceDir}/bin/intermediate/UWP_ARM"
     },
     {


### PR DESCRIPTION
Looks like CMake defaults to the newest SDK version, but the latest Windows Kit doesn't include ARM anymore ☠️

(edit: sorry I forgot DCO! Will remediate that later, or you can close this PR)