### PR TITLE
Fixed shader bind enough to turn it on

### DIFF
--- a/StereoKit/SKShaders.targets
+++ b/StereoKit/SKShaders.targets
@@ -43,7 +43,7 @@
 		<PropertyGroup>
 			<SKOpt Condition="'$(Configuration)'=='Release'">-o3</SKOpt>
 			<SKOpt Condition="'$(Configuration)'=='Debug'">-d</SKOpt>
-			
+
 			<!-- Needs to be normalized for Linux, also a trailing '\' will act
 			     as an escape character for quotes. -->
 			<IncludeFolderNormalized>$([MSBuild]::NormalizeDirectory('$(SKShaderStandardInclude)').TrimEnd('\'))</IncludeFolderNormalized>
@@ -81,18 +81,32 @@
 	<!-- Collect shader files that should be treated like code. -->
 	<ItemGroup>
 		<SKShaderCode Condition="'$(SKBuildShaderCode)'=='true'" Include="$(SKShaderCodeFolder)**/*.hlsl" Exclude="**/bin/**;**/obj/**;**/$(SKAssetFolder)/**"/>
-		
-		<Compile Include="@(SKShaderCode->'$(IntermediateOutputPath)Shaders\Material%(Filename).gen.cs')" KeepDuplicates="false" />
+		<UpToDateCheckInput Include="@(SKShaderCode)"/>
+
+		<Compile Include="@(SKShaderCode->'$(IntermediateOutputPath)%(RecursiveDir)Material%(Filename).gen.cs')" KeepDuplicates="false">
+			<DependentUpon>@(SKShaderCode->'%(Identity)')</DependentUpon>
+			<AutoGen>true</AutoGen>
+			<DesignTimeSharedInput>true</DesignTimeSharedInput>
+			<Visible>true</Visible>
+			<Link>@(SKShaderCode->'%(RecursiveDir)Material%(Filename).gen.cs')</Link>
+		</Compile>
 	</ItemGroup>
 
 	<!-- Compile the shaders and generate the C# in the /obj/ folder -->
-	<Target Name="StereoKit_Shader_Code" BeforeTargets="BeforeCompile" Inputs="@(SKShaderCode->'%(FullPath)')" Outputs="@(SKShaderCode->'$(IntermediateOutputPath)Shaders\Material%(Filename).gen.cs')">
-		<Message Text="[StereoKit NuGet] Generating C# for %(SKShaderCode.Identity) -> $(IntermediateOutputPath)Shaders\Material%(SKShaderCode.Filename).gen.cs" Importance="high" />
+	<Target Name="StereoKit_Shader_Code" BeforeTargets="BeforeCompile" Inputs="@(SKShaderCode->'%(FullPath)')" Outputs="@(SKShaderCode->'$(IntermediateOutputPath)%(RecursiveDir)Material%(Filename).gen.cs')">
+		<Message Text="[StereoKit NuGet] Generating C# for %(SKShaderCode.Identity) -> $(IntermediateOutputPath)%(SKShaderCode.RecursiveDir)Material%(SKShaderCode.Filename).gen.cs" Importance="high" />
 
-		<Exec Command='$(SKShadercPath) $(SKOpt) -e -sk -t xe -i "$(IncludeFolderNormalized)" "%(SKShaderCode.Identity)" -o "$(IntermediateOutputPath)Shaders\Material%(SKShaderCode.Filename).gen.cs"'></Exec>
+		<Exec Command='$(SKShadercPath) $(SKOpt) -e -sk -t xe -i "$(IncludeFolderNormalized)" "%(SKShaderCode.Identity)" -o "$(IntermediateOutputPath)%(SKShaderCode.RecursiveDir)Material%(SKShaderCode.Filename).gen.cs"'></Exec>
 
 		<ItemGroup>
-			<Compile Include="$(IntermediateOutputPath)Shaders\Material%(SKShaderCode.Filename).gen.cs" KeepDuplicates="false" />
+			<Compile Remove ="@(SKShaderCode->'$(IntermediateOutputPath)%(RecursiveDir)Material%(Filename).gen.cs')"/>
+			<Compile Include="@(SKShaderCode->'$(IntermediateOutputPath)%(RecursiveDir)Material%(Filename).gen.cs')" KeepDuplicates="false">
+				<DependentUpon>@(SKShaderCode->'%(Identity)')</DependentUpon>
+				<AutoGen>true</AutoGen>
+				<DesignTimeSharedInput>true</DesignTimeSharedInput>
+				<Visible>true</Visible>
+				<Link>@(SKShaderCode->'%(RecursiveDir)Material%(Filename).gen.cs')</Link>
+			</Compile>
 		</ItemGroup>
 	</Target>
 

--- a/StereoKit/StereoKit.props
+++ b/StereoKit/StereoKit.props
@@ -7,7 +7,7 @@
 		<SKShowDebugVars         Condition="'$(SKShowDebugVars)'         == ''">false</SKShowDebugVars>
 		<SKAutoFindShaders       Condition="'$(SKAutoFindShaders)'       == ''">True</SKAutoFindShaders>
 		<SKShaderCodeFolder      Condition="'$(SKShaderCodeFolder)'      == ''"></SKShaderCodeFolder>
-		<SKBuildShaderCode       Condition="'$(SKBuildShaderCode)'       == ''">false</SKBuildShaderCode>
+		<SKBuildShaderCode       Condition="'$(SKBuildShaderCode)'       == ''">true</SKBuildShaderCode>
 		<SKOpenXRLoaderFolder    Condition="'$(SKOpenXRLoaderFolder)'    == ''">$(ProjectDir)openxr_loader/</SKOpenXRLoaderFolder>
 		<SKShaderStandardInclude Condition="'$(SKShaderStandardInclude)' == ''">$(MSBuildThisFileDirectory)../tools/include/</SKShaderStandardInclude>
 	</PropertyGroup>


### PR DESCRIPTION
- `UpToDateCheckInput` seems to work well enough to prevent skipping updates on change!
- Also used a different syntax for determining file paths that seems to work properly in context.
- Added support for shaders nested in folders.

There still seems to be some weird behavior related to generated files not always visually nesting, as well as when moving files around.