### PR TITLE
Simplify and disable shader binding for now.

### DIFF
--- a/StereoKit/SKShaders.targets
+++ b/StereoKit/SKShaders.targets
@@ -77,44 +77,23 @@
 	</Target>
 
 	<!-- Shader C# code generation -->
-	
-	<!-- Collect shader files that should be treated like code. -->
-	<ItemGroup Condition="'$(SKBuildShaderCode)' == 'true'">
-		<SKShaderCode Include="$(SKShaderCodeFolder)**/*.hlsl" Exclude="**/bin/**;**/obj/**;**/$(SKAssetFolder)/**"/>
 
-		<Compile Update="@(SKShaderCode->'$(IntermediateOutputPath)Shaders\Material%(Filename).gen.cs')">
-			<DependentUpon>%(SKShaderCode.Filename)%(SKShaderCode.Extension)</DependentUpon>
-			<AutoGen>true</AutoGen>
-			<DesignTimeSharedInput>true</DesignTimeSharedInput>
-			<Link>Material%(SKShaderCode.Filename).gen.cs</Link>
-			<Visible>true</Visible>
-		</Compile>
+	<!-- Collect shader files that should be treated like code. -->
+	<ItemGroup>
+		<SKShaderCode Condition="'$(SKBuildShaderCode)'=='true'" Include="$(SKShaderCodeFolder)**/*.hlsl" Exclude="**/bin/**;**/obj/**;**/$(SKAssetFolder)/**"/>
+		
+		<Compile Include="@(SKShaderCode->'$(IntermediateOutputPath)Shaders\Material%(Filename).gen.cs')" KeepDuplicates="false" />
 	</ItemGroup>
 
-	<!-- Compile the shaders ang generate the C# in the /obj/ folder -->
-	<Target Name="StereoKit_Shader_Code" Condition="'$(SKBuildShaderCode)' == 'true'" BeforeTargets="BeforeCompile" Inputs="@(SKShaderCode)" Outputs="@(SKShaderCode->'$(IntermediateOutputPath)Shaders\Material%(Filename).generated.cs')">
+	<!-- Compile the shaders and generate the C# in the /obj/ folder -->
+	<Target Name="StereoKit_Shader_Code" BeforeTargets="BeforeCompile" Inputs="@(SKShaderCode->'%(FullPath)')" Outputs="@(SKShaderCode->'$(IntermediateOutputPath)Shaders\Material%(Filename).gen.cs')">
 		<Message Text="[StereoKit NuGet] Generating C# for %(SKShaderCode.Identity) -> $(IntermediateOutputPath)Shaders\Material%(SKShaderCode.Filename).gen.cs" Importance="high" />
 
 		<Exec Command='$(SKShadercPath) $(SKOpt) -e -sk -t xe -i "$(IncludeFolderNormalized)" "%(SKShaderCode.Identity)" -o "$(IntermediateOutputPath)Shaders\Material%(SKShaderCode.Filename).gen.cs"'></Exec>
 
-		<!-- Insert generated files into the Compile list.
-		     We also attempt to nest them under the corresponding .hlsl file,
-		     however, this doesn't appear to work when the linked files are in the
-		     /obj folder. -->
 		<ItemGroup>
-			<Compile Remove ="$(IntermediateOutputPath)Shaders\Material%(SKShaderCode.Filename).gen.cs"/>
-			<Compile Include="$(IntermediateOutputPath)Shaders\Material%(SKShaderCode.Filename).gen.cs" KeepDuplicates="false">
-				<DependentUpon>%(SKShaderCode.Filename)%(SKShaderCode.Extension)</DependentUpon>
-				<AutoGen>true</AutoGen>
-				<DesignTimeSharedInput>true</DesignTimeSharedInput>
-				<Link>Material%(SKShaderCode.Filename).gen.cs</Link>
-				<Visible>true</Visible>
-			</Compile>
+			<Compile Include="$(IntermediateOutputPath)Shaders\Material%(SKShaderCode.Filename).gen.cs" KeepDuplicates="false" />
 		</ItemGroup>
-	</Target>
-
-	<Target Name="StereoKit_Shader_Code_Rebuild" Condition="'$(SKBuildShaderCode)' == 'true'" AfterTargets="CoreClean">
-		<Delete Files="@(SKShaderCode->'$(IntermediateOutputPath)Shaders\Material%(Filename).gen.cs')" />
 	</Target>
 
 </Project>

--- a/StereoKit/StereoKit.props
+++ b/StereoKit/StereoKit.props
@@ -7,7 +7,7 @@
 		<SKShowDebugVars         Condition="'$(SKShowDebugVars)'         == ''">false</SKShowDebugVars>
 		<SKAutoFindShaders       Condition="'$(SKAutoFindShaders)'       == ''">True</SKAutoFindShaders>
 		<SKShaderCodeFolder      Condition="'$(SKShaderCodeFolder)'      == ''"></SKShaderCodeFolder>
-		<SKBuildShaderCode       Condition="'$(SKBuildShaderCode)'       == ''">true</SKBuildShaderCode>
+		<SKBuildShaderCode       Condition="'$(SKBuildShaderCode)'       == ''">false</SKBuildShaderCode>
 		<SKOpenXRLoaderFolder    Condition="'$(SKOpenXRLoaderFolder)'    == ''">$(ProjectDir)openxr_loader/</SKOpenXRLoaderFolder>
 		<SKShaderStandardInclude Condition="'$(SKShaderStandardInclude)' == ''">$(MSBuildThisFileDirectory)../tools/include/</SKShaderStandardInclude>
 		<SKCopyAssets            Condition="'$(SKCopyAssets)'	== '' and '$(UseUwp)'=='true'">false</SKCopyAssets>


### PR DESCRIPTION
Shader binding feature doesn't seem to allow for triggering builds from shader changes, resulting in outdated shaders and confusing dev experience. I've been unable to resolve why just yet, but since this is generating actual code, I've decided to disable it for this release.

MSBuild properly detects when shader files are changed, and properly rebuilds! However, Visual Studio has a separate Fast Up To Date Check system that decides if files have been changed, and is failing to identifying the shader files for some unknown reason. So MSBuild never actually gets a chance to execute.

Setting `SKBuildShaderCode` to `true` or manually adding items to the `SKShaderCode` can still trigger the binding feature.