### PR TITLE
Fixed an issue with setting `ModelNode.Material`.

### DIFF
--- a/Examples/StereoKitTest/Tests/TestNodes.cs
+++ b/Examples/StereoKitTest/Tests/TestNodes.cs
@@ -147,6 +147,8 @@ class TestNodes : ITest
 		ModelNode node2 = model.AddNode("New Node 2", Matrix.Identity, Mesh.Cube, Material.Default);
 		ModelNode node3 = model.AddNode("New Node 3", Matrix.Identity);
 
+		// This causes a Visual to be added to Node 1, where previously it had
+		// none.
 		node1.Material = Material.Default;
 		node1.Mesh     = Mesh.Cube;
 

--- a/Examples/StereoKitTest/Tests/TestNodes.cs
+++ b/Examples/StereoKitTest/Tests/TestNodes.cs
@@ -96,6 +96,7 @@ class TestNodes : ITest
 		Tests.Test(TestEmptyVisuals);
 		Tests.Test(TestEmptyModel);
 		Tests.Test(TestNodeInfo);
+		Tests.Test(TestAddNode);
 	}
 
 	bool TestEmptyVisuals()
@@ -135,6 +136,26 @@ class TestNodes : ITest
 			&& n.GetInfo("c") == null
 			&& n.GetInfo("d") == null
 			&& n.GetInfo("e") == null;
+	}
+
+	bool TestAddNode()
+	{
+		Model model = Model.FromFile("Radio.glb").Copy();
+		int count       = model.Nodes.Count;
+		int visualCount = model.Visuals.Count;
+		ModelNode node1 = model.AddNode("New Node 1", Matrix.Identity);
+		ModelNode node2 = model.AddNode("New Node 2", Matrix.Identity, Mesh.Cube, Material.Default);
+		ModelNode node3 = model.AddNode("New Node 3", Matrix.Identity);
+
+		node1.Material = Material.Default;
+		node1.Mesh     = Mesh.Cube;
+
+		Log.Info("Add nodes to existing:");
+		RecursiveTraversal(model.RootNode);
+
+		return
+			count       + 3 == model.Nodes  .Count &&
+			visualCount + 2 == model.Visuals.Count;
 	}
 
 	/// :CodeSample: Model Model.RootNode Model.Child Model.Sibling Model.Parent

--- a/StereoKitC/asset_types/model.cpp
+++ b/StereoKitC/asset_types/model.cpp
@@ -627,9 +627,10 @@ void model_node_set_material(model_t model, model_node_id node, material_t mater
 		vis = model->visuals.add({});
 		model->nodes[node].visual = vis;
 	}
-	assets_safeswap_ref(
-		(asset_header_t**)&model->visuals[vis].material,
-		(asset_header_t* )material);
+	material_t prev_material = model->visuals[vis].material;
+	model->visuals[vis].material = material;
+	material_addref (model->visuals[vis].material);
+	material_release(prev_material);
 }
 
 ///////////////////////////////////////////


### PR DESCRIPTION
Setting the Material of a ModelNode when no Material had previously been assigned would cause SK to try and release the previous material, using access patterns that would cause bad access errors. This should fix #1154!