### PR TITLE
GL array textures (temp)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -217,8 +217,8 @@ add_compile_definitions(BASISD_SUPPORT_BC7_MODE5=0)
 
 #### sk_gpu - https://github.com/StereoKit/sk_gpu ####
 CPMAddPackage( # We're scraping the comment after the NAME for some other scripts
-  NAME sk_gpu # 2025.2.11
-  URL https://github.com/StereoKit/sk_gpu/releases/download/v2025.2.11/sk_gpu.v2025.2.11.zip
+  NAME sk_gpu # 2025.2.28
+  URL https://github.com/StereoKit/sk_gpu/releases/download/v2025.2.28/sk_gpu.v2025.2.28.zip
 )
 # For building directly with in-progress sk_gpu changes, point this to your
 # local sk_gpu clone, and use it instead of CPM.

--- a/StereoKitC/xr_backends/openxr_view.cpp
+++ b/StereoKitC/xr_backends/openxr_view.cpp
@@ -466,11 +466,11 @@ bool openxr_display_swapchain_update(device_display_t *display) {
 	int32_t array_count  = display->view_cap;
 	int32_t quilt_width  = 1;
 	int32_t quilt_height = 1;
-#if defined(SKG_OPENGL)
+/*#if defined(SKG_OPENGL)
 	array_count  = 1;
 	quilt_width  = display->view_cap;
 	quilt_height = 1;
-#endif
+#endif*/
 	w = w * quilt_width;
 	h = h * quilt_height;
 


### PR DESCRIPTION
This temporarily switches GL platforms back to array textures.
This build will not properly support MSAA on GL platforms, as `GL_EXT_multisampled_render_to_texture` does not work with array textures.