### PR TITLE
More docs and fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,6 +151,10 @@ elseif(WIN32)
   endif()
 endif()
 
+if (__MINGW32__)
+  add_compile_definitions(PAL_STDCPP_COMPAT="needed for mingw")
+endif()
+
 if(CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
   add_definitions("-DWINDOWS_UWP")
 endif()
@@ -207,12 +211,11 @@ add_compile_definitions(BASISD_SUPPORT_ATC=0)
 add_compile_definitions(BASISD_SUPPORT_ETC2_EAC_A8=0)
 add_compile_definitions(BASISD_SUPPORT_BC7=0)
 add_compile_definitions(BASISD_SUPPORT_BC7_MODE5=0)
-if (__MINGW32__)
-  add_compile_definitions(PAL_STDCPP_COMPAT="needed for mingw")
-endif()
+
+#### sk_gpu - https://github.com/StereoKit/sk_gpu ####
 CPMAddPackage( # We're scraping the comment after the NAME for some other scripts
-  NAME sk_gpu # 2024.9.26
-  URL https://github.com/StereoKit/sk_gpu/releases/download/v2024.9.26/sk_gpu.v2024.9.26.zip
+  NAME sk_gpu # 2025.1.22
+  URL https://github.com/StereoKit/sk_gpu/releases/download/v2025.1.22/sk_gpu.v2025.1.22.zip
 )
 # For building directly with in-progress sk_gpu changes, point this to your
 # local sk_gpu clone, and use it instead of CPM.
@@ -462,7 +465,7 @@ else()
 endif()
 
 skshaderc_compile_headers(StereoKitC
-  ${CMAKE_BINARY_DIR}/shaders
+  ${CMAKE_BINARY_DIR}/shaders/
   "-O3 -f -z ${SK_SHADER_VERBOSITY} -t ${SK_SHADER_TARGETS} -i ${CMAKE_CURRENT_SOURCE_DIR}/tools/include"
   StereoKitC/shaders_builtin/shader_builtin_blit.hlsl
   StereoKitC/shaders_builtin/shader_builtin_default.hlsl
@@ -684,7 +687,7 @@ if (SK_BUILD_TESTS)
   )
 
   if (MSVC AND SK_MULTITHREAD_BUILD_BY_DEFAULT)
-    target_compile_options(StereoKitCTest PRIVATE "/MP")
+    target_compile_options(StereoKitCTest PRIVATE "/MP8")
   endif()
 
   skshaderc_compile_headers( StereoKitCTest
@@ -712,9 +715,9 @@ endif()
 # default, this is mostly for when using Visual Studio as
 # the IDE. CLI users can pass in command line arguments.
 if (MSVC AND SK_MULTITHREAD_BUILD_BY_DEFAULT)
-  add_compile_options($<$<CXX_COMPILER_ID:MSVC>:/MP>)
-  target_compile_options(openxr_loader PRIVATE "/MP")
-  target_compile_options(StereoKitC PRIVATE "/MP")
+  add_compile_options($<$<CXX_COMPILER_ID:MSVC>:/MP8>)
+  target_compile_options(openxr_loader PRIVATE "/MP8")
+  target_compile_options(StereoKitC PRIVATE "/MP8")
 endif()
 
 ###########################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -691,7 +691,7 @@ if (SK_BUILD_TESTS)
   endif()
 
   skshaderc_compile_headers( StereoKitCTest
-    ${CMAKE_BINARY_DIR}/test_shaders
+    ${CMAKE_BINARY_DIR}/test_shaders/
     "-O3 -f ${SK_SHADER_VERBOSITY} -t ${SK_SHADER_TARGETS} -i ${CMAKE_CURRENT_SOURCE_DIR}/tools/include"
     Examples/StereoKitCTest/Shaders/blit.hlsl
     Examples/StereoKitCTest/Shaders/skt_default_lighting.hlsl

--- a/Examples/StereoKitTest/DebugToolWindow.cs
+++ b/Examples/StereoKitTest/DebugToolWindow.cs
@@ -102,7 +102,7 @@ class DebugToolWindow : IStepper
 	public bool Initialize()
 	{
 		itemDemos         = new HandMenuItem("Demos",        Sprite.ToggleOn,  () => Program.WindowDemoShow = !Program.WindowDemoShow);
-		itemConsole       = new HandMenuItem("Console",      Sprite.ToggleOn,  () => Program.WindowConsoleShow = !Program.WindowConsoleShow);
+		itemConsole       = new HandMenuItem("Console",      Sprite.ToggleOn,  () => Program.WindowLog.Enabled = !Program.WindowLog.Enabled);
 		itemToolsAvatar   = new HandMenuItem("Avatar",       Sprite.ToggleOff, () => ToggleAvatar() );
 		itemToolsSkeleton = new HandMenuItem("Skeleton",     Sprite.ToggleOff, () => skeleton = ToggleTool(skeleton) );
 		itemToolsTheme    = new HandMenuItem("Theme Editor", Sprite.ToggleOff, () => theme    = ToggleTool(theme) );
@@ -162,7 +162,7 @@ class DebugToolWindow : IStepper
 	public void Step()
 	{
 		itemDemos        .image = Program.WindowDemoShow    ? Sprite.ToggleOn : Sprite.ToggleOff;
-		itemConsole      .image = Program.WindowConsoleShow ? Sprite.ToggleOn : Sprite.ToggleOff;
+		itemConsole      .image = Program.WindowLog.Enabled ? Sprite.ToggleOn : Sprite.ToggleOff;
 		itemToolsAvatar  .image = avatar   != null ? Sprite.ToggleOn : Sprite.ToggleOff;
 		itemToolsSkeleton.image = skeleton != null ? Sprite.ToggleOn : Sprite.ToggleOff;
 		itemToolsTheme   .image = theme    != null ? Sprite.ToggleOn : Sprite.ToggleOff;

--- a/Examples/StereoKitTest/Demos/DemoPBR.cs
+++ b/Examples/StereoKitTest/Demos/DemoPBR.cs
@@ -49,14 +49,14 @@ class DemoPBR : ITest
 		// Iterate using a foreach
 		Log.Info("Builtin PBR Materials contain these parameters:");
 		foreach (MatParamInfo info in Material.PBR.GetAllParamInfo())
-			Log.Info($"- {info.name} : {info.type}");
+			Log.Info($"- {info.type,8}: {info.name}");
 
 		// Or with a normal for loop
 		Log.Info("Builtin Unlit Materials contain these parameters:");
 		for (int i=0; i<Material.Unlit.ParamCount; i+=1)
 		{
 			MatParamInfo info = Material.Unlit.GetParamInfo(i);
-			Log.Info($"- {info.name} : {info.type}");
+			Log.Info($"- {info.type,8}: {info.name}");
 		}
 		/// :End:
 	}

--- a/Examples/StereoKitTest/Docs/DocBackend.cs
+++ b/Examples/StereoKitTest/Docs/DocBackend.cs
@@ -1,24 +1,16 @@
-﻿using StereoKit;
+﻿// SPDX-License-Identifier: MIT
+// The authors below grant copyright rights under the MIT license:
+// Copyright (c) 2019-2025 Nick Klingensmith
+// Copyright (c) 2025 Qualcomm Technologies, Inc.
+
+using StereoKit;
 using StereoKit.Framework;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 class DocBackend : ITest
 {
-	public void Initialize()
-	{
-	}
-
-	public void Shutdown()
-	{
-	}
-
-	public void Step()
-	{
-	}
+	public void Initialize() { }
+	public void Shutdown  () { }
+	public void Step      () { }
 }
 
 /// :CodeSample: OpenXR.RequestExt OpenXR.ExtEnabled Backend.XRType OpenXR.GetFunction OpenXR.Instance OpenXR.Time IStepper
@@ -79,7 +71,8 @@ class Win32PerformanceCounterExt : IStepper
 		return xrConvertTimeToWin32PerformanceCounterKHR != null;
 	}
 
-	// A more complicated extension might use these, but 
+	// A more complicated extension might use these, but this EXT does not
+	// require any actions on-Step.
 	public void Shutdown() { }
 	public void Step() { }
 }

--- a/Examples/StereoKitTest/Docs/DocEasing.cs
+++ b/Examples/StereoKitTest/Docs/DocEasing.cs
@@ -1,0 +1,79 @@
+﻿// SPDX-License-Identifier: MIT
+// The authors below grant copyright rights under the MIT license:
+// Copyright (c) 2025 Nick Klingensmith
+// Copyright (c) 2025 Qualcomm Technologies, Inc.
+
+using StereoKit;
+using StereoKit.Framework;
+using System;
+
+class DocEasing : ITest
+{
+	/// :CodeSample: EasePose EaseVec3 EaseColor Ease EasePose.Resolve EaseVec3.Resolve EaseColor.Resolve EasePose.AnimTo EaseVec3.AnimTo EaseColor.AnimTo EasePose.IsFinished EaseVec3.IsFinished EaseColor.IsFinished
+	/// ### Easing a Cube
+	/// Here we're just animating a cube around, using some custom easing
+	/// functions as well as builtin ones! The color here is animated using a
+	/// conventional animation, just flipping through various hues, but the pose
+	/// and scale are using easing to go to a position _and_ come back!
+	///
+	/// ![Easing Cube]({{site.screen_url}}/EasingCube.jpg)
+
+	// Initial starting values for the pose, size, and color of a cube that
+	// we'll animate!
+	EasePose  pose  = new EasePose (V.XYZ(0,-0.1f,-0.5f), Quat.Identity);
+	EaseVec3  scale = new EaseVec3 (0.1f,0.1f,0.1f);
+	EaseColor color = new EaseColor(Color.White);
+
+	// Here's a custom easing function! This one goes from 0 to 1 and then back
+	// to 0 again! So it actually ends in the exact same place it started. We
+	// could achieve the same behavior with just sin(pi*t), but the rest of the
+	// math here softens the start and end of the animation.
+	// See a graph here: https://www.desmos.com/calculator/zz8cdvrvju
+	static float EaseReturn(float t) => (float)Math.Sin(2*Math.PI*t - 0.5*Math.PI) * 0.5f + 0.5f;
+
+	void StepEasedCube()
+	{
+		// If the Ease animation for the Pose is finished or never started to
+		// begin with, we can make it hop with our custom `EaseReturn`
+		// function!
+		if (pose.IsFinished)
+			pose.AnimTo(
+				new Pose(V.XYZ(0, 0.1f, -0.5f), Quat.FromAngles(0, 180, 0)),
+				0.5f,
+				EaseReturn);
+
+		if (scale.IsFinished)
+			scale.AnimTo(
+				V.XYZ(0.15f, 0.15f, 0.15f),
+				0.75f,
+				EaseReturn);
+
+		// For the color, we're picking a semi-random hue, and using one of the
+		// built-in easing functions to just ease all the way to our
+		// destination color!
+		if (color.IsFinished)
+			color.AnimTo(
+				Color.HSV((Time.Frame % 100) / 100.0f, 0.7f, 0.7f),
+				1,
+				Ease.FastIn);
+
+		// Convert `pose` and `scale` into a transform Matrix! Ease values have
+		// implicit conversions that will automatically `Resolve` the current
+		// value, so most of the time you can just pass them the same way you
+		// would a normal type. In this case to call `ToMatrix` we need to
+		// either explicitly cast, or call `Resolve`, and `Resolve` is the most
+		// obvious action.
+		Matrix transform = pose.Resolve().ToMatrix(scale);
+		Mesh.Cube.Draw(Material.Default, transform, color);
+	}
+	/// :End:
+
+	public void Step()
+	{
+		StepEasedCube();
+		Tests.Screenshot("EasingCube.jpg", 75, 600,600, 45, Vec3.Zero, new Vec3(0,0,-0.5f));
+	}
+	public void Initialize()
+		=> Tests.RunForSeconds(1);
+	public void Shutdown() { }
+}

--- a/Examples/StereoKitTest/Docs/DocHierarchy.cs
+++ b/Examples/StereoKitTest/Docs/DocHierarchy.cs
@@ -1,0 +1,108 @@
+﻿// SPDX-License-Identifier: MIT
+// The authors below grant copyright rights under the MIT license:
+// Copyright (c) 2025 Nick Klingensmith
+// Copyright (c) 2025 Qualcomm Technologies, Inc.
+
+using StereoKit;
+
+class DocHierarchy : ITest
+{
+	static void HierarchicalTransform()
+	{
+		/// :CodeSample: Hierarchy Hierarchy.Push Hierarchy.Pop
+		/// ### Transforming with Hierarchy
+		/// 
+		/// In StereoKit, draw calls all happen relative to the `Hierarchy`
+		/// stack! In this example, we make 2 draw calls with the same
+		/// transform matrix, but use the `Hierarchy` as a transform parent to
+		/// ensure the draws happen in different locations.
+		/// 
+		/// ![Two spheres, one red and one blue, both at different locations]({{site.screen_url}}/Docs/Hierarchy_Transform.jpg)
+		/// 
+		/// `Push`/`Pop` calls can also be nested to create more complex
+		/// hierarchies on a stack! Each `Push` call is also relative to the
+		/// parent `Push`ed transform.
+		///
+		Matrix transform = Matrix.S(0.2f);
+
+		Hierarchy.Push(Matrix.T(-0.2f, 0, -0.5f));
+		Mesh.Sphere.Draw(Material.Default, transform, Color.HSV(0.0f, .8f, .8f));
+		Hierarchy.Pop();
+
+		Hierarchy.Push(Matrix.T( 0.2f, 0, -0.5f));
+		Mesh.Sphere.Draw(Material.Default, transform, Color.HSV(0.5f, .8f, .8f));
+		Hierarchy.Pop();
+		/// > One key thing to remember is that you should _always_ match a `Pop` for each `Push`.
+		/// :End:
+	}
+
+	static void HierarchicalIntersection()
+	{
+		/// :CodeSample: Hierarchy Hierarchy.Push Hierarchy.Pop Hierarchy.ToLocal Hierarchy.ToWorld
+		/// ### Spaces and Intersections
+		/// 
+		/// One tricky thing you need to keep in mind when working with
+		/// different spaces like the ones created with `Hierarchy` is that any
+		/// values you use for math need to be in the same space! I like to
+		/// explicitly label my variables with the space they're in anytime I'm
+		/// working with anything even a little complicated!
+		///
+		/// ![An intersecting Ray in a complicated hierarchy]({{site.screen_url}}/Docs/Hierarchy_Spaces.jpg)
+		/// 
+		/// Here's an example of intersecting a ray with some content that
+		/// exists inside of a `Hierarchy` stack. You always need to transform
+		/// your data into `Mesh` or `Model` space in order to do an
+		/// `Intersect`, but the `Hierarchy` here adds a bit of extra
+		/// complexity to the problem!
+
+		// It can often be helpful to consider if you're making a function
+		// "Hierarchy aware", meaning that it will still work properly if the
+		// code _already_ exists within a transformed hierarchy! Here we're
+		// using `Hierarchy.ToWorld` to ensure our intersection ray is
+		// _for sure_ in World Space.
+		Ray parentSpaceRay = new Ray(V.XYZ(0.5f, 4, -0.5f), V.XYZ(-1, 0, 0));
+		Ray worldSpaceRay  = Hierarchy.ToWorld(parentSpaceRay);
+		Lines.Add(parentSpaceRay, 0.5f, Color.White, 0.005f);
+
+		// Sometimes it can help with clarity to add scope brackets to show
+		// how the hierarchy is affecting the code!
+		Hierarchy.Push(Matrix.T(0, 4, -0.5f));
+		{
+			Matrix localTransform = Matrix.TRS(Vec3.Zero, Quat.FromAngles(20, 135, 45), 0.2f);
+			Mesh.Cube.Draw(Material.Default, localTransform);
+
+			// Mesh intersection _must_ be done in Mesh space, since that's
+			// the space the Vertex data is in. So we need to convert our
+			// intersection ray all the way from world space to mesh space here
+			// before calling `Intersect`!
+			Ray localSpaceRay = Hierarchy.ToLocal(worldSpaceRay);
+			Ray meshSpaceRay  = localTransform.Inverse.Transform(localSpaceRay);
+			if (meshSpaceRay.Intersect(Mesh.Cube, out Ray meshSpaceAt))
+			{
+				// Similarly, the intersection point needs to be transformed
+				// from Mesh space back into our local space before drawing it.
+				Ray localAt = localTransform.Transform(meshSpaceAt);
+				Mesh.Sphere.Draw(Material.Default, Matrix.TS(localAt.position, 0.04f), Color.HSV(0.36f, .8f, .8f));
+			}
+		}
+		Hierarchy.Pop();
+		/// :End:
+	}
+
+	public void Initialize()
+	{
+	}
+
+	public void Shutdown()
+	{
+	}
+
+	public void Step()
+	{
+		HierarchicalTransform();
+		HierarchicalIntersection();
+
+		Tests.Screenshot("Docs/Hierarchy_Transform.jpg", 600, 400,     Vec3.Zero,          new Vec3(0.0f, 0, -0.5f));
+		Tests.Screenshot("Docs/Hierarchy_Spaces.jpg",    600, 400, 60, new Vec3(0.1f,4,0), new Vec3(0.1f, 4, -0.5f));
+	}
+}

--- a/Examples/StereoKitTest/Docs/DocInput.cs
+++ b/Examples/StereoKitTest/Docs/DocInput.cs
@@ -1,0 +1,40 @@
+﻿using StereoKit;
+
+class DocInput : ITest
+{
+	static void FingerGlowWindow()
+	{
+		Pose pose = new Pose(0,0,-0.5f, Quat.LookDir(0,0,1));
+		UI.WindowBegin("Finger Glow", ref pose);
+		UI.LayoutReserve(V.XX(0.1f));
+		UI.WindowEnd();
+
+		/// :CodeSample: Input.FingerGlow
+		/// ### Disabling Finger Glow
+		/// When using StereoKit's built-in UI shaders, or the shader API's
+		/// `sk_finger_glow`, StereoKit provides a glowing aura around the
+		/// pointer finger.
+		/// 
+		/// ![Finger Glow on a Window panel]({{site.screen_url}}/Docs/Input_FingerGlow.jpg)
+		/// 
+		/// This feature is on by default, but can be disabled without
+		/// modifying shaders! As long as `Input.FingerGlow` is `false` at
+		/// _the end of the frame_, StereoKit will skip providing the shaders
+		/// with valid finger pose data for the glow effect.
+		Input.FingerGlow = false;
+		/// :End:
+		
+		// Our screenshot still needs this to be on
+		Input.FingerGlow = true;
+	}
+
+	public void Initialize() => Tests.RunForFrames(2);
+	public void Shutdown  () { }
+	public void Step      ()
+	{
+		FingerGlowWindow();
+
+		Tests.Hand([new HandJoint(V.XYZ(-0.009f, -0.171f, -0.402f), new Quat(0.221f, -0.047f, -0.827f, 0.515f), 0.020f), new HandJoint(V.XYZ(-0.009f, -0.171f, -0.402f), new Quat(0.221f, -0.047f, -0.827f, 0.515f), 0.020f), new HandJoint(V.XYZ(0.005f, -0.166f, -0.432f), new Quat(0.245f, 0.010f, -0.766f, 0.594f), 0.013f), new HandJoint(V.XYZ(0.018f, -0.155f, -0.463f), new Quat(0.221f, -0.045f, -0.827f, 0.516f), 0.010f), new HandJoint(V.XYZ(0.030f, -0.151f, -0.485f), new Quat(0.221f, -0.045f, -0.827f, 0.516f), 0.009f), new HandJoint(V.XYZ(-0.016f, -0.164f, -0.394f), new Quat(0.488f, -0.042f, -0.077f, 0.868f), 0.022f), new HandJoint(V.XYZ(-0.001f, -0.112f, -0.421f), new Quat(0.422f, 0.007f, -0.091f, 0.902f), 0.011f), new HandJoint(V.XYZ(0.002f, -0.082f, -0.446f), new Quat(0.338f, 0.008f, -0.065f, 0.939f), 0.009f), new HandJoint(V.XYZ(0.003f, -0.066f, -0.466f), new Quat(0.308f, 0.029f, -0.040f, 0.950f), 0.008f), new HandJoint(V.XYZ(0.002f, -0.051f, -0.484f), new Quat(0.308f, 0.029f, -0.040f, 0.950f), 0.007f), new HandJoint(V.XYZ(-0.033f, -0.161f, -0.390f), new Quat(0.488f, -0.042f, -0.077f, 0.868f), 0.022f), new HandJoint(V.XYZ(-0.023f, -0.106f, -0.417f), new Quat(0.276f, 0.070f, 0.005f, 0.958f), 0.012f), new HandJoint(V.XYZ(-0.029f, -0.082f, -0.454f), new Quat(-0.219f, 0.054f, 0.050f, 0.973f), 0.008f), new HandJoint(V.XYZ(-0.031f, -0.094f, -0.479f), new Quat(-0.497f, 0.040f, 0.136f, 0.856f), 0.008f), new HandJoint(V.XYZ(-0.030f, -0.116f, -0.493f), new Quat(-0.497f, 0.040f, 0.136f, 0.856f), 0.007f), new HandJoint(V.XYZ(-0.049f, -0.157f, -0.387f), new Quat(0.488f, -0.042f, -0.077f, 0.868f), 0.020f), new HandJoint(V.XYZ(-0.044f, -0.110f, -0.416f), new Quat(0.308f, 0.064f, 0.052f, 0.948f), 0.010f), new HandJoint(V.XYZ(-0.050f, -0.087f, -0.449f), new Quat(-0.235f, -0.000f, 0.113f, 0.965f), 0.008f), new HandJoint(V.XYZ(-0.048f, -0.099f, -0.473f), new Quat(-0.560f, -0.064f, 0.133f, 0.815f), 0.007f), new HandJoint(V.XYZ(-0.042f, -0.122f, -0.484f), new Quat(-0.560f, -0.064f, 0.133f, 0.815f), 0.006f), new HandJoint(V.XYZ(-0.058f, -0.158f, -0.389f), new Quat(0.459f, -0.018f, 0.173f, 0.871f), 0.019f), new HandJoint(V.XYZ(-0.064f, -0.120f, -0.417f), new Quat(0.381f, 0.037f, 0.111f, 0.917f), 0.009f), new HandJoint(V.XYZ(-0.069f, -0.098f, -0.439f), new Quat(-0.135f, -0.038f, 0.192f, 0.971f), 0.007f), new HandJoint(V.XYZ(-0.066f, -0.104f, -0.459f), new Quat(-0.482f, -0.152f, 0.167f, 0.846f), 0.007f), new HandJoint(V.XYZ(-0.057f, -0.120f, -0.472f), new Quat(-0.482f, -0.152f, 0.167f, 0.846f), 0.006f), new HandJoint(V.XYZ(-0.028f, -0.133f, -0.403f), new Quat(-0.269f, 0.025f, -0.084f, 0.959f), 0.000f), new HandJoint(V.XYZ(-0.039f, -0.187f, -0.363f), new Quat(0.488f, -0.042f, -0.077f, 0.868f), 0.000f)]);
+		Tests.Screenshot("Docs/Input_FingerGlow.jpg", 1, 400, 400, 90, V.XYZ(0, -0.05f, -0.3f), V.XYZ(0, -0.05f, -0.5f));
+	}
+}

--- a/Examples/StereoKitTest/Docs/DocSK.cs
+++ b/Examples/StereoKitTest/Docs/DocSK.cs
@@ -1,0 +1,37 @@
+﻿// SPDX-License-Identifier: MIT
+// The authors below grant copyright rights under the MIT license:
+// Copyright (c) 2025 Nick Klingensmith
+// Copyright (c) 2025 Qualcomm Technologies, Inc.
+
+using StereoKit;
+
+class DocSK : ITest
+{
+	static void QuitLifecycle() {
+		// :CodeSample: SK.Quit QuitReason SK.QuitReason
+		// ### Quitting and Reasons
+		//
+		// `SK.Quit` allows you to exit the application, with an optionally
+		// provided reason! You can check the `SK.QuitReason` to see if
+		// StereoKit's reason for exiting was benign, like a User request, or
+		// if something more severe happened like an OpenXR runtime crash!
+		if (!SK.Initialize())
+			return;
+
+		SK.Run(() =>
+		{
+			if (Input.Key(Key.Esc).IsJustActive())
+				SK.Quit(QuitReason.User);
+		});
+
+		Log.Info($"{SK.QuitReason}");
+		// :End:
+	}
+
+	// Our sample is lifetime code, so we unfortunately can't run it in this
+	// context! This does still benefit from refactoring and syntax checking
+	// though.
+	public void Step      () { }
+	public void Initialize() { }
+	public void Shutdown  () { }
+}

--- a/Examples/StereoKitTest/Docs/DocText.cs
+++ b/Examples/StereoKitTest/Docs/DocText.cs
@@ -1,16 +1,70 @@
 ﻿// SPDX-License-Identifier: MIT
 // The authors below grant copyright rights under the MIT license:
-// Copyright (c) 2024 Nick Klingensmith
-// Copyright (c) 2024 Qualcomm Technologies, Inc.
+// Copyright (c) 2024-2025 Nick Klingensmith
+// Copyright (c) 2024-2025 Qualcomm Technologies, Inc.
 
 using StereoKit;
 
 class DocText : ITest
 {
-	TextStyle style = TextStyle.FromFont(Font.FromFile("aileron_font.ttf"), 0.2f, Color.White);
+		public static void TextSizes()
+	{
+		/// :CodeSample: Text.SizeLayout Text.SizeRender
+		/// ### Text Sizes
+		/// 
+		/// When you need to work with placing text, `Text.SizeLayout` and
+		/// `Text.SizeRender` are the keys to the kingdom! `SizeLayout` will
+		/// give you the size of your text as far as layout is generally
+		/// concerned, while `SizeRender` will take your layout size and
+		/// provide the total bounds that you need to watch out for! Some fonts
+		/// can have absolutely _unreasonable_ ascenders and descenders for
+		/// some of  their glyphs. Extreme cases can be a bit rare, so in
+		/// general you'll only need to work with the layout size. Just watch
+		/// out when you need to clip your text!
+		/// 
+		/// ![Text sizes]({{site.screen_url}}/Docs/Text_Sizes.jpg)
+		/// _You can see here with Segoe UI, the ascender area for rendering looks ridiculous._
+		/// 
+		/// In this screenshot, the black area represents the layout size,
+		/// while the gray area represents the render size. "lÔTy" is a decent
+		/// set of characters to illustrate a pretty normal range of height
+		/// variation.
+		string text  = "lÔTy";
+		TextStyle style = TextStyle.Default;
 
+		Text.Add(text, Matrix.Identity, style, TextAlign.Center);
+
+		// Calculate the text sizes! Layout size is used for placing text, but
+		// render size indicates the total area where text could end up,
+		// accounting for _extreme_ ascenders and descenders.
+		Vec2 layoutSz = Text.SizeLayout(text,     style);
+		Vec2 renderSz = Text.SizeRender(layoutSz, style, out float renderYOff);
+
+		// Draw the layout size behind the text in black
+		Mesh.Quad.Draw(Material.Unlit,
+			Matrix.TS(V.XYZ(0, 0, 0.0001f), (-layoutSz).XY1),
+			Color.Black);
+
+		// Draw the render size behind the text in gray, note that we're
+		// dividing the y offset by 2 because we're drawing from the _center_
+		// of a quad rather than something like the top left.
+		Mesh.Quad.Draw(Material.Unlit,
+			Matrix.TS(V.XYZ(0, renderYOff/2.0f, 0.0002f), (-renderSz).XY1),
+			new Color(0.2f,0.2f,0.2f));
+		/// :End:
+	}
+
+	TextStyle style = TextStyle.FromFont(Font.FromFile("aileron_font.ttf"), 0.2f, Color.White);
 	void ShowTextStyleInfo()
 	{
+		/// :CodeSample: TextStyle TextStyle.Ascender TextStyle.CapHeight TextStyle.Descender TextStyle.LineHeightPct TextStyle.TotalHeight
+		/// ### TextStyle Info
+		/// If you're doing advanced text layout, StereoKit does provide some
+		/// information about the font underlying the TextStyle! Here's a
+		/// quick sketch that shows what all that info represents:
+		/// 
+		/// ![Where style info lands on text]({{site.screen_url}}/Docs/Text_StyleInfo.jpg)
+		/// 
 		// Some representative characters:
 		// l frequently goes above CapHeight all the way to the Ascender.
 		// Ô will go past the Ascender outside the layout bounds, and slightly below the baseline.
@@ -28,8 +82,8 @@ class DocText : ITest
 		Vec2 size  = Text.SizeLayout(text, style);
 		Vec2 sizeR = Text.SizeRender(size, style, out float yOff);
 
-		Mesh.Cube.Draw(Material.Unlit, Matrix.TS(size .XY0/-2 + V.XYZ(0, 0,    0.001f), size .XY0 + V.XYZ(0, 0, 0.001f)), colLayoutArea);
-		Mesh.Cube.Draw(Material.Unlit, Matrix.TS(sizeR.XY0/-2 + V.XYZ(0, yOff, 0.002f), sizeR.XY0 + V.XYZ(0, 0, 0.001f)), colRenderArea);
+		Mesh.Quad.Draw(Material.Unlit, Matrix.TS(size .XY0/-2 + V.XYZ(0, 0,    0.0001f), size .XY1), colLayoutArea);
+		Mesh.Quad.Draw(Material.Unlit, Matrix.TS(sizeR.XY0/-2 + V.XYZ(0, yOff, 0.0002f), sizeR.XY1), colRenderArea);
 
 		// Show lines representing the typography units for this style
 		Color32 colCapHeight  = new Color32( 50, 255,  50, 255);
@@ -49,17 +103,25 @@ class DocText : ITest
 		Lines.Add(V.XY0(0, capHeightAt ), V.XY0(-size.x, capHeightAt ), colCapHeight,  0.003f);
 		Lines.Add(V.XY0(0, descenderAt ), V.XY0(-size.x, descenderAt ), colDescender,  0.003f);
 		Lines.Add(V.XY0(0, lineHeightAt), V.XY0(-size.x, lineHeightAt), colLineHeight, 0.003f);
+		/// :End:
 	}
 
 	public void Step()
 	{
 		Hierarchy.Push(Matrix.TR(0, 0, -0.5f, Quat.LookDir(0, 0, 1)));
-
 		ShowTextStyleInfo();
 		Hierarchy.Pop();
 
 		Vec2 s = Text.SizeLayout("lÔTy", style);
-		Tests.Screenshot("TextStyleInfo.jpg", 400, 400, V.XYZ(s.x/2, s.y/-2, -0.18f), V.XYZ(s.x/2, s.y/-2, -0.5f));
+		Tests.Screenshot("Docs/Text_StyleInfo.jpg", 400, 400, 70, V.XY0(s.x / 2, s.y / -2), V.XYZ(s.x / 2, s.y / -2, -0.5f));
+
+		Hierarchy.Push(Matrix.TR(0, 1, -0.5f, Quat.LookDir(0, 0, 1)));
+		TextSizes();
+		Hierarchy.Pop();
+
+		s = Text.SizeLayout("lÔTy", TextStyle.Default);
+		s = Text.SizeRender(s, TextStyle.Default, out float yOff);
+		Tests.Screenshot("Docs/Text_Size.jpg", 400, 400, 15, V.XYZ(0, 1+yOff/2.0f, -0.18f), V.XYZ(0, 1+yOff/2.0f, -0.5f));
 	}
 
 	public void Initialize() {}

--- a/Examples/StereoKitTest/Docs/DocUI.cs
+++ b/Examples/StereoKitTest/Docs/DocUI.cs
@@ -13,13 +13,14 @@ class DocUI : ITest
 
 	public void Step()
 	{
-		ShowWindowButton   ();
-		ShowWindowToggle   ();
-		ShowWindowSeparator();
-		ShowWindowSlider   ();
-		ShowWindowInput    ();
-		ShowWindowRadio    ();
-		ShowWindowEnabled  ();
+		ShowWindowButton    ();
+		ShowWindowToggle    ();
+		ShowWindowSeparator ();
+		ShowWindowSlider    ();
+		ShowWindowInput     ();
+		ShowWindowRadio     ();
+		ShowWindowEnabled   ();
+		ShowWindowTextScroll();
 
 		Tests.Screenshot("UI/ButtonWindow.jpg",    1, 500, 400, 50, V.XYZ(.0f,-0.02f,-.2f), V.XYZ(.0f,-0.02f,0));
 		Tests.Screenshot("UI/ToggleWindow.jpg",    1, 500, 400, 50, V.XYZ(.3f,-0.04f,-.2f), V.XYZ(.3f,-0.04f,0));
@@ -28,6 +29,7 @@ class DocUI : ITest
 		Tests.Screenshot("UI/InputWindow.jpg",     1, 500, 400, 45, V.XYZ(1.2f,-0.02f,-.2f), V.XYZ(1.2f,-0.02f,0));
 		Tests.Screenshot("UI/RadioWindow.jpg",     1, 500, 500, 55, V.XYZ(1.5f,-0.06f,-.2f), V.XYZ(1.5f,-0.06f,0));
 		Tests.Screenshot("UI/EnabledWindow.jpg",   1, 500, 500, 55, V.XYZ(1.8f,-0.07f,-.2f), V.XYZ(1.8f,-0.07f,0));
+		Tests.Screenshot("UI/TextScroll.jpg",      1, 500, 500, 55, V.XYZ(2.1f,-0.05f,-.2f), V.XYZ(2.1f,-0.05f,0));
 	}
 
 	/// :CodeSample: UI UI.Button UI.WindowBegin UI.WindowEnd
@@ -224,6 +226,27 @@ class DocUI : ITest
 			UI.PopEnabled();
 		}
 		UI.PopEnabled();
+
+		UI.WindowEnd();
+	}
+	/// :End:
+
+	string loremIpsum = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur sollicitudin lectus at fringilla blandit. Morbi at leo pulvinar, consequat nisi sed, eleifend dui. Donec efficitur eros libero, sed euismod velit lobortis at. Aliquam erat volutpat. Etiam pellentesque quis nisl vitae mattis. Proin tortor nisl, sollicitudin at suscipit id, tincidunt pellentesque justo. Praesent ut justo quis neque pulvinar sagittis mattis vel magna. Aenean placerat, felis in pretium viverra, felis neque volutpat nibh, quis molestie tellus diam sed augue. Nulla ac cursus nunc. Proin viverra tincidunt lacus, aliquet pretium dui. Suspendisse aliquam ligula a mauris commodo varius. Nam hendrerit tincidunt consectetur. Phasellus efficitur diam arcu, in ultricies nunc rhoncus ut. Donec mollis mattis aliquam. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec consectetur purus ac finibus pulvinar.\n\nCurabitur ipsum tellus, pharetra eget erat ac, hendrerit tincidunt neque. Fusce varius pretium ligula, nec ultrices sem consequat in. Nulla finibus ipsum vel augue dapibus convallis. In quis lectus non massa malesuada gravida nec eget massa. Praesent at rhoncus turpis. Duis porta magna eu ligula sodales imperdiet. Vivamus convallis rutrum diam, ac tempor lectus iaculis pharetra. Ut pulvinar placerat felis, vel scelerisque nisi. Duis non lobortis arcu.";
+	/// :CodeSample: UI.Text
+	/// ### Scrolling Text
+	/// 
+	/// `UI.Text` has an optional overload that allows you to scroll long
+	/// chunks of text! Here's a simple example that allows you to scroll some
+	/// Lorem Ipsum text vertically.
+	/// 
+	/// ![A window with a scrolling text box]({{site.screen_url}}/UI/TextScrollWindow.jpg)
+	Pose windowPoseScroll = new Pose(2.1f, 0, 0, Quat.Identity);
+	Vec2 scroll           = V.XY(0,0.1f);
+	void ShowWindowTextScroll()
+	{
+		UI.WindowBegin("Window Text Scroll", ref windowPoseScroll);
+
+		UI.Text(loremIpsum, ref scroll, UIScroll.Vertical, 0.1f);
 
 		UI.WindowEnd();
 	}

--- a/Examples/StereoKitTest/Guides/GuideGettingStarted.cs
+++ b/Examples/StereoKitTest/Guides/GuideGettingStarted.cs
@@ -3,7 +3,7 @@
 /// 
 /// The minimum prerequisite for StereoKit is the .NET SDK! You can use `dotnet --version` to check if this is already present.
 /// 
-/// Open up your Terminal, and run the following:
+/// If it is not, open up your Terminal, and run the following:
 /// ```bash
 /// winget install Microsoft.DotNet.SDK.9
 /// # Restart the Terminal to refresh your Path variable
@@ -18,7 +18,7 @@
 /// # Install the StereoKit templates!
 /// dotnet new install StereoKit.Templates
 /// 
-/// # Create a .NET Core based StereoKit project, and run it
+/// # Create a multiplatform StereoKit project, and run it
 /// mkdir SKProjectName
 /// cd    SKProjectName
 /// 

--- a/Examples/StereoKitTest/Program.cs
+++ b/Examples/StereoKitTest/Program.cs
@@ -15,7 +15,7 @@ class Program
 
 	// The base settings we use for this test app. Some of these, like mode,
 	// are overridden, particularly when running tests.
-	static SKSettings     settings  = new SKSettings {
+	static SKSettings settings = new SKSettings {
 		appName         = "StereoKit C#",
 		blendPreference = DisplayBlend.AnyTransparent,
 		mode            = AppMode.XR,

--- a/Examples/StereoKitTest/Program.cs
+++ b/Examples/StereoKitTest/Program.cs
@@ -13,7 +13,6 @@ class Program
 	static string startTest = "welcome";
 	static SKSettings settings = new SKSettings {
 		appName         = "StereoKit C#",
-		assetsFolder    = "Assets",
 		blendPreference = DisplayBlend.AnyTransparent,
 		mode            = AppMode.XR,
 		logFilter       = LogLevel.Diagnostic,

--- a/Examples/StereoKitTest/StereoKitTest_NetAndroid/AndroidManifest.xml
+++ b/Examples/StereoKitTest/StereoKitTest_NetAndroid/AndroidManifest.xml
@@ -32,6 +32,11 @@
 		<intent> <action android:name="org.khronos.openxr.OpenXRApiLayerService" /> </intent>
 	</queries>
 
+	<!-- AndroidXR items -->
+	<uses-permission android:name="android.permission.SCENE_UNDERSTANDING" />
+	<uses-permission android:name="android.permission.HAND_TRACKING" />
+	<uses-permission android:name="android.permission.EYE_TRACKING_FINE" />
+
 	<!-- Vive specific items  -->
 	<uses-feature android:name="wave.feature.handtracking" android:required="false"/>
 	<uses-feature android:name="wave.feature.tracker"      android:required="false"/>

--- a/Examples/StereoKitTest/Tests.cs
+++ b/Examples/StereoKitTest/Tests.cs
@@ -5,67 +5,68 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 
+public enum SceneType
+{
+	Demos,
+	Tests,
+	Docs,
+	MAX
+}
+
 public static class Tests
 {
-	public enum Category
-	{
-		Demo,
-		Test,
-		Documentation,
-		MAX
-	}
-
-	struct TestItem
+	struct SceneItem
 	{
 		public Type   type;
 		public string name;
 	}
 
-	static List<Type> allTests  = new List<Type>();
-	static List<TestItem>[] categoryTests = new List<TestItem>[(int)Category.MAX];
-	static ITest activeScene;
-	static ITest nextScene;
-	static int   testIndex  = 0;
-	static int   runFrames  = 2;
-	static float runSeconds = 0;
-	static int   sceneFrame = 0;
-	static float sceneTime  = 0;
-	static int   failures   = 0;
-	static HashSet<string> screens = new HashSet<string>();
+	static Type[]          allScenes;
+	static SceneItem[][]   sceneTypes;
+	static ITest           activeScene;
+	static ITest           nextScene;
+	static int             sceneIndex  = 0;
+	static int             runFrames   = 2;
+	static float           runSeconds  = 0;
+	static int             sceneFrame  = 0;
+	static float           sceneTime   = 0;
+	static int             failures    = 0;
+	static HashSet<string> screenshots = new HashSet<string>();
 
-	private static Type ActiveTest { set { nextScene = (ITest)Activator.CreateInstance(value); } }
-	public  static bool IsTesting { get; set; }
-	public  static bool TestSingle { get; set; }
+	private static Type   ActiveScene        { set { nextScene = (ITest)Activator.CreateInstance(value); } }
+	public  static bool   IsTesting          { get; set; }
+	public  static bool   TestSingle         { get; set; }
 
-	public static string ScreenshotRoot     { get; set; } = "../../../docs/img/screenshots";
-	public static bool   MakeScreenshots    { get; set; } = true;
-	public static string GltfFolders        { get; set; } = null; // "C:\\Tools\\glTF-Sample-Models-master\\2.0";
-	public static string GltfScreenshotRoot { get; set; } = null;
+	public  static string ScreenshotRoot     { get; set; } = null;
+	public  static bool   MakeScreenshots    { get; set; } = true;
+	public  static string GltfFolders        { get; set; } = null;
+	public  static string GltfScreenshotRoot { get; set; } = null;
 
 	public static void FindTests()
 	{
-		allTests = Assembly.GetExecutingAssembly()
+		allScenes = Assembly.GetExecutingAssembly()
 			.GetTypes()
-			.Where  (a => a != typeof(ITest) && typeof(ITest).IsAssignableFrom(a) )
-			.OrderBy(a => a.Name )
-			.ToList ();
+			.Where   (a => a != typeof(ITest) && typeof(ITest).IsAssignableFrom(a) )
+			.OrderBy (a => a.Name )
+			.ToArray ();
 
-		categoryTests[(int)Category.Demo] = allTests
-			.Where (t => t.Name.StartsWith("Demo"))
-			.Select(t => new TestItem { type = t, name=t.Name.Substring("Demo".Length) })
-			.ToList();
-		categoryTests[(int)Category.Test] = allTests
-			.Where (t => t.Name.StartsWith("Test"))
-			.Select(t => new TestItem { type = t, name = t.Name.Substring("Test".Length) })
-			.ToList();
-		categoryTests[(int)Category.Documentation] = allTests
-			.Where (t => t.Name.StartsWith("Doc"))
-			.Select(t => new TestItem { type = t, name = t.Name.Substring("Doc".Length) })
-			.ToList();
+		sceneTypes = new SceneItem[(int)SceneType.MAX][];
+		sceneTypes[(int)SceneType.Demos] = allScenes
+			.Where  (t => t.Name.StartsWith("Demo"))
+			.Select (t => new SceneItem { type = t, name = t.Name.Substring("Demo".Length) })
+			.ToArray();
+		sceneTypes[(int)SceneType.Tests] = allScenes
+			.Where  (t => t.Name.StartsWith("Test"))
+			.Select (t => new SceneItem { type = t, name = t.Name.Substring("Test".Length) })
+			.ToArray();
+		sceneTypes[(int)SceneType.Docs] = allScenes
+			.Where  (t => t.Name.StartsWith("Doc"))
+			.Select (t => new SceneItem { type = t, name = t.Name.Substring("Doc".Length) })
+			.ToArray();
 	}
 
-	public static int Count(Category category) => categoryTests[(int)category].Count;
-	public static bool IsActive(Category category, int i) => categoryTests[(int)category][i].type == activeScene.GetType();
+	public static int  Count   (SceneType category)        => sceneTypes[(int)category].Length;
+	public static bool IsActive(SceneType category, int i) => sceneTypes[(int)category][i].type == activeScene.GetType();
 
 	public static void Initialize()
 	{
@@ -73,7 +74,7 @@ public static class Tests
 			nextScene = null;
 		}
 		if (nextScene == null)
-			nextScene = (ITest)Activator.CreateInstance(allTests[testIndex]);
+			nextScene = (ITest)Activator.CreateInstance(allScenes[sceneIndex]);
 	}
 
 	public static void Update()
@@ -87,8 +88,8 @@ public static class Tests
 			GC.Collect(int.MaxValue, GCCollectionMode.Forced);
 			if (IsTesting)
 			{
-				Time.SetTime(0);
-				Input.HandVisible(Handed.Max, false);
+				Time .SetTime          (0);
+				Input.HandVisible      (Handed.Max, false);
 				Input.HandClearOverride(Handed.Left);
 				Input.HandClearOverride(Handed.Right);
 			}
@@ -118,11 +119,11 @@ public static class Tests
 
 		if (IsTesting && FinishedWithTest())
 		{
-			testIndex += 1;
-			if (testIndex >= allTests.Count || TestSingle)
+			sceneIndex += 1;
+			if (sceneIndex >= allScenes.Length || TestSingle)
 				SK.Quit();
 			else
-				SetTestActive(allTests[testIndex].Name);
+				SetTestActive(allScenes[sceneIndex].Name);
 		}
 	}
 	public static void Shutdown()
@@ -143,21 +144,21 @@ public static class Tests
 		Log.Info($"Quit reason: <~WHT>{SK.QuitReason}<~clr>");
 	}
 
-	public static string GetTestName(Category category, int index)
+	public static string GetTestName(SceneType category, int index)
 	{
-		return categoryTests[(int)category][index].name;
+		return sceneTypes[(int)category][index].name;
 	}
 
-	public static void SetTestActive(Category category, int index)
+	public static void SetTestActive(SceneType category, int index)
 	{
-		Log.Info($"Starting Scene: {categoryTests[(int)category][index].name}");
-		ActiveTest = categoryTests[(int)category][index].type;
+		Log.Info($"Starting Scene: {sceneTypes[(int)category][index].name}");
+		ActiveScene = sceneTypes[(int)category][index].type;
 	}
 
 	public static void SetTestActive(string name)
 	{
 		name = name.ToLower();
-		Type result = allTests.OrderBy( a => {
+		Type result = allScenes.OrderBy( a => {
 			string str = a.Name.ToLower();
 			if (str == name)             return 0;
 			else if (str.Contains(name)) return str.Length - name.Length;
@@ -165,10 +166,10 @@ public static class Tests
 		}).First();
 		Log.Info($"Starting Scene: {result.Name}");
 
-		sceneFrame = 0;
-		runFrames  = 2;
-		runSeconds = 0;
-		ActiveTest = result;
+		sceneFrame  = 0;
+		runFrames   = 2;
+		runSeconds  = 0;
+		ActiveScene = result;
 	}
 
 	public static void Test(Func<bool> testFunction)
@@ -187,22 +188,15 @@ public static class Tests
 
 	private static bool FinishedWithTest()
 	{
-		if (runSeconds != 0) {
-			return Time.Totalf-sceneTime > runSeconds;
-		}
-		if (runFrames != -1) { 
-			return sceneFrame == runFrames;
-		}
+		if (runSeconds != 0) return Time.Totalf-sceneTime > runSeconds;
+		if (runFrames != -1) return sceneFrame == runFrames;
 		return true;
 	}
-	public static void RunForFrames(int frames)
-		=> runFrames = frames;
-	public static void RunForSeconds(float seconds)
-		=> runSeconds = seconds;
-	public static void RunContinue()
-		=> runFrames += 1;
-	public static void RunStop()
-		=> runFrames = -1;
+
+	public static void RunForFrames (int   frames)  => runFrames  = frames;
+	public static void RunForSeconds(float seconds) => runSeconds = seconds;
+	public static void RunContinue  ()              => runFrames +=  1;
+	public static void RunStop      ()              => runFrames  = -1;
 
 	public static void Screenshot(string name, int width, int height, float fov, Vec3 from, Vec3 at)
 		=> Screenshot(name, 0, width, height, fov, from, at);
@@ -210,26 +204,26 @@ public static class Tests
 		=> Screenshot(name, 0, width, height, 90, from, at);
 	public static void Screenshot(string name, int frame, int width, int height, float fov, Vec3 from, Vec3 at)
 	{
-		if (!IsTesting || frame != sceneFrame || screens.Contains(name) || !MakeScreenshots)
+		if (!IsTesting || frame != sceneFrame || screenshots.Contains(name) || !MakeScreenshots)
 			return;
-		screens.Add(name);
+		screenshots.Add(name);
 
 		string file = Path.Combine(ScreenshotRoot, name);
 		string dir  = Path.GetDirectoryName(file);
-		if (!Directory.Exists(dir))
+		if (Directory.Exists(dir) == false)
 			Directory.CreateDirectory(dir);
 		Renderer.Screenshot(file, from, at, width, height, fov);
 	}
 
 	public static void ScreenshotGltf(string name, int width, int height, Vec3 from, Vec3 at)
 	{
-		if (!IsTesting || screens.Contains(name) || !MakeScreenshots || GltfScreenshotRoot == null)
+		if (!IsTesting || screenshots.Contains(name) || !MakeScreenshots || GltfScreenshotRoot == null)
 			return;
-		screens.Add(name);
+		screenshots.Add(name);
 
 		string file = Path.Combine(GltfScreenshotRoot, name);
 		string dir  = Path.GetDirectoryName(file);
-		if (!Directory.Exists(dir))
+		if (Directory.Exists(dir) == false)
 			Directory.CreateDirectory(dir);
 		Renderer.Screenshot(file, from, at, width, height, 45);
 	}

--- a/Examples/StereoKitTest/Tests/TestFromThread.cs
+++ b/Examples/StereoKitTest/Tests/TestFromThread.cs
@@ -34,9 +34,9 @@ class TestFromThread : ITest
 			material        = Material.Default.Copy();
 			mesh            = Mesh.GenerateSphere(1);
 
-			Color32[] colors = new Color32[1] { Color.White };
-			Tex tex = Tex.FromColors(colors, 1, 1);
-			tex.SetColors(1, 1, colors);
+			Color32[] colors = [ Color.White, Color.White, Color.White, Color.White ];
+			Tex tex = Tex.FromColors(colors, 2, 2);
+			tex.SetColors(2, 2, colors);
 
 			material[MatParamName.DiffuseTex] = tex;
 

--- a/Examples/StereoKitTest/Tools/LogWindow.cs
+++ b/Examples/StereoKitTest/Tools/LogWindow.cs
@@ -1,7 +1,7 @@
 ﻿// SPDX-License-Identifier: MIT
 // The authors below grant copyright rights under the MIT license:
-// Copyright (c) 2023 Nick Klingensmith
-// Copyright (c) 2023 Qualcomm Technologies, Inc.
+// Copyright (c) 2023-2025 Nick Klingensmith
+// Copyright (c) 2023-2025 Qualcomm Technologies, Inc.
 
 using System;
 using System.Collections.Generic;
@@ -17,7 +17,8 @@ namespace StereoKit.Framework
 			public string   text;
 			public int      count;
 		}
-		public bool Enabled { get; set; } = true;
+		private bool enabled = false;
+		public  bool Enabled { get => enabled; set { enabled = value; pose = UI.PopupPose(); } }
 
 		public Pose pose = Pose.Identity;
 
@@ -36,7 +37,10 @@ namespace StereoKit.Framework
 		ulong lastMemPoll = 0;
 
 		public LogWindow()
-			=> Log.Subscribe(OnLog);
+		{
+			Log.Subscribe(OnLog);
+			Enabled = true;
+		}
 
 		public bool Initialize()
 		{

--- a/StereoKit/Assets/Tex.cs
+++ b/StereoKit/Assets/Tex.cs
@@ -155,6 +155,14 @@ namespace StereoKit
 		#endregion
 
 		#region Methods
+		public Tex Copy(TexType textureType = TexType.Image, TexFormat textureFormat = TexFormat.None)
+		{
+			IntPtr result = NativeAPI.tex_copy(_inst, textureType, textureFormat);
+			return result == IntPtr.Zero
+				? null
+				: new Tex(result);
+		}
+
 		/// <summary>Set the texture's pixels using a pointer to a chunk of
 		/// memory! This is great if you're pulling in some color data from
 		/// native code, and don't want to pay the cost of trying to marshal

--- a/StereoKit/Framework/Ease.cs
+++ b/StereoKit/Framework/Ease.cs
@@ -1,7 +1,7 @@
 ﻿// SPDX-License-Identifier: MIT
 // The authors below grant copyright rights under the MIT license:
-// Copyright (c) 2024 Nick Klingensmith
-// Copyright (c) 2024 Qualcomm Technologies, Inc.
+// Copyright (c) 2024-2025 Nick Klingensmith
+// Copyright (c) 2024-2025 Qualcomm Technologies, Inc.
 
 using System;
 
@@ -112,7 +112,7 @@ namespace StereoKit.Framework
 		/// <returns>The current easing value.</returns>
 		public Vec3 Resolve()
 		{
-			float t = Math.Min(1, (Time.Totalf - start) / duration);
+			float t = duration == 0 ? 1 : Math.Min(1, (Time.Totalf - start) / duration);
 			return Vec3.Lerp(begin, end, ease(t));
 		}
 
@@ -139,7 +139,7 @@ namespace StereoKit.Framework
 		/// the provided value.</summary>
 		/// <param name="value">The new value that should be assigned right now
 		/// without animation.</param>
-		public void SetTo (Vec3 value) { begin = value; start = 0; end = value; ease = Ease.Linear; this.duration = 1; }
+		public void SetTo (Vec3 value) { begin = value; start = 0; end = value; ease = Ease.Linear; this.duration = 0; }
 
 		/// <summary>An implicit "Resolve" of this easing type to its value.</summary>
 		/// <param name="value">The easing value.</param>
@@ -177,7 +177,7 @@ namespace StereoKit.Framework
 		/// <returns>The current easing value.</returns>
 		public Color Resolve()
 		{
-			float t = Math.Min(1, (Time.Totalf - start) / duration);
+			float t = duration == 0 ? 1 : Math.Min(1, (Time.Totalf - start) / duration);
 			return Color.Lerp(begin, end, ease(t));
 		}
 
@@ -191,13 +191,13 @@ namespace StereoKit.Framework
 		/// <param name="easeFn">An easing function the animation will follow.
 		/// A good all-around default would be Ease.SoftOut. A number of easing
 		/// functions can be found in the Ease class.</param>
-		public void AnimTo(Color destination, float duration, EaseFn easeFn) { begin = Resolve(); start = Time.Totalf; end = destination; ease = easeFn;      this.duration = duration; }
+		public void AnimTo(Color destination, float duration, EaseFn easeFn) { begin = Resolve(); start = Time.Totalf; end = destination; ease = easeFn; this.duration = duration; }
 		/// <summary>Sets this to a specific value with no easing animation.
 		/// This will cancel any in-progress animations, and jump straight to
 		/// the provided value.</summary>
 		/// <param name="value">The new value that should be assigned right now
 		/// without animation.</param>
-		public void SetTo (Color value)                                      { begin = value;     start = 0;           end = value;       ease = Ease.Linear; this.duration = 1; }
+		public void SetTo (Color value) { begin = value; start = 0; end = value; ease = Ease.Linear; duration = 0; }
 
 		/// <summary>An implicit "Resolve" of this easing type to its value.</summary>
 		/// <param name="value">The easing value.</param>
@@ -233,7 +233,7 @@ namespace StereoKit.Framework
 		/// <returns>The current easing value.</returns>
 		public Pose Resolve()
 		{
-			float t = Math.Min(1, (Time.Totalf - start) / duration);
+			float t = duration == 0 ? 1 : Math.Min(1, (Time.Totalf - start) / duration);
 			return Pose.Lerp(begin, end, ease(t));
 		}
 
@@ -247,13 +247,13 @@ namespace StereoKit.Framework
 		/// <param name="easeFn">An easing function the animation will follow.
 		/// A good all-around default would be Ease.SoftOut. A number of easing
 		/// functions can be found in the Ease class.</param>
-		public void AnimTo(Pose destination, float duration, EaseFn easeFn) { begin = Resolve(); start = Time.Totalf; end = destination; ease = easeFn;      this.duration = duration; }
+		public void AnimTo(Pose destination, float duration, EaseFn easeFn) { begin = Resolve(); start = Time.Totalf; end = destination; ease = easeFn; this.duration = duration; }
 		/// <summary>Sets this to a specific value with no easing animation.
 		/// This will cancel any in-progress animations, and jump straight to
 		/// the provided value.</summary>
 		/// <param name="value">The new value that should be assigned right now
 		/// without animation.</param>
-		public void SetTo (Pose value)                                      { begin = value;     start = 0;           end = value;       ease = Ease.Linear; this.duration = 1; }
+		public void SetTo (Pose value) { begin = value; start = 0; end = value; ease = Ease.Linear; duration = 0; }
 
 		/// <summary>An implicit "Resolve" of this easing type to its value.</summary>
 		/// <param name="value">The easing value.</param>

--- a/StereoKit/Math/Matrix.cs
+++ b/StereoKit/Math/Matrix.cs
@@ -260,6 +260,13 @@ namespace StereoKit
 		/// <returns>A non-uniform scaling matrix.</returns>
 		public static Matrix S(Vec3 scale)
 			=> Matrix4x4.CreateScale(scale.x, scale.y, scale.z);
+		/// <summary>Creates a scaling Matrix, where scale can be different
+		/// on each axis (non-uniform).</summary>
+		/// <param name="x">How much larger or smaller this transform makes
+		/// things. 1 is a good default, as 0 will shrink it to nothing!</param>
+		/// <returns>A non-uniform scaling matrix.</returns>
+		public static Matrix S(float x, float y, float z)
+			=> Matrix4x4.CreateScale(x, y, z);
 		/// <summary>Creates a scaling Matrix, where the scale is the same on
 		/// each axis (uniform).</summary>
 		/// <param name="scale">How much larger or smaller this transform

--- a/StereoKit/Math/Matrix.cs
+++ b/StereoKit/Math/Matrix.cs
@@ -1,4 +1,9 @@
-﻿using System.Numerics;
+﻿// SPDX-License-Identifier: MIT
+// The authors below grant copyright rights under the MIT license:
+// Copyright (c) 2019-2025 Nick Klingensmith
+// Copyright (c) 2025 Qualcomm Technologies, Inc.
+
+using System.Numerics;
 
 namespace StereoKit
 {
@@ -209,7 +214,7 @@ namespace StereoKit
 		/// <param name="translation">Move an object by this amount.</param>
 		/// <returns>A Matrix containing a simple translation!</returns>
 		public static Matrix T(Vec3 translation) 
-			=> Matrix4x4.CreateTranslation(translation.x, translation.y, translation.z);
+			=> Matrix4x4.CreateTranslation(translation.v.X, translation.v.Y, translation.v.Z);
 		/// <summary>Translate. Creates a translation Matrix!</summary>
 		/// <param name="x">Move an object on the x axis by this amount.</param>
 		/// <param name="y">Move an object on the y axis by this amount.</param>
@@ -223,8 +228,8 @@ namespace StereoKit
 		/// this transform.</param>
 		/// <returns>A Matrix that will rotate by the provided Quaternion 
 		/// orientation.</returns>
-		public static Matrix R(Quat rotation) 
-			=> Matrix4x4.CreateFromQuaternion(rotation);
+		public static Matrix R(Quat rotation)
+			=> Matrix4x4.CreateFromQuaternion(rotation.q);
 		/// <summary>Create a rotation matrix from pitch, yaw, and roll 
 		/// information. Units are in degrees.</summary>
 		/// <param name="pitchXDeg">Pitch, or rotation around the X axis, in
@@ -253,7 +258,7 @@ namespace StereoKit
 		/// makes things. Vec3.One is a good default, as Vec3.Zero will
 		/// shrink it to nothing!</param>
 		/// <returns>A non-uniform scaling matrix.</returns>
-		public static Matrix S(Vec3 scale) 
+		public static Matrix S(Vec3 scale)
 			=> Matrix4x4.CreateScale(scale.x, scale.y, scale.z);
 		/// <summary>Creates a scaling Matrix, where the scale is the same on
 		/// each axis (uniform).</summary>
@@ -261,7 +266,7 @@ namespace StereoKit
 		/// makes things. 1 is a good default, as 0 will shrink it to nothing!
 		/// This will expand to a scale vector of (size, size, size)</param>
 		/// <returns>A uniform scaling matrix.</returns>
-		public static Matrix S(float scale) 
+		public static Matrix S(float scale)
 			=> Matrix4x4.CreateScale(scale, scale, scale);
 
 		/// <summary>Translate, Scale. Creates a transform Matrix using both
@@ -272,8 +277,12 @@ namespace StereoKit
 		/// This will expand to a scale vector of (size, size, size)</param>
 		/// <returns>A Matrix that combines translation and scale information
 		/// into a single Matrix!</returns>
-		public static Matrix TS(Vec3 translation, float scale) 
-			=> NativeAPI.matrix_trs(translation, Quat.Identity, new Vec3(scale, scale, scale));
+		public static Matrix TS(Vec3 translation, float scale)
+			=> new Matrix4x4(
+				scale, 0, 0, 0,
+				0, scale, 0, 0,
+				0, 0, scale, 0,
+				translation.v.X, translation.v.Y, translation.v.Z, 1);
 		/// <summary>Translate, Scale. Creates a transform Matrix using both
 		/// these components!</summary>
 		/// <param name="translation">Move an object by this amount.</param>
@@ -283,7 +292,11 @@ namespace StereoKit
 		/// <returns>A Matrix that combines translation and scale information
 		/// into a single Matrix!</returns>
 		public static Matrix TS(Vec3 translation, Vec3 scale)
-			=> NativeAPI.matrix_trs(translation, Quat.Identity, scale);
+			=> new Matrix4x4(
+				scale.v.X, 0, 0, 0,
+				0, scale.v.Y, 0, 0,
+				0, 0, scale.v.Z, 0,
+				translation.v.X, translation.v.Y, translation.v.Z, 1);
 		/// <summary>Translate, Scale. Creates a transform Matrix using both
 		/// these components!</summary>
 		/// <param name="x">Move an object on the x axis by this amount.</param>
@@ -294,8 +307,12 @@ namespace StereoKit
 		/// shrink it to nothing!</param>
 		/// <returns>A Matrix that combines translation and scale information
 		/// into a single Matrix!</returns>
-		public static Matrix TS(float x, float y, float z, float scale) 
-			=> NativeAPI.matrix_trs(new Vec3(x, y, z), Quat.Identity, new Vec3(scale, scale, scale));
+		public static Matrix TS(float x, float y, float z, float scale)
+			=> new Matrix4x4(
+				scale, 0, 0, 0,
+				0, scale, 0, 0,
+				0, 0, scale, 0,
+				x, y, z, 1);
 		/// <summary>Translate, Scale. Creates a transform Matrix using both
 		/// these components!</summary>
 		/// <param name="x">Move an object on the x axis by this amount.</param>
@@ -306,8 +323,12 @@ namespace StereoKit
 		/// shrink it to nothing!</param>
 		/// <returns>A Matrix that combines translation and scale information
 		/// into a single Matrix!</returns>
-		public static Matrix TS(float x, float y, float z, Vec3  scale) 
-			=> NativeAPI.matrix_trs(new Vec3(x, y, z), Quat.Identity, scale);
+		public static Matrix TS(float x, float y, float z, Vec3  scale)
+			=> new Matrix4x4(
+				scale.v.X, 0, 0, 0,
+				0, scale.v.Y, 0, 0,
+				0, 0, scale.v.Z, 0,
+				x, y, z, 1);
 
 
 		/// <summary>Translate, Rotate. Creates a transform Matrix using 
@@ -318,7 +339,7 @@ namespace StereoKit
 		/// <returns>A Matrix that combines translation and rotation
 		/// information into a single Matrix!</returns>
 		public static Matrix TR(Vec3 translation, Quat rotation)
-			=> NativeAPI.matrix_trs(translation, rotation, Vec3.One);
+			=> TR(translation.v.X, translation.v.Y, translation.v.Z, rotation);
 		/// <summary>Translate, Rotate. Creates a transform Matrix using 
 		/// these components!</summary>
 		/// <param name="x">Move an object on the x axis by this amount.</param>
@@ -329,7 +350,13 @@ namespace StereoKit
 		/// <returns>A Matrix that combines translation and rotation
 		/// information into a single Matrix!</returns>
 		public static Matrix TR(float x, float y, float z, Quat rotation)
-			=> NativeAPI.matrix_trs(new Vec3(x, y, z), rotation, Vec3.One);
+		{
+			Matrix4x4 result = Matrix4x4.CreateFromQuaternion(rotation.q);
+			result.M41 = x;
+			result.M42 = y;
+			result.M43 = z;
+			return result;
+		}
 		/// <summary>Translate, Rotate. Creates a transform Matrix using 
 		/// these components!</summary>
 		/// <param name="translation">Move an object by this amount.</param>
@@ -338,8 +365,8 @@ namespace StereoKit
 		/// Units are in degrees.</param>
 		/// <returns>A Matrix that combines translation and rotation
 		/// information into a single Matrix!</returns>
-		public static Matrix TR(Vec3 translation, Vec3 pitchYawRollDeg) 
-			=> NativeAPI.matrix_trs(translation, Quat.FromAngles(pitchYawRollDeg), Vec3.One);
+		public static Matrix TR(Vec3 translation, Vec3 pitchYawRollDeg)
+			=> TR(translation.v.X, translation.v.Y, translation.v.Z, Quat.FromAngles(pitchYawRollDeg));
 		/// <summary>Translate, Rotate. Creates a transform Matrix using 
 		/// these components!</summary>
 		/// <param name="x">Move an object on the x axis by this amount.</param>
@@ -350,9 +377,9 @@ namespace StereoKit
 		/// Units are in degrees.</param>
 		/// <returns>A Matrix that combines translation and rotation
 		/// information into a single Matrix!</returns>
-		public static Matrix TR(float x, float y, float z, Vec3 pitchYawRollDeg) 
-			=> NativeAPI.matrix_trs(new Vec3(x, y, z), Quat.FromAngles(pitchYawRollDeg), Vec3.One);
-		
+		public static Matrix TR(float x, float y, float z, Vec3 pitchYawRollDeg)
+			=> TR(x, y, z, Quat.FromAngles(pitchYawRollDeg));
+
 		/// <summary>Translate, Rotate, Scale. Creates a transform Matrix 
 		/// using all these components!</summary>
 		/// <param name="translation">Move an object by this amount.</param>
@@ -363,8 +390,8 @@ namespace StereoKit
 		/// This will expand to a scale vector of (size, size, size)</param>
 		/// <returns>A Matrix that combines translation, rotation, and scale
 		/// information into a single Matrix!</returns>
-		public static Matrix TRS(Vec3 translation, Quat rotation, float scale) 
-			=> NativeAPI.matrix_trs(translation, rotation, new Vec3(scale, scale, scale));
+		public static Matrix TRS(Vec3 translation, Quat rotation, float scale)
+			=> TRS(translation, rotation, new Vec3(scale, scale, scale));
 		/// <summary>Translate, Rotate, Scale. Creates a transform Matrix 
 		/// using all these components!</summary>
 		/// <param name="translation">Move an object by this amount.</param>
@@ -375,8 +402,16 @@ namespace StereoKit
 		/// shrink it to nothing!</param>
 		/// <returns>A Matrix that combines translation, rotation, and scale
 		/// information into a single Matrix!</returns>
-		public static Matrix TRS(Vec3 translation, Quat rotation, Vec3  scale) 
-			=> NativeAPI.matrix_trs(translation, rotation, scale);
+		public static Matrix TRS(Vec3 translation, Quat rotation, Vec3 scale)
+		{
+			Matrix4x4 result =
+				Matrix4x4.CreateScale(scale.v) *
+				Matrix4x4.CreateFromQuaternion(rotation);
+			result.M41 += translation.v.X;
+			result.M42 += translation.v.Y;
+			result.M43 += translation.v.Z;
+			return result;
+		}
 		/// <summary>Translate, Rotate, Scale. Creates a transform Matrix 
 		/// using all these components!</summary>
 		/// <param name="translation">Move an object by this amount.</param>
@@ -388,8 +423,8 @@ namespace StereoKit
 		/// shrink it to nothing!</param>
 		/// <returns>A Matrix that combines translation, rotation, and scale
 		/// information into a single Matrix!</returns>
-		public static Matrix TRS(Vec3 translation, Vec3 pitchYawRollDeg, float scale) 
-			=> NativeAPI.matrix_trs(translation, Quat.FromAngles(pitchYawRollDeg), new Vec3(scale, scale, scale));
+		public static Matrix TRS(Vec3 translation, Vec3 pitchYawRollDeg, float scale)
+			=> TRS(translation, Quat.FromAngles(pitchYawRollDeg), new Vec3(scale, scale, scale));
 		/// <summary>Translate, Rotate, Scale. Creates a transform Matrix 
 		/// using all these components!</summary>
 		/// <param name="translation">Move an object by this amount.</param>
@@ -401,8 +436,8 @@ namespace StereoKit
 		/// shrink it to nothing!</param>
 		/// <returns>A Matrix that combines translation, rotation, and scale
 		/// information into a single Matrix!</returns>
-		public static Matrix TRS(Vec3 translation, Vec3 pitchYawRollDeg, Vec3 scale) 
-			=> NativeAPI.matrix_trs(translation, Quat.FromAngles(pitchYawRollDeg), scale);
+		public static Matrix TRS(Vec3 translation, Vec3 pitchYawRollDeg, Vec3 scale)
+			=> TRS(translation, Quat.FromAngles(pitchYawRollDeg), scale);
 
 		/// <summary>This creates a matrix used for projecting 3D geometry
 		/// onto a 2D surface for rasterization. Perspective projection 

--- a/StereoKit/Math/Vec2.cs
+++ b/StereoKit/Math/Vec2.cs
@@ -1,7 +1,7 @@
 ﻿// SPDX-License-Identifier: MIT
 // The authors below grant copyright rights under the MIT license:
-// Copyright (c) 2019-2024 Nick Klingensmith
-// Copyright (c) 2024 Qualcomm Technologies, Inc.
+// Copyright (c) 2019-2025 Nick Klingensmith
+// Copyright (c) 2024-2025 Qualcomm Technologies, Inc.
 
 using System;
 using System.Numerics;
@@ -121,6 +121,9 @@ namespace StereoKit
 		/// <summary>Promotes this Vec2 to a Vec3, using 0 for the Z axis.
 		/// </summary>
 		public Vec3 XY0 => new Vec3(x, y, 0);
+		/// <summary>Promotes this Vec2 to a Vec3, using 1 for the Z axis.
+		/// </summary>
+		public Vec3 XY1 => new Vec3(x, y, 1);
 		/// <summary>Promotes this Vec2 to a Vec3, using 0 for the Y axis.
 		/// </summary>
 		public Vec3 X0Y => new Vec3(x, 0, y);

--- a/StereoKit/Native/NativeAPI.cs
+++ b/StereoKit/Native/NativeAPI.cs
@@ -178,6 +178,7 @@ namespace StereoKit
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr tex_create_file_arr     (string[] files, int file_count, [MarshalAs(UnmanagedType.Bool)] bool srgb_data, int priority);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr tex_create_cubemap_file ([In] byte[] cubemap_file_utf8,  [MarshalAs(UnmanagedType.Bool)] bool srgb_data, int priority);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr tex_create_cubemap_files(string[] cube_face_file_xxyyzz, [MarshalAs(UnmanagedType.Bool)] bool srgb_data, int priority);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr tex_copy                (IntPtr texture, TexType type, TexFormat format);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   tex_set_id              (IntPtr texture, string id);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr tex_get_id              (IntPtr texture);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   tex_set_fallback        (IntPtr texture, IntPtr fallback);

--- a/StereoKit/Native/NativeEnums.cs
+++ b/StereoKit/Native/NativeEnums.cs
@@ -290,12 +290,16 @@ namespace StereoKit
 	public enum QuitReason {
 		/// <summary>Default state when SK has not quit.</summary>
 		None,
-		/// <summary>User has selected to quit the application using application controls.</summary>
+		/// <summary>The user (or possibly the OS) has explicitly asked to exit the
+		/// application under normal circumstances.</summary>
 		User,
-		/// <summary>Runtime Error SESSION_LOST</summary>
+		/// <summary>Some runtime error occurred, causing the application to quit
+		/// gracefully.</summary>
+		Error,
+		/// <summary>If initialization failed, StereoKit won't run to begin with!</summary>
+		InitializationFailed,
+		/// <summary>The runtime under StereoKit has encountered an issue and has been lost.</summary>
 		SessionLost,
-		/// <summary>User has closed the application from outside of the application.</summary>
-		SystemClose,
 	}
 
 	/// <summary>What type of user motion is the device capable of tracking? For the normal

--- a/StereoKit/Native/NativeTypes.cs
+++ b/StereoKit/Native/NativeTypes.cs
@@ -36,7 +36,7 @@ namespace StereoKit
 		/// <summary> The default log filtering level. This can be changed at
 		/// runtime, but this allows you to set the log filter before
 		/// Initialization occurs, so you can choose to get information from
-		/// that. Default is LogLevel.Info.</summary>
+		/// that. Default is LogLevel.Diagnostic.</summary>
 		public LogLevel     logFilter;
 		/// <summary>If the runtime supports it, should this application run
 		/// as an overlay above existing applications? Check

--- a/StereoKit/SK.cs
+++ b/StereoKit/SK.cs
@@ -110,7 +110,7 @@ namespace StereoKit
 		/// trailing '/' is unnecessary.</param>
 		/// <returns>Returns true if all systems are successfully 
 		/// initialized!</returns>
-		public static bool Initialize(string projectName = null, string assetsFolder = "")
+		public static bool Initialize(string projectName = null, string assetsFolder = null)
 			=> Initialize(new SKSettings{ appName = projectName, assetsFolder = assetsFolder });
 
 		/// <summary>If you need to call StereoKit code before calling

--- a/StereoKitC/asset_types/texture.cpp
+++ b/StereoKitC/asset_types/texture.cpp
@@ -673,6 +673,44 @@ tex_t tex_create_cubemap_files(const char **cube_face_file_xxyyzz, bool32_t srgb
 }
 
 ///////////////////////////////////////////
+
+tex_t tex_copy(const tex_t texture, tex_type_ type, tex_format_ format) {
+	tex_t result = tex_create(type, format == tex_format_none ? texture->format : format);
+	tex_set_color_arr_mips(result, texture->width, texture->height, nullptr, 1, skg_mip_count(texture->width, texture->height));
+
+	bool wants_mips = (type          & tex_type_mips) > 0;
+	bool has_mips   = (texture->type & tex_type_mips) > 0;
+	bool generate_mips = has_mips == false && wants_mips == true;
+
+	if (generate_mips) {
+		if (type & tex_type_rendertarget || backend_graphics_get() != backend_graphics_d3d11) {
+			skg_tex_copy_to (&texture->tex, 0, &result->tex, 0);
+			skg_tex_gen_mips(&result->tex);
+		} else {
+			// D3D11 needs a rendertarget to generate mips!
+			skg_tex_t intermediate = skg_tex_create(skg_tex_type_rendertarget, skg_use_static, result->tex.format, skg_mip_generate);
+			skg_tex_set_contents_arr(&intermediate, nullptr, texture->tex.array_count, skg_mip_count(texture->width, texture->height), texture->width, texture->height, 1);
+			skg_tex_copy_to (&texture->tex, 0, &intermediate, 0);
+			skg_tex_gen_mips(&intermediate);
+			skg_tex_copy_to (&intermediate, -1, &result->tex, -1);
+			skg_tex_destroy (&intermediate);
+		}
+	} else {
+		skg_tex_copy_to(&texture->tex, 0, &result->tex, 0);
+	}
+	return result;
+}
+
+///////////////////////////////////////////
+
+bool32_t tex_gen_mips(tex_t texture) {
+	if ((texture->type & tex_type_mips        ) == 0 ||
+		(texture->type & tex_type_rendertarget) == 0)
+		return false;
+	return false;
+}
+
+///////////////////////////////////////////
 // Texture manipulation functions        //
 ///////////////////////////////////////////
 

--- a/StereoKitC/stereokit.cpp
+++ b/StereoKitC/stereokit.cpp
@@ -147,8 +147,12 @@ bool32_t sk_init(sk_settings_t settings) {
 	rand_set_seed((uint32_t)stm_now());
 
 	local.initialized = stereokit_systems_register();
-	if (!local.initialized) log_show_any_fail_reason();
-	else                    log_clear_any_fail_reason();
+	if (!local.initialized) {
+		log_show_any_fail_reason();
+		sk_quit(quit_reason_initialization_failed);
+	} else {
+		log_clear_any_fail_reason();
+	}
 
 	local.app_system     = systems_find    ("App");
 	local.app_system_idx = systems_find_idx("App");
@@ -182,6 +186,7 @@ void sk_shutdown_unsafe(void) {
 	sk_mem_log_allocations();
 	log_clear_subscribers ();
 
+	// Persist the quit reason after everything has been shut down and cleared.
 	quit_reason_ temp_quit_reason = local.quit_reason;
 	local = {};
 	local.disallow_user_shutdown = true;
@@ -295,7 +300,7 @@ void sk_app_step() {
 
 void sk_quit(quit_reason_ quit_reason) {
 	local.quit_reason = quit_reason;
-	local.running = false;
+	local.running     = false;
 }
 
 ///////////////////////////////////////////

--- a/StereoKitC/stereokit.cpp
+++ b/StereoKitC/stereokit.cpp
@@ -86,8 +86,9 @@ bool32_t sk_init(sk_settings_t settings) {
 
 	local.settings    = settings;
 	local.init_thread = ft_id_current();
-	if (local.settings.log_filter != log_none)
-		log_set_filter(local.settings.log_filter);
+	log_set_filter(local.settings.log_filter != log_none
+		? local.settings.log_filter
+		: log_diagnostic);
 
 	// Manual positioning happens when _any_ of the flascreen positioning
 	// settings are set.

--- a/StereoKitC/stereokit.cpp
+++ b/StereoKitC/stereokit.cpp
@@ -99,6 +99,7 @@ bool32_t sk_init(sk_settings_t settings) {
 
 	// Set some default values
 	if (local.settings.app_name           == nullptr) local.settings.app_name           = "StereoKit App";
+	if (local.settings.assets_folder      == nullptr) local.settings.assets_folder      = "Assets";
 	if (local.settings.flatscreen_width   == 0      ) local.settings.flatscreen_width   = 1280;
 	if (local.settings.flatscreen_height  == 0      ) local.settings.flatscreen_height  = 720;
 	if (local.settings.render_scaling     == 0      ) local.settings.render_scaling     = 1;

--- a/StereoKitC/stereokit.h
+++ b/StereoKitC/stereokit.h
@@ -441,12 +441,16 @@ typedef struct system_info_t {
 typedef enum quit_reason_ {
 	/*Default state when SK has not quit.*/
 	quit_reason_none,
-	/*User has selected to quit the application using application controls.*/
+	/*The user (or possibly the OS) has explicitly asked to exit the
+	  application under normal circumstances.*/
 	quit_reason_user,
-	/* Runtime Error SESSION_LOST*/
+	/*Some runtime error occurred, causing the application to quit
+	  gracefully.*/
+	quit_reason_error,
+	/*If initialization failed, StereoKit won't run to begin with!*/
+	quit_reason_initialization_failed,
+	/*The runtime under StereoKit has encountered an issue and has been lost.*/
 	quit_reason_session_lost,
-	/* User has closed the application from outside of the application.*/
-	quit_reason_system_close,
 } quit_reason_;
 
 SK_API bool32_t      sk_init               (sk_settings_t settings);

--- a/StereoKitC/stereokit.h
+++ b/StereoKitC/stereokit.h
@@ -1067,6 +1067,8 @@ SK_API tex_t        tex_create_file         (const char *file_utf8,             
 SK_API tex_t        tex_create_file_arr     (const char **in_arr_files, int32_t file_count, bool32_t srgb_data sk_default(true), int32_t priority sk_default(10));
 SK_API tex_t        tex_create_cubemap_file (const char *cubemap_file_utf8,                 bool32_t srgb_data sk_default(true), int32_t priority sk_default(10));
 SK_API tex_t        tex_create_cubemap_files(const char **in_arr_cube_face_file_xxyyzz,     bool32_t srgb_data sk_default(true), int32_t priority sk_default(10));
+SK_API tex_t        tex_copy                (const tex_t texture, tex_type_ type sk_default(tex_type_image), tex_format_ format sk_default(tex_format_none));
+SK_API bool32_t     tex_gen_mips            (tex_t texture);
 SK_API void         tex_set_id              (tex_t texture, const char *id);
 SK_API const char*  tex_get_id              (const tex_t texture);
 SK_API void         tex_set_fallback        (tex_t texture, tex_t fallback);

--- a/StereoKitC/xr_backends/simulator.cpp
+++ b/StereoKitC/xr_backends/simulator.cpp
@@ -139,7 +139,7 @@ void simulator_step_begin() {
 		case platform_evt_mouse_press:  if (sk_app_focus() == app_focus_active) input_key_inject_press  (data.press_release); break;
 		case platform_evt_mouse_release:if (sk_app_focus() == app_focus_active) input_key_inject_release(data.press_release); break;
 		//case platform_evt_scroll:       if (sk_app_focus() == app_focus_active) win32_scroll += data.scroll;                  break;
-		case platform_evt_close:        sk_quit(quit_reason_system_close); break;
+		case platform_evt_close:        sk_quit(quit_reason_user); break;
 		case platform_evt_resize:       sim_surface_resize(sim_surface, data.resize.width, data.resize.height); break;
 		case platform_evt_none: break;
 		default: break;

--- a/StereoKitC/xr_backends/window.cpp
+++ b/StereoKitC/xr_backends/window.cpp
@@ -133,7 +133,7 @@ void window_step_begin() {
 		case platform_evt_character:    input_text_inject_char  (data.character);                                  break;
 		case platform_evt_mouse_press:  if (sk_app_focus() == app_focus_active) input_key_inject_press  (data.press_release); break;
 		case platform_evt_mouse_release:if (sk_app_focus() == app_focus_active) input_key_inject_release(data.press_release); break;
-		case platform_evt_close:        sk_quit(quit_reason_system_close); break;
+		case platform_evt_close:        sk_quit(quit_reason_user); break;
 		case platform_evt_resize:       window_surface_resize(local->surface, data.resize.width, data.resize.height); break;
 		case platform_evt_none: break;
 		default: break;


### PR DESCRIPTION
Adds samples for:
- StereoKit.Framework.Easing
- Hierarchy
- QuitReason
- Input.FingerGlow
- UI.Text
- Text.Size

Fixes and polish:
- GPU mip generation for DX11
- Added Tex.Copy
- QuitReason refined values and behavior
- Most Quat and Pose code works without SK initialization now
- SKSettings.assetFolder defaults to "Assets" when null (TODO: update template)
- Cleaned up Program.cs for StereoKitTest
- Pulled some manifest items from the AndroidXR docs (TODO: update template)