### PR TITLE
Support for .NET 9 UWP projects

### DIFF
--- a/StereoKit/BuildStereoKitSDK.targets
+++ b/StereoKit/BuildStereoKitSDK.targets
@@ -16,8 +16,10 @@
 		<SKSDKBuildOS Condition="'$(TargetFrameworkIdentifier)'=='MonoAndroid'"                             >Android</SKSDKBuildOS>
 		<SKSDKBuildOS Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)'))=='android'">Android</SKSDKBuildOS>
 		<SKSDKBuildOS Condition="'$(SKSDKBuildOS)'=='' and '$(TargetPlatformIdentifier)'=='UAP'"            >Uwp</SKSDKBuildOS>
+		<SKSDKBuildOS Condition="'$(SKSDKBuildOS)'=='' and '$(UseUwp)'=='true'"                             >Uwp</SKSDKBuildOS>
 		<SKSDKBuildOS Condition="'$(SKSDKBuildOS)'=='' and '$(OS)'=='Windows_NT'"                           >Win32</SKSDKBuildOS>
 		<SKSDKBuildOS Condition="'$(SKSDKBuildOS)'=='' and '$(OS)'!='Windows_NT'"                           >Linux</SKSDKBuildOS>
+
 
 		<!-- Find what architecture we'll want to build. -->
 		<SKSDKBuildMode Condition="'$(SKSDKBuildMode)'=='' and '$(Platform)'=='AnyCPU' and '$(SKSDKBuildOS)'=='Android'">ARM64</SKSDKBuildMode>

--- a/StereoKit/StereoKit.targets
+++ b/StereoKit/StereoKit.targets
@@ -6,7 +6,7 @@
 
 	<!-- Copy the package's native libraries into the project, for those
 	     platforms that require it. -->
-	<Target Name="StereoKit_Libraries" BeforeTargets="AfterBuild" AfterTargets="StereoKit_Properties" Condition="'$(OutputType)'!='Library' or '$(SKBuildPlatform)'=='Android'">
+	<Target Name="StereoKit_Libraries" BeforeTargets="AfterBuild" AfterTargets="StereoKit_Properties" Condition="'$(OutputType)'!='Library' or '$(SKBuildPlatform)'=='Android' and '$(UseUwp)'!='true'">
 		<Message Importance="high" Text="[StereoKit NuGet] Copying native libraries for .NET $(SKBuildNET) $(SKBuildPlatform)."/>
 		<Message Importance="high" Condition= "'$(SKBuildPlatform)'=='Android'" Text="[StereoKit NuGet] Using the $(SKOpenXRLoader) &lt;SKOpenXRLoader&gt; version of the Android OpenXR loader."/>
 		<Error Condition="'$(SKBuildPlatform)'=='Android' and '$(SKOpenXRLoader)'!='None' and !Exists('$(MSBuildThisFileDirectory)../android_openxr_loaders/$(SKOpenXRLoader.ToLower())/arm64/libopenxr_loader.so') and !Exists('$(MSBuildThisFileDirectory)../android_openxr_loaders/$(SKOpenXRLoader.ToLower())/x64/libopenxr_loader.so') and !Exists('$(SKOpenXRLoaderFolder)$(SKOpenXRLoader)/arm64/libopenxr_loader.so') and !Exists('$(SKOpenXRLoaderFolder)$(SKOpenXRLoader)/x64/libopenxr_loader.so')" Text="StereoKit could not find the Android OpenXR Loader indicated by &lt;SKOpenXRLoader&gt;! Please copy your platform specific libopenxr_loader.so file in this folder: $(SKOpenXRLoaderFolder)$(SKOpenXRLoader)/[x64|arm64]/" />
@@ -45,6 +45,28 @@
 			DestinationFolder  = "$(OutputPath)"
 			SkipUnchangedFiles = "true"/>
 
+	</Target>
+
+	<!-- Shenanigans to get UWP working here -->
+	<Target Name="StereoKit_FixUWPBinaries" AfterTargets="ResolvePackageAssets" Condition="'$(UseUwp)'=='true'">
+		<Message Importance="High" Text="[StereoKit NuGet] Replacing StereoKit Win32 binaries with UWP versions." />
+		<!-- Immediately after package assets are picked, we insert ourselves and
+		     swap out the incorrect Win32 binaries that .NET selects for the UWP
+		     ones. .NET deprecated the RIDs necessary to distinguish properly
+		     between UWP and Win32, perhaps there's a better mechanism here, but
+		     this seems like it'll be alright. -->
+		<ItemGroup>
+			<NativeCopyLocalItems Remove="$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)..\runtimes\win-$(Platform)\native\StereoKitC.dll'))"/>
+			<NativeCopyLocalItems Remove="$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)..\runtimes\win-$(Platform)\native\StereoKitC.pdb'))"/>
+			<NativeCopyLocalItems
+				Include   = "$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)..\runtimes\win10-$(Platform)\nativeassets\uap10.0\StereoKitC.dll'))"
+				AssetType = "native"
+				CopyLocal = "true"/>
+			<NativeCopyLocalItems
+				Include   = "$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)..\runtimes\win10-$(Platform)\nativeassets\uap10.0\StereoKitC.pdb'))"
+				AssetType = "native"
+				CopyLocal = "true"/>
+		</ItemGroup>
 	</Target>
 
 	<!-- Link libraries directly in Xamarin and Maui Android projects. -->


### PR DESCRIPTION
This is all the necessary bits for enabling UWP on .NET 9! This work is derived largely from the sample in #1122, which was incredibly helpful for making this work!

Making a working template is another matter, but seems to be at least somewhat doable. With these modifications, I was able to build and run SK UWP apps on desktop as well as HoloLens 2. I was unable to deploy a project directly from Visual Studio, but was able to build an .msix that worked well on-device. Getting this right may involve some magic words in launchSettings.json, or perhaps the .csproj?

For the .csproj, I added `<SKCopyAssets>false</SKCopyAssets>` to avoid fighting with UWP's copying, and stored UWP assets in an `Assets/UWP` subfolder, and StereoKit assets in `Assets/`.

Will work on some template stuff for this more later!