### PR TITLE
Skip cmake test project build

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -15,7 +15,9 @@
         "CMAKE_SYSTEM_NAME":    "WindowsStore",
         "CMAKE_SYSTEM_VERSION": "10.0.22621.0",
         "DYNAMIC_LOADER":       "ON",
-        "CMAKE_CXX_FLAGS":      "/MP"
+        "CMAKE_CXX_FLAGS":      "/MP",
+        "CMAKE_C_COMPILER_WORKS": true,
+        "CMAKE_CXX_COMPILER_WORKS": true
       },
       "condition": {
           "type": "equals",


### PR DESCRIPTION
This is an alternative fix for the ARM UWP build not working with latest Windows SDK. Previous solution (#1136) wasn't working with GitHub Actions.