### PR TITLE
MSBuild hooks to generate .cs bindings to HLSL files.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -217,8 +217,8 @@ add_compile_definitions(BASISD_SUPPORT_BC7_MODE5=0)
 
 #### sk_gpu - https://github.com/StereoKit/sk_gpu ####
 CPMAddPackage( # We're scraping the comment after the NAME for some other scripts
-  NAME sk_gpu # 2025.1.22
-  URL https://github.com/StereoKit/sk_gpu/releases/download/v2025.1.22/sk_gpu.v2025.1.22.zip
+  NAME sk_gpu # 2025.2.11
+  URL https://github.com/StereoKit/sk_gpu/releases/download/v2025.2.11/sk_gpu.v2025.2.11.zip
 )
 # For building directly with in-progress sk_gpu changes, point this to your
 # local sk_gpu clone, and use it instead of CPM.

--- a/Examples/StereoKitTest/StereoKitTest_NetAndroid/StereoKitTest_NetAndroid.csproj
+++ b/Examples/StereoKitTest/StereoKitTest_NetAndroid/StereoKitTest_NetAndroid.csproj
@@ -13,6 +13,7 @@
 		<SKOpenXRLoaderFolder Condition="'$(OS)'=='Windows_NT'">C:/Tools/openxr_loaders/</SKOpenXRLoaderFolder>
 		<SKOpenXRLoader>Standard</SKOpenXRLoader>
 		<SKAssetFolder>..\..\Assets</SKAssetFolder>
+		<SKShaderCodeFolder>..\</SKShaderCodeFolder>
 		<SKAssetDestination>Assets</SKAssetDestination>
 		<SKShowDebugVars>true</SKShowDebugVars>
 		

--- a/Examples/StereoKitTest/StereoKitTest_NetUWP/StereoKitTest_NetUWP.csproj
+++ b/Examples/StereoKitTest/StereoKitTest_NetUWP/StereoKitTest_NetUWP.csproj
@@ -16,6 +16,7 @@
 
 		<SKCopyAssets>true</SKCopyAssets>
 		<SKAssetFolder>..\..\Assets</SKAssetFolder>
+		<SKShaderCodeFolder>..\</SKShaderCodeFolder>
 		<SKAssetDestination>Assets</SKAssetDestination>
 		<SKShowDebugVars>true</SKShowDebugVars>
 

--- a/StereoKit/SKShaders.targets
+++ b/StereoKit/SKShaders.targets
@@ -20,6 +20,7 @@
 		<SKShadercExe Condition="$([MSBuild]::IsOSPlatform('Windows'))">skshaderc\win32_$(PlatformArch)\skshaderc.exe</SKShadercExe>
 		<SKShadercExe Condition="$([MSBuild]::IsOSPlatform('Linux'))"  >skshaderc/linux_$(PlatformArch)/skshaderc</SKShadercExe>
 		<SKShadercExe Condition="$([MSBuild]::IsOSPlatform('OSX'))"    >skshaderc/mac/skshaderc</SKShadercExe>
+		<SKShadercPath>$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)../tools/$(SKShadercExe)'))</SKShadercPath>
 		<SKAutoFindShaders Condition="'$(SKAutoFindShaders)' == ''">True</SKAutoFindShaders>
 	</PropertyGroup>
 
@@ -51,7 +52,7 @@
 		<!-- Setup metadata for custom build tool -->
 		<ItemGroup>
 			<SKShader Condition="'%(SKShader.RelFile)'!=''">
-				<Command>"$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)../tools/$(SKShadercExe)'))" $(SKOpt) -e -t xge -i "$(IncludeFolderNormalized)" -o "$([System.String]::Copy('$(IntermediateOutputPath)$(SKAssetDestination)/%(SKShader.RelFolder)').Replace('\','/'))" "%(SKShader.Identity)"</Command>
+				<Command>$(SKShadercPath) $(SKOpt) -e -t xe -i "$(IncludeFolderNormalized)" -o "$([System.String]::Copy('$(IntermediateOutputPath)$(SKAssetDestination)/%(SKShader.RelFolder)').Replace('\','/'))" "%(SKShader.Identity)"</Command>
 				<Outputs>$(IntermediateOutputPath)$(SKAssetDestination)/%(SKShader.RelFile).sks</Outputs>
 				<RelativeName>%(SKShader.RelFile).sks</RelativeName>
 			</SKShader>
@@ -74,4 +75,46 @@
 			<SKContent Include="$(IntermediateOutputPath)$(SKAssetDestination)/**/*.sks" />
 		</ItemGroup>
 	</Target>
