### PR TITLE
Fix for SKCopyAssets dependency on UseUwp

### DIFF
--- a/StereoKit/StereoKit.props
+++ b/StereoKit/StereoKit.props
@@ -10,8 +10,6 @@
 		<SKBuildShaderCode       Condition="'$(SKBuildShaderCode)'       == ''">false</SKBuildShaderCode>
 		<SKOpenXRLoaderFolder    Condition="'$(SKOpenXRLoaderFolder)'    == ''">$(ProjectDir)openxr_loader/</SKOpenXRLoaderFolder>
 		<SKShaderStandardInclude Condition="'$(SKShaderStandardInclude)' == ''">$(MSBuildThisFileDirectory)../tools/include/</SKShaderStandardInclude>
-		<SKCopyAssets            Condition="'$(SKCopyAssets)'	== '' and '$(UseUwp)'=='true'">false</SKCopyAssets>
-		<SKCopyAssets            Condition="'$(SKCopyAssets)'	== '' and '$(UseUwp)'!='true'">true</SKCopyAssets>
 	</PropertyGroup>
 
 	<Target Name="StereoKit_Properties" BeforeTargets="BeforeBuild">
@@ -26,6 +24,9 @@
 			<SKBuildNET Condition="'$(TargetFrameworkIdentifier)'=='MonoAndroid'"  >Mono</SKBuildNET>
 			<SKBuildNET Condition="'$(TargetFrameworkIdentifier)'=='.NETFramework'">Framework</SKBuildNET>
 			<SKBuildNET Condition="'$(TargetPlatformIdentifier)'=='UAP'"           >UWP</SKBuildNET>
+
+			<SKCopyAssets            Condition="'$(SKCopyAssets)' == '' and '$(UseUwp)'=='true'">false</SKCopyAssets>
+			<SKCopyAssets            Condition="'$(SKCopyAssets)' == '' and '$(UseUwp)'!='true'">true</SKCopyAssets>
 
 			<SKOpenXRLoaderFolder    Condition="'$(SKOpenXRLoaderFolder)'   !=''">$([MSBuild]::EnsureTrailingSlash($([MSBuild]::NormalizePath('$(SKOpenXRLoaderFolder)'))))</SKOpenXRLoaderFolder>
 			<SKShaderStandardInclude Condition="'$(SKShaderStandardInclude)'!=''">$([MSBuild]::EnsureTrailingSlash($([MSBuild]::NormalizePath('$(SKShaderStandardInclude)'))))</SKShaderStandardInclude>


### PR DESCRIPTION
As discussed in #1122, SK's asset copy should be disabled by default in UWP .NET projects, and the previous attempt didn't seem to do this correctly. This change should allow the SK NuGet package to work in UWP Blank CoreApplication App projects more or less out-of-the-box.