### PR TITLE
Added `Input.FingerGlow`

### DIFF
--- a/StereoKit/Native/NativeAPI.cs
+++ b/StereoKit/Native/NativeAPI.cs
@@ -598,6 +598,9 @@ namespace StereoKit
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void     input_text_inject_char(uint character);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void     input_hand_visible (Handed hand, [MarshalAs(UnmanagedType.Bool)] bool visible);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void     input_hand_material(Handed hand, IntPtr material);
+		[return: MarshalAs(UnmanagedType.Bool)]
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern bool     input_get_finger_glow();
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void     input_set_finger_glow([MarshalAs(UnmanagedType.Bool)] bool visible);
 
 		///////////////////////////////////////////
 

--- a/StereoKit/Systems/Input.cs
+++ b/StereoKit/Systems/Input.cs
@@ -375,6 +375,17 @@ namespace StereoKit
 		/// </summary>
 		public static Mouse Mouse => Marshal.PtrToStructure<Mouse>(NativeAPI.input_mouse());
 
+		/// <summary>This controls the visibility of StereoKit's finger glow
+		/// effect on the UI. When true, SK will fill out global shader
+		/// variable `sk_fingertip[2]` with the location of the pointer
+		/// finger's tips. When false, or the hand is untracked, the location
+		/// will be set to an unlikely faraway position.</summary>
+		public static bool FingerGlow
+		{
+			set => NativeAPI.input_set_finger_glow(value);
+			get => NativeAPI.input_get_finger_glow();
+		}
+
 		/// <summary>Gets raw controller input data from the system. Note that
 		/// not all buttons provided here are guaranteed to be present on the
 		/// user's physical controller. Controllers are also not guaranteed to

--- a/StereoKitC/hands/input_hand.cpp
+++ b/StereoKitC/hands/input_hand.cpp
@@ -119,6 +119,7 @@ float               hand_size_update = 0;
 int32_t             input_hand_pointer_id[handed_max] = {-1, -1};
 array_t<hand_sim_t> hand_sim_poses   = {};
 hand_sim_id_t       hand_sim_next_id = 1;
+bool32_t            hand_finger_glow_visible = true;
 
 void input_gen_fallback_mesh(const hand_joint_t fingers[][5], mesh_t mesh, vert_t** ref_verts, vind_t** ref_inds);
 
@@ -169,6 +170,7 @@ void input_hand_refresh_system() {
 void input_hand_init() {
 	input_hand_pointer_id[handed_left ] = input_add_pointer(input_source_hand | input_source_hand_left  | input_source_can_press);
 	input_hand_pointer_id[handed_right] = input_add_pointer(input_source_hand | input_source_hand_right | input_source_can_press);
+	hand_finger_glow_visible = true;
 
 	float blend = 1;
 	for (int32_t i = 0; i < _countof(hand_sources); i++) {
@@ -688,6 +690,18 @@ void input_hand_visible(handed_ hand, bool32_t visible) {
 	}
 
 	hand_state[hand].visible = visible;
+}
+
+///////////////////////////////////////////
+
+bool32_t input_get_finger_glow(void) {
+	return hand_finger_glow_visible;
+}
+
+///////////////////////////////////////////
+
+void input_set_finger_glow(bool32_t visible) {
+	hand_finger_glow_visible = visible;
 }
 
 } // namespace sk

--- a/StereoKitC/stereokit.h
+++ b/StereoKitC/stereokit.h
@@ -2184,6 +2184,8 @@ SK_API void                  input_text_reset        (void);
 SK_API void                  input_text_inject_char  (char32_t character);
 SK_API void                  input_hand_visible      (handed_ hand, bool32_t visible);
 SK_API void                  input_hand_material     (handed_ hand, material_t material);
+SK_API bool32_t              input_get_finger_glow   (void);
+SK_API void                  input_set_finger_glow   (bool32_t visible);
 
 SK_API hand_sim_id_t         input_hand_sim_pose_add   (const pose_t* in_arr_palm_relative_hand_joints_25, controller_key_ button1, controller_key_ and_button2 sk_default(controller_key_none), key_ or_hotkey1 sk_default(key_none), key_ and_hotkey2 sk_default(key_none));
 SK_API void                  input_hand_sim_pose_remove(hand_sim_id_t id);

--- a/StereoKitC/systems/render.cpp
+++ b/StereoKitC/systems/render.cpp
@@ -791,7 +791,7 @@ void render_draw_queue(render_list_t list, const matrix *views, const matrix *pr
 	local.global_buffer.eye_offset = eye_offset;
 	for (int32_t i = 0; i < handed_max; i++) {
 		const hand_t* hand = input_hand((handed_)i);
-		vec3 tip = (hand->tracked_state & button_state_active) != 0 && input_hand_get_visible((handed_)i) 
+		vec3 tip = (hand->tracked_state & button_state_active) != 0 && input_get_finger_glow()
 			? hand->fingers[1][4].position
 			: vec3{ 0,-1000,0 };
 		local.global_buffer.fingertip[i] = { tip.x, tip.y, tip.z, 0 };


### PR DESCRIPTION
Attached finger glow to an independent switch, `Input.FingerGlow`, rather than the hand's visibility. This should resolve #1137

More work may be needed in v0.4 scenarios with controllers, but that system still needs a proper interface!