+
+	<!-- Shader C# code generation -->
+	
+	<!-- Collect shader files that should be treated like code. -->
+	<ItemGroup Condition="'$(SKBuildShaderCode)' == 'true'">
+		<SKShaderCode Include="$(SKShaderCodeFolder)**/*.hlsl" Exclude="**/bin/**;**/obj/**;**/$(SKAssetFolder)/**"/>
+
+		<Compile Update="@(SKShaderCode->'$(IntermediateOutputPath)Shaders\Material%(Filename).gen.cs')">
+			<DependentUpon>%(SKShaderCode.Filename)%(SKShaderCode.Extension)</DependentUpon>
+			<AutoGen>true</AutoGen>
+			<DesignTimeSharedInput>true</DesignTimeSharedInput>
+			<Link>Material%(SKShaderCode.Filename).gen.cs</Link>
+			<Visible>true</Visible>
+		</Compile>
+	</ItemGroup>
+
+	<!-- Compile the shaders ang generate the C# in the /obj/ folder -->
+	<Target Name="StereoKit_Shader_Code" Condition="'$(SKBuildShaderCode)' == 'true'" BeforeTargets="BeforeCompile" Inputs="@(SKShaderCode)" Outputs="@(SKShaderCode->'$(IntermediateOutputPath)Shaders\Material%(Filename).generated.cs')">
+		<Message Text="[StereoKit NuGet] Generating C# for %(SKShaderCode.Identity) -> $(IntermediateOutputPath)Shaders\Material%(SKShaderCode.Filename).gen.cs" Importance="high" />
+
+		<Exec Command='$(SKShadercPath) $(SKOpt) -e -sk -t xe -i "$(IncludeFolderNormalized)" "%(SKShaderCode.Identity)" -o "$(IntermediateOutputPath)Shaders\Material%(SKShaderCode.Filename).gen.cs"'></Exec>
+
+		<!-- Insert generated files into the Compile list.
+		     We also attempt to nest them under the corresponding .hlsl file,
+		     however, this doesn't appear to work when the linked files are in the
+		     /obj folder. -->
+		<ItemGroup>
+			<Compile Remove ="$(IntermediateOutputPath)Shaders\Material%(SKShaderCode.Filename).gen.cs"/>
+			<Compile Include="$(IntermediateOutputPath)Shaders\Material%(SKShaderCode.Filename).gen.cs" KeepDuplicates="false">
+				<DependentUpon>%(SKShaderCode.Filename)%(SKShaderCode.Extension)</DependentUpon>
+				<AutoGen>true</AutoGen>
+				<DesignTimeSharedInput>true</DesignTimeSharedInput>
+				<Link>Material%(SKShaderCode.Filename).gen.cs</Link>
+				<Visible>true</Visible>
+			</Compile>
+		</ItemGroup>
+	</Target>
+
+	<Target Name="StereoKit_Shader_Code_Rebuild" Condition="'$(SKBuildShaderCode)' == 'true'" AfterTargets="CoreClean">
+		<Delete Files="@(SKShaderCode->'$(IntermediateOutputPath)Shaders\Material%(Filename).gen.cs')" />
+	</Target>
+
 </Project>

--- a/StereoKit/StereoKit.props
+++ b/StereoKit/StereoKit.props
@@ -6,12 +6,14 @@
 		<SKOpenXRLoader          Condition="'$(SKOpenXRLoader)'          == ''">Standard</SKOpenXRLoader>
 		<SKShowDebugVars         Condition="'$(SKShowDebugVars)'         == ''">false</SKShowDebugVars>
 		<SKAutoFindShaders       Condition="'$(SKAutoFindShaders)'       == ''">True</SKAutoFindShaders>
+		<SKShaderCodeFolder      Condition="'$(SKShaderCodeFolder)'      == ''"></SKShaderCodeFolder>
+		<SKBuildShaderCode       Condition="'$(SKBuildShaderCode)'       == ''">true</SKBuildShaderCode>
 		<SKOpenXRLoaderFolder    Condition="'$(SKOpenXRLoaderFolder)'    == ''">$(ProjectDir)openxr_loader/</SKOpenXRLoaderFolder>
 		<SKShaderStandardInclude Condition="'$(SKShaderStandardInclude)' == ''">$(MSBuildThisFileDirectory)../tools/include/</SKShaderStandardInclude>
 		<SKCopyAssets            Condition="'$(SKCopyAssets)'	== '' and '$(UseUwp)'=='true'">false</SKCopyAssets>
 		<SKCopyAssets            Condition="'$(SKCopyAssets)'	== '' and '$(UseUwp)'!='true'">true</SKCopyAssets>
 	</PropertyGroup>
