### PR TITLE
Relax restriction on `ModelNode` Visuals always being valid.

### DIFF
--- a/Examples/StereoKitTest/Tests/TestNodes.cs
+++ b/Examples/StereoKitTest/Tests/TestNodes.cs
@@ -143,14 +143,13 @@ class TestNodes : ITest
 		Model model = Model.FromFile("Radio.glb").Copy();
 		int count       = model.Nodes.Count;
 		int visualCount = model.Visuals.Count;
-		ModelNode node1 = model.AddNode("New Node 1", Matrix.Identity);
-		ModelNode node2 = model.AddNode("New Node 2", Matrix.Identity, Mesh.Cube, Material.Default);
-		ModelNode node3 = model.AddNode("New Node 3", Matrix.Identity);
+		ModelNode node1 = model.AddNode("New Node", Matrix.Identity);
+		ModelNode node2 = model.AddNode("New Node", Matrix.Identity, Mesh.Cube, Material.Default);
+		ModelNode node3 = model.AddNode("New Node", Matrix.Identity);
 
 		// This causes a Visual to be added to Node 1, where previously it had
 		// none.
 		node1.Material = Material.Default;
-		node1.Mesh     = Mesh.Cube;
 
 		Log.Info("Add nodes to existing:");
 		RecursiveTraversal(model.RootNode);

