### PR TITLE
SK.Settings is now SK's internal copy of the settings.

### DIFF
--- a/StereoKit/Native/NativeAPI.cs
+++ b/StereoKit/Native/NativeAPI.cs
@@ -23,6 +23,7 @@ namespace StereoKit
 		[return: MarshalAs(UnmanagedType.Bool)]
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern bool        sk_is_stepping();
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern DisplayMode sk_active_display_mode();
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern SKSettings  sk_get_settings();
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern SystemInfo  sk_system_info();
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr      sk_version_name();
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern ulong       sk_version_id();

--- a/StereoKit/SK.cs
+++ b/StereoKit/SK.cs
@@ -17,9 +17,11 @@ namespace StereoKit
 
 		/// <summary>This is a copy of the settings that StereoKit was
 		/// initialized with, so you can refer back to them a little easier.
-		/// These are read only, and keep in mind that some settings are 
-		/// only requests! Check SK.System and other properties for the 
-		/// current state of StereoKit.</summary>
+		/// Some of these values will be different than provided, as StereoKit
+		/// will resolve some default values based on the platform capabilities
+		/// or internal preference. These are read only, and keep in mind that
+		/// some settings are only requests! Check SK.System and other
+		/// properties for the current state of StereoKit.</summary>
 		public static SKSettings Settings { get; private set; }
 		/// <summary>Has StereoKit been successfully initialized already? If
 		/// initialization was attempted and failed, this value will be 
@@ -147,11 +149,13 @@ namespace StereoKit
 				catch { settings.appName = "StereoKit App"; }
 			}
 
-			// DllImport finds the function at the beginning of the function 
-			// call, so this needs to be in a separate function from 
+			// DllImport finds the function at the beginning of the function
+			// call, so this needs to be in a separate function from
 			// NativeLib.LoadDll
 			bool result = NativeAPI.sk_init(settings);
-			Settings = settings;
+			// Get the "resolved" settings from StereoKit, so we pick up some
+			// of the final defaults or calculated settings.
+			Settings = NativeAPI.sk_get_settings();
 
 			// Get system information
 			if (result) { 


### PR DESCRIPTION
This fixes an issue in the tests where a file was being loaded with `SK.Settings.assetsFolder`, which had not been filled out with the correct default value yet.