-	
+
 	<Target Name="StereoKit_Properties" BeforeTargets="BeforeBuild">
 		<PropertyGroup>
 			<!--These variables are not populated outside of Targets-->
@@ -25,8 +27,9 @@
 			<SKBuildNET Condition="'$(TargetFrameworkIdentifier)'=='.NETFramework'">Framework</SKBuildNET>
 			<SKBuildNET Condition="'$(TargetPlatformIdentifier)'=='UAP'"           >UWP</SKBuildNET>
 
-			<SKOpenXRLoaderFolder>$([MSBuild]::EnsureTrailingSlash($([MSBuild]::NormalizePath('$(SKOpenXRLoaderFolder)'))))</SKOpenXRLoaderFolder>
-			<SKShaderStandardInclude>$([MSBuild]::EnsureTrailingSlash($([MSBuild]::NormalizePath('$(SKShaderStandardInclude)'))))</SKShaderStandardInclude>
+			<SKOpenXRLoaderFolder    Condition="'$(SKOpenXRLoaderFolder)'   !=''">$([MSBuild]::EnsureTrailingSlash($([MSBuild]::NormalizePath('$(SKOpenXRLoaderFolder)'))))</SKOpenXRLoaderFolder>
+			<SKShaderStandardInclude Condition="'$(SKShaderStandardInclude)'!=''">$([MSBuild]::EnsureTrailingSlash($([MSBuild]::NormalizePath('$(SKShaderStandardInclude)'))))</SKShaderStandardInclude>
+			<SKShaderCodeFolder      Condition="'$(SKShaderCodeFolder)'     !=''">$([MSBuild]::EnsureTrailingSlash($([MSBuild]::NormalizePath('$(SKShaderCodeFolder)'))))</SKShaderCodeFolder>
 		</PropertyGroup>
 
 		<Message Condition="'$(SKShowDebugVars)'=='true'" Importance="high" Text="[StereoKit NuGet] ____StereoKit MSBuild Variables____"/>
@@ -34,6 +37,8 @@
 		<Message Condition="'$(SKShowDebugVars)'=='true'" Importance="high" Text="[StereoKit NuGet] SKAssetDestination         : $(SKAssetDestination)"/>
 		<Message Condition="'$(SKShowDebugVars)'=='true'" Importance="high" Text="[StereoKit NuGet] SKCopyAssets               : $(SKCopyAssets)"/>
 		<Message Condition="'$(SKShowDebugVars)'=='true'" Importance="high" Text="[StereoKit NuGet] SKAutoFindShaders          : $(SKAutoFindShaders)"/>
+		<Message Condition="'$(SKShowDebugVars)'=='true'" Importance="high" Text="[StereoKit NuGet] SKBuildShaderCode          : $(SKBuildShaderCode)"/>
+		<Message Condition="'$(SKShowDebugVars)'=='true'" Importance="high" Text="[StereoKit NuGet] SKShaderCodeFolder         : $(SKShaderCodeFolder)"/>
 		<Message Condition="'$(SKShowDebugVars)'=='true'" Importance="high" Text="[StereoKit NuGet] SKShadercExe               : $(SKShadercExe)"/>
 		<Message Condition="'$(SKShowDebugVars)'=='true'" Importance="high" Text="[StereoKit NuGet] SKShaderStandardInclude    : $(SKShaderStandardInclude)"/>
 		<Message Condition="'$(SKShowDebugVars)'=='true'" Importance="high" Text="[StereoKit NuGet] SKOpenXRLoader             : $(SKOpenXRLoader)"/>


### PR DESCRIPTION
.hlsl files that are included in the project and _not_ in the /Assets folder will now compile to bytes and be embedded in C# bindings to that shader! This generated code will go in the /obj folder, but will be linked into the project.

For example, `Floor.hlsl` will auto-generate a class `MaterialFloor` that inherits from `Material`, and exposes properties for each global var in the shader. You can then do this:

```csharp
MaterialFloor mat = new();
mat.Radius = new Vec4(5, 10, 0, 0);

Mesh.Cube.Draw(mat, Matrix.Identity);
```
For comparison, you can still use shaders from in the /Assets folder as before, which looks like this:
```csharp
Material mat = new Material(Shader.FromFile("Floor.hlsl"));
floorMat["radius"] = new Vec4(5, 10, 0, 0);

Mesh.Cube.Draw(mat, Matrix.Identity);
```

This helps provide stronger, safer typing.