--- a/StereoKitC/asset_types/mesh.cpp
+++ b/StereoKitC/asset_types/mesh.cpp
@@ -616,9 +616,14 @@ void mesh_draw(mesh_t mesh, material_t material, matrix transform, color128 colo
 
 ///////////////////////////////////////////
 
-bool32_t mesh_ray_intersect(mesh_t mesh, ray_t model_space_ray, cull_ cull_mode, ray_t *out_pt, uint32_t* out_start_inds) {
+bool32_t mesh_ray_intersect(mesh_t mesh, ray_t model_space_ray, cull_ cull_mode, ray_t *out_pt, uint32_t* out_opt_start_inds) {
+	*out_pt = {};
+	if (out_opt_start_inds) *out_opt_start_inds = 0;
+
 	vec3 result = {};
 
+	if (mesh == nullptr)
+		return false;
 	const mesh_collision_t *data = mesh_get_collision_data(mesh);
 	if (data == nullptr)
 		return false;
@@ -679,11 +684,9 @@ bool32_t mesh_ray_intersect(mesh_t mesh, ray_t model_space_ray, cull_ cull_mode,
 		// Check if point is in triangle
 		if ((u >= 0) && (v >= 0) && (u + v < 1)) {
 			float dist = vec3_magnitude_sq(pt - model_space_ray.pos);
-			if (dist < nearest_dist) {
+			if (nearest_dist > dist) {
 				nearest_dist = dist;
-				if (out_start_inds != nullptr) {
-					*out_start_inds = i;
-				}
+				if (out_opt_start_inds) *out_opt_start_inds = i;
 				*out_pt = {pt, data->planes[i / 3].normal};
 			}
 		}

--- a/StereoKitC/asset_types/model.cpp
+++ b/StereoKitC/asset_types/model.cpp
@@ -62,8 +62,9 @@ model_t model_copy(model_t model) {
 	result->nodes_used   = model->nodes_used;
 	result->anim_inst.anim_id = -1;
 	for (int32_t i = 0; i < result->visuals.count; i++) {
-		material_addref(result->visuals[i].material);
-		mesh_addref    (result->visuals[i].mesh);
+		model_visual_t* vis = &result->visuals[i];
+		if (vis->material) material_addref(vis->material);
+		if (vis->mesh    ) mesh_addref    (vis->mesh);
 	}
 	for (int32_t i = 0; i < result->nodes.count; i++) {
 		result->nodes[i].name = string_copy(result->nodes[i].name);
@@ -73,11 +74,13 @@ model_t model_copy(model_t model) {
 	// the original meshes, not the active, modified meshes.
 	if (model->anim_inst.skinned_meshes != nullptr) {
 		for (int32_t i = 0; i < model->anim_inst.skinned_mesh_count; i++) {
-			model_node_id node   = model->anim_data.skeletons[i].skin_node;
-			int32_t       visual = result->nodes[node].visual;
-			assets_safeswap_ref(
-				(asset_header_t**)&result->visuals[visual].mesh,
-				(asset_header_t* ) model ->anim_inst.skinned_meshes[i].original_mesh);
+			model_node_id   node = model->anim_data.skeletons[i].skin_node;
+			model_visual_t* vis  = &result->visuals[result->nodes[node].visual];
+
+			mesh_t old_mesh = vis->mesh;
+			vis->mesh = model->anim_inst.skinned_meshes[i].original_mesh;
+			mesh_addref (vis->mesh);
+			mesh_release(old_mesh);
 		}
 	}
 	result->anim_data = anim_data_copy(&model->anim_data);
@@ -147,22 +150,21 @@ model_t model_create_file(const char *filename, shader_t shader) {
 
 void model_recalculate_bounds(model_t model) {
 	model->bounds_dirty = false;
-	if (model->visuals.count <= 0) {
-		model->bounds = {};
-		return;
-	}
-	
-	// Get an initial size
-	vec3 first_corner = bounds_corner(mesh_get_bounds(model->visuals[0].mesh), 0);
-	vec3 min, max;
-	min = max = matrix_transform_pt( model->visuals[0].transform_model, first_corner);
-	
+
+	vec3 min = {  FLT_MAX,  FLT_MAX,  FLT_MAX };
+	vec3 max = { -FLT_MAX, -FLT_MAX, -FLT_MAX };
+	bool has_bounds = false;
+
 	// Find the corners for each bounding cube, and factor them in!
 	for (int32_t m = 0; m < model->visuals.count; m += 1) {
-		bounds_t bounds = mesh_get_bounds(model->visuals[m].mesh);
+		const model_visual_t* vis = &model->visuals[m];
+		if (vis->mesh == nullptr) continue;
+		has_bounds = true;
+
+		bounds_t bounds = mesh_get_bounds(vis->mesh);
 		for (int32_t i = 0; i < 8; i += 1) {
 			vec3 corner = bounds_corner      (bounds, i);
-			vec3 pt     = matrix_transform_pt(model->visuals[m].transform_model, corner);
+			vec3 pt     = matrix_transform_pt(vis->transform_model, corner);
 			min.x = fminf(pt.x, min.x);
 			min.y = fminf(pt.y, min.y);
 			min.z = fminf(pt.z, min.z);
@@ -174,31 +176,30 @@ void model_recalculate_bounds(model_t model) {
 	}
 	
 	// Final bounds value
-	model->bounds = bounds_t{ min / 2 + max / 2, max - min };
+	model->bounds = has_bounds
+		? bounds_t{ min / 2 + max / 2, max - min }
+		: bounds_t{ };
 }
 
 ///////////////////////////////////////////
 
 void model_recalculate_bounds_exact(model_t model) {
 	model->bounds_dirty = false;
-	if (model->visuals.count <= 0) {
-		model->bounds = {};
-		return;
-	}
 
-	// Get an initial size
-	vec3 first_corner = model->visuals[0].mesh->verts != nullptr
-		? model->visuals[0].mesh->verts[0].pos
-		: bounds_corner(model->visuals[0].mesh->bounds, 0);
-
-	vec3     minf = matrix_transform_pt( model->visuals[0].transform_model, first_corner);
-	XMVECTOR min  = XMLoadFloat3((XMFLOAT3*)&minf);
-	XMVECTOR max  = XMLoadFloat3((XMFLOAT3*)&minf);
+	XMFLOAT3 xmmin = {  FLT_MAX,   FLT_MAX,   FLT_MAX };
+	XMFLOAT3 xmmax = { -FLT_MAX,  -FLT_MAX,  -FLT_MAX };
+	XMVECTOR min   = XMLoadFloat3(&xmmin);
+	XMVECTOR max   = XMLoadFloat3(&xmmax);
+	bool has_bounds = false;
 
 	// Use all the transformed vertices, and factor them in!
 	for (int32_t m = 0; m < model->visuals.count; m += 1) {
-		XMMATRIX      transform_model = XMLoadFloat4x4((XMFLOAT4X4*)&model->visuals[m].transform_model.row);
-		const mesh_t  mesh            = model->visuals[m].mesh;
+		const model_visual_t* vis = &model->visuals[m];
+		if (vis->mesh == nullptr) continue;
+		has_bounds = true;
+
+		XMMATRIX      transform_model = XMLoadFloat4x4((XMFLOAT4X4*)&vis->transform_model.row);
+		const mesh_t  mesh            = vis->mesh;
 		const vert_t* verts           = mesh->verts;
 
 		if (verts != nullptr) {
@@ -220,12 +221,15 @@ void model_recalculate_bounds_exact(model_t model) {
 	}
 
 	// Final bounds value
+	if (has_bounds) {
+		XMVECTOR center     = XMVectorMultiplyAdd(min, g_XMOneHalf, XMVectorMultiply(max, g_XMOneHalf));
+		XMVECTOR dimensions = XMVectorSubtract   (max, min);
 
-	XMVECTOR center     = XMVectorMultiplyAdd(min, g_XMOneHalf, XMVectorMultiply(max, g_XMOneHalf));
-	XMVECTOR dimensions = XMVectorSubtract   (max, min);
-
-	XMStoreFloat3((XMFLOAT3*)&(model->bounds.center),     center);
-	XMStoreFloat3((XMFLOAT3*)&(model->bounds.dimensions), dimensions);
+		XMStoreFloat3((XMFLOAT3*)&(model->bounds.center),     center);
+		XMStoreFloat3((XMFLOAT3*)&(model->bounds.dimensions), dimensions);
+	} else {
+		model->bounds = bounds_t{ };
+	}
 }
 
 ///////////////////////////////////////////
@@ -273,15 +277,16 @@ bounds_t model_get_bounds(model_t model) {
 ///////////////////////////////////////////
 
 bool32_t model_ray_intersect(model_t model, ray_t model_space_ray, cull_ cull_mode, ray_t *out_pt) {
+	*out_pt = {};
+
 	vec3 bounds_at;
 	if (!bounds_ray_intersect(model->bounds, model_space_ray, &bounds_at))
 		return false;
 
 	float closest = FLT_MAX;
-	*out_pt = {};
 	for (int32_t i = 0; i < model->nodes.count; i++) {
-		model_node_t *n = &model->nodes[i];
-		if (!n->solid || n->visual == -1)
+		const model_node_t *n = &model->nodes[i];
+		if (!n->solid || n->visual == -1 || model->visuals[n->visual].mesh == nullptr)
 			continue;
 
 		matrix inverse   = matrix_invert(n->transform_model);
@@ -289,7 +294,7 @@ bool32_t model_ray_intersect(model_t model, ray_t model_space_ray, cull_ cull_mo
 		ray_t  at;
 		if (mesh_ray_intersect(model->visuals[n->visual].mesh, local_ray, cull_mode, &at, nullptr)) {
 			float d = vec3_distance_sq(local_ray.pos, at.pos);
-			if (d < closest) {
+			if (closest > d) {
 				closest = d;
 				*out_pt = matrix_transform_ray(n->transform_model, at);
 			}
@@ -301,15 +306,16 @@ bool32_t model_ray_intersect(model_t model, ray_t model_space_ray, cull_ cull_mo
 ///////////////////////////////////////////
 
 bool32_t model_ray_intersect_bvh(model_t model, ray_t model_space_ray, cull_ cull_mode, ray_t *out_pt) {
+	*out_pt = {};
+
 	vec3 bounds_at;
 	if (!bounds_ray_intersect(model->bounds, model_space_ray, &bounds_at))
 		return false;
 
 	float closest = FLT_MAX;
-	*out_pt = {};
 	for (int32_t i = 0; i < model->nodes.count; i++) {
-		model_node_t *n = &model->nodes[i];
-		if (!n->solid || n->visual == -1)
+		const model_node_t *n = &model->nodes[i];
+		if (!n->solid || n->visual == -1 || model->visuals[n->visual].mesh == nullptr)
 			continue;
 
 		matrix inverse   = matrix_invert(n->transform_model);
@@ -317,7 +323,7 @@ bool32_t model_ray_intersect_bvh(model_t model, ray_t model_space_ray, cull_ cul
 		ray_t  at;
 		if (mesh_ray_intersect_bvh(model->visuals[n->visual].mesh, local_ray, cull_mode, &at, nullptr)) {
 			float d = vec3_distance_sq(local_ray.pos, at.pos);
-			if (d < closest) {
+			if (closest > d) {
 				closest = d;
 				*out_pt = matrix_transform_ray(n->transform_model, at);
 			}
@@ -329,31 +335,33 @@ bool32_t model_ray_intersect_bvh(model_t model, ray_t model_space_ray, cull_ cul
 ///////////////////////////////////////////
 
 // Same as model_ray_intersect_bvh, but returns mesh, mesh transform and start index if intersection found
-bool32_t model_ray_intersect_bvh_detailed(model_t model, ray_t model_space_ray, cull_ cull_mode, ray_t *out_pt, mesh_t *out_mesh, matrix *out_matrix, uint32_t* out_start_inds) {
+bool32_t model_ray_intersect_bvh_detailed(model_t model, ray_t model_space_ray, cull_ cull_mode, ray_t *out_pt, mesh_t *out_opt_mesh, matrix *out_opt_matrix, uint32_t* out_opt_start_inds) {
+	*out_pt = {};
+	if (out_opt_mesh      ) *out_opt_mesh       = nullptr;
+	if (out_opt_matrix    ) *out_opt_matrix     = {};
+	if (out_opt_start_inds) *out_opt_start_inds = 0;
+
 	vec3 bounds_at;
 	if (!bounds_ray_intersect(model->bounds, model_space_ray, &bounds_at))
 		return false;
 
 	float closest = FLT_MAX;
-	*out_pt = {};
 	for (int32_t i = 0; i < model->nodes.count; i++) {
-		model_node_t *n = &model->nodes[i];
-		if (!n->solid || n->visual == -1)
+		const model_node_t *n = &model->nodes[i];
+		if (!n->solid || n->visual == -1 || model->visuals[n->visual].mesh == nullptr)
 			continue;
 
-		matrix inverse   = matrix_invert(n->transform_model);
-		ray_t  local_ray = matrix_transform_ray(inverse, model_space_ray);
-		ray_t  at;
+		matrix   inverse   = matrix_invert(n->transform_model);
+		ray_t    local_ray = matrix_transform_ray(inverse, model_space_ray);
+		ray_t    at;
 		uint32_t local_start_inds;
 		if (mesh_ray_intersect_bvh(model->visuals[n->visual].mesh, local_ray, cull_mode , &at, &local_start_inds)) {
 			float d = vec3_distance_sq(local_ray.pos, at.pos);
-			if (d < closest) {
+			if (closest > d) {
 				closest = d;
-				if (out_mesh != nullptr && out_start_inds != nullptr) {
-					*out_mesh = model->visuals[n->visual].mesh;
-					*out_matrix = n->transform_model;
-					*out_start_inds = local_start_inds;
-				}
+				if (out_opt_mesh      ) *out_opt_mesh       = model->visuals[n->visual].mesh;
+				if (out_opt_start_inds) *out_opt_start_inds = local_start_inds;
+				if (out_opt_matrix    ) *out_opt_matrix     = n->transform_model;
 				*out_pt = matrix_transform_ray(n->transform_model, at);
 			}
 		}
@@ -388,12 +396,6 @@ model_node_id model_node_add(model_t model, const char *name, matrix transform, 
 ///////////////////////////////////////////
 
 model_node_id model_node_add_child(model_t model, model_node_id parent, const char *name, matrix local_transform, mesh_t mesh, material_t material, bool32_t solid) {
-	if ((mesh != nullptr && material == nullptr) ||
-		(mesh == nullptr && material != nullptr)) {
-		log_err("model_node_add_child: mesh and material must either both be null, or neither be null!");
-		return -1;
-	}
-
 	model_node_id node_id = (model_node_id)model->nodes.count;
 	char          tmp_name[32];
 	if (name == nullptr) {
@@ -431,9 +433,9 @@ model_node_id model_node_add_child(model_t model, model_node_id parent, const ch
 		node.transform_model = local_transform;
 	}
 
-	if (mesh != nullptr) {
-		material_addref(material);
-		mesh_addref    (mesh);
+	if (mesh != nullptr || material != nullptr) {
+		if (material) material_addref(material);
+		if (mesh    ) mesh_addref    (mesh);
 
 		model_visual_t visual = {};
 		visual.material        = material;
@@ -442,9 +444,11 @@ model_node_id model_node_add_child(model_t model, model_node_id parent, const ch
 		visual.node            = node_id;
 		visual.visible         = true;
 		node.visual = model->visuals.add(visual);
-		model->bounds = model->visuals.count == 1
-			? bounds_transform(mesh_get_bounds(mesh), node.transform_model)
-			: bounds_grow_to_fit_box(model->bounds, mesh_get_bounds(mesh), &node.transform_model);
+		if (mesh) {
+			model->bounds = model->visuals.count == 1
+				? bounds_transform(mesh_get_bounds(mesh), node.transform_model)
+				: bounds_grow_to_fit_box(model->bounds, mesh_get_bounds(mesh), &node.transform_model);
+		}
 	}
 
 	model->nodes.add(node);
@@ -561,7 +565,7 @@ bool32_t model_node_get_visible(model_t model, model_node_id node) {
 
 material_t  model_node_get_material(model_t model, model_node_id node) {
 	int32_t vis = model->nodes[node].visual;
-	if (vis < 0) {
+	if (vis < 0 || model->visuals[vis].material == nullptr) {
 		return nullptr;
 	} else {
 		material_addref(model->visuals[vis].material);
@@ -573,7 +577,7 @@ material_t  model_node_get_material(model_t model, model_node_id node) {
 
 mesh_t model_node_get_mesh(model_t model, model_node_id node) {
 	int32_t vis = model->nodes[node].visual;
-	if (vis < 0) {
+	if (vis < 0 || model->visuals[vis].mesh == nullptr) {
 		return nullptr;
 	} else {
 		mesh_addref(model->visuals[vis].mesh);
@@ -624,12 +628,15 @@ void model_node_set_visible(model_t model, model_node_id node, bool32_t visible)
 void model_node_set_material(model_t model, model_node_id node, material_t material) {
 	int32_t vis = model->nodes[node].visual;
 	if (vis < 0) {
+		if (material == nullptr) return;
+
 		vis = model->visuals.add({});
 		model->nodes[node].visual = vis;
 	}
 	material_t prev_material = model->visuals[vis].material;
 	model->visuals[vis].material = material;
-	material_addref (model->visuals[vis].material);
+	if (material)
+		material_addref(material);
 	material_release(prev_material);
 }
 
@@ -638,13 +645,16 @@ void model_node_set_material(model_t model, model_node_id node, material_t mater
 void model_node_set_mesh(model_t model, model_node_id node, mesh_t mesh) {
 	int32_t vis = model->nodes[node].visual;
 	if (vis < 0) {
+		if (mesh == nullptr) return;
+
 		vis = model->visuals.add({});
 		model->nodes[node].visual = vis;
 	}
 	mesh_t prev_mesh = model->visuals[vis].mesh;
 	model->visuals[vis].mesh = mesh;
 	model->bounds_dirty = true;
-	mesh_addref (model->visuals[vis].mesh);
+	if (mesh)
+		mesh_addref(mesh);
 	mesh_release(prev_mesh);
 }
 

--- a/StereoKitC/log.cpp
+++ b/StereoKitC/log.cpp
@@ -94,6 +94,8 @@ void log_platform_output(log_ level, const char* text);
 ///////////////////////////////////////////
 
 int32_t log_count_color_tags(const char* ch, int32_t *out_len) {
+	if (ch == nullptr) return 0;
+
 	*out_len = 0;
 	int32_t tags = 0;
 	int32_t curr = 0;
@@ -376,6 +378,8 @@ void log_set_name(const char* name) {
 ///////////////////////////////////////////
 
 void log_platform_output(log_ level, const char *text) {
+	if (text == nullptr) text = "(null)";
+
 #if defined(SK_OS_ANDROID)
 	if (log_opened == false) {
 		log_opened = true;

--- a/StereoKitC/stereokit.h
+++ b/StereoKitC/stereokit.h
@@ -834,7 +834,7 @@ SK_API bounds_t    mesh_get_bounds      (mesh_t mesh);
 SK_API bool32_t    mesh_has_skin        (mesh_t mesh);
 SK_API void        mesh_set_skin        (mesh_t mesh, const uint16_t *in_arr_bone_ids_4, int32_t bone_id_4_count, const vec4 *in_arr_bone_weights, int32_t bone_weight_count, const matrix *bone_resting_transforms, int32_t bone_count);
 SK_API void        mesh_update_skin     (mesh_t mesh, const matrix *in_arr_bone_transforms, int32_t bone_count);
-SK_API bool32_t    mesh_ray_intersect    (mesh_t mesh, ray_t model_space_ray, cull_ cull_mode, ray_t* out_pt, uint32_t* out_start_inds sk_default(nullptr));
+SK_API bool32_t    mesh_ray_intersect    (mesh_t mesh, ray_t model_space_ray, cull_ cull_mode, ray_t* out_pt, uint32_t* out_opt_start_inds sk_default(nullptr));
 SK_API bool32_t    mesh_ray_intersect_bvh(mesh_t mesh, ray_t model_space_ray, cull_ cull_mode, ray_t* out_pt, uint32_t* out_start_inds sk_default(nullptr));
 SK_API bool32_t    mesh_get_triangle     (mesh_t mesh, uint32_t triangle_index, vert_t* out_a, vert_t* out_b, vert_t* out_c);
 
@@ -1456,7 +1456,7 @@ SK_API void          model_set_bounds              (model_t model, const sk_ref(
 SK_API bounds_t      model_get_bounds              (model_t model);
 SK_API bool32_t      model_ray_intersect             (model_t model, ray_t model_space_ray, cull_ cull_mode, ray_t* out_pt);
 SK_API bool32_t      model_ray_intersect_bvh         (model_t model, ray_t model_space_ray, cull_ cull_mode, ray_t* out_pt);
-SK_API bool32_t      model_ray_intersect_bvh_detailed(model_t model, ray_t model_space_ray, cull_ cull_mode, ray_t* out_pt, mesh_t *out_mesh sk_default(nullptr), matrix *out_matrix sk_default(nullptr), uint32_t* out_start_inds sk_default(nullptr));
+SK_API bool32_t      model_ray_intersect_bvh_detailed(model_t model, ray_t model_space_ray, cull_ cull_mode, ray_t* out_pt, mesh_t *out_opt_mesh sk_default(nullptr), matrix *out_opt_matrix sk_default(nullptr), uint32_t* out_opt_start_inds sk_default(nullptr));
 
 SK_API void          model_step_anim               (model_t model);
 SK_API bool32_t      model_play_anim               (model_t model, const char *animation_name, anim_mode_ mode);

--- a/StereoKitC/systems/render.cpp
+++ b/StereoKitC/systems/render.cpp
@@ -1494,7 +1494,7 @@ void render_list_add_model_mat(render_list_t list, model_t model, material_t mat
 	anim_update_model(model);
 	for (int32_t i = 0; i < model->visuals.count; i++) {
 		const model_visual_t *vis = &model->visuals[i];
-		if (vis->visible == false) continue;
+		if (vis->visible == false || vis->mesh == nullptr || vis->material == nullptr) continue;
 		
 		render_item_t item;
 		item.mesh      = vis->mesh;


### PR DESCRIPTION
For #1154. `ModelNode` Visuals had a requirement where they _must_ have both a `Material` and `Mesh`. This was enforced during creation of the `ModelNode`, however, calling `ModelNode.Material = X;` on a `ModelNode` without a pre-existing Visual element would cause a Visual to be created, without any way to immediately specify a corresponding `Mesh`. This would mean that it was trivial to get into an invalid state when using the `Mesh`/`Material` setters.

The only solution that didn't seem to include a collection of strange behaviors was relaxing the requirement for `ModelNode` Visuals to be in a valid state, so this restriction is now removed. Now, if a Visual is missing a `Mesh` or `Material`, it simply does not draw.

This PR includes a bunch of defensive checks to account for the looser requirements, as well as some light refactoring in related methods.