### PR TITLE
Multiview for GL (breaking)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -217,8 +217,8 @@ add_compile_definitions(BASISD_SUPPORT_BC7_MODE5=0)
 
 #### sk_gpu - https://github.com/StereoKit/sk_gpu ####
 CPMAddPackage( # We're scraping the comment after the NAME for some other scripts
-  NAME sk_gpu # 2025.2.28
-  URL https://github.com/StereoKit/sk_gpu/releases/download/v2025.2.28/sk_gpu.v2025.2.28.zip
+  NAME sk_gpu # 2025.3.11
+  URL https://github.com/StereoKit/sk_gpu/releases/download/v2025.3.11/sk_gpu.v2025.3.11.zip
 )
 # For building directly with in-progress sk_gpu changes, point this to your
 # local sk_gpu clone, and use it instead of CPM.

--- a/Examples/Assets/Shaders/floor_shader.hlsl
+++ b/Examples/Assets/Shaders/floor_shader.hlsl
@@ -8,19 +8,18 @@ float4 radius;
 struct vsIn {
 	float4 pos : SV_POSITION;
 };
-struct psIn {
+struct psIn : sk_ps_input_t {
 	float4 pos   : SV_POSITION;
 	float4 world : TEXCOORD0;
-	uint view_id : SV_RenderTargetArrayIndex;
 };
 
-psIn vs(vsIn input, uint id : SV_InstanceID) {
+psIn vs(vsIn input, sk_vs_input_t sk_in) {
 	psIn o;
-	o.view_id = id % sk_view_count;
-	id        = id / sk_view_count;
+	uint view_id = sk_view_init(sk_in, o);
+	uint id      = sk_inst_id  (sk_in);
 
 	o.world = mul(input.pos, sk_inst[id].world);
-	o.pos   = mul(o.world,   sk_viewproj[o.view_id]);
+	o.pos   = mul(o.world,   sk_viewproj[view_id]);
 
 	return o;
 }

--- a/Examples/Assets/edged_quadrant.hlsl
+++ b/Examples/Assets/edged_quadrant.hlsl
@@ -11,7 +11,7 @@ struct vsIn {
 	float2 quadrant : TEXCOORD0;
 	float4 color    : COLOR0;
 };
-struct psIn {
+struct psIn : sk_ps_input_t {
 	float4 pos        : SV_Position;
 	float3 normal     : NORMAL0;
 	float4 light_edge : COLOR0;
@@ -19,13 +19,12 @@ struct psIn {
 	float4 world      : TEXCOORD0;
 	float  alpha      : TEXCOORD1;
 	float  glow_mask  : TEXCOORD2;
-	uint   view_id : SV_RenderTargetArrayIndex;
 };
 
-psIn vs(vsIn input, uint id : SV_InstanceID) {
+psIn vs(vsIn input, sk_vs_input_t sk_in) {
 	psIn o;
-	o.view_id = id % sk_view_count;
-	id        = id / sk_view_count;
+	uint view_id = sk_view_init(sk_in, o);
+	uint id      = sk_inst_id  (sk_in);
 	
 	// Extract scale from the matrix
 	float4x4 world_mat = sk_inst[id].world;
@@ -43,7 +42,7 @@ psIn vs(vsIn input, uint id : SV_InstanceID) {
 	sized_pos.zw = input.pos.zw;
 
 	o.world  = mul(sized_pos, world_mat);
-	o.pos    = mul(o.world, sk_viewproj[o.view_id]);
+	o.pos    = mul(o.world, sk_viewproj[view_id]);
 	o.normal = normalize(mul(input.norm, (float3x3)world_mat));
 
 	o.inst_col       = sk_inst[id].color;

--- a/Examples/Assets/holographic_quadrant.hlsl
+++ b/Examples/Assets/holographic_quadrant.hlsl
@@ -11,7 +11,7 @@ struct vsIn {
 	float2 quadrant : TEXCOORD0;
 	float4 color    : COLOR0;
 };
-struct psIn {
+struct psIn : sk_ps_input_t {
 	float4 pos        : SV_Position;
 	float3 normal     : NORMAL0;
 	float4 light_edge : COLOR0;
@@ -19,14 +19,15 @@ struct psIn {
 	float4 world      : TEXCOORD0;
 	float  alpha      : TEXCOORD1;
 	float  glow_mask  : TEXCOORD2;
-	uint   view_id : SV_RenderTargetArrayIndex;
+	uint   view_id    : TEXCOORD3;
 };
 
-psIn vs(vsIn input, uint id : SV_InstanceID) {
+psIn vs(vsIn input, sk_vs_input_t sk_in) {
 	psIn o;
-	o.view_id = id % sk_view_count;
-	id        = id / sk_view_count;
-	
+	uint view_id = sk_view_init(sk_in, o);
+	uint id      = sk_inst_id  (sk_in);
+	o.view_id = view_id;
+
 	// Extract scale from the matrix
 	float4x4 world_mat = sk_inst[id].world;
 	float2   scale     = float2(
@@ -43,7 +44,7 @@ psIn vs(vsIn input, uint id : SV_InstanceID) {
 	sized_pos.zw = input.pos.zw;
 
 	o.world  = mul(sized_pos, world_mat);
-	o.pos    = mul(o.world, sk_viewproj[o.view_id]);
+	o.pos    = mul(o.world, sk_viewproj[view_id]);
 	o.normal = normalize(mul(input.norm, (float3x3)world_mat));
 
 	o.inst_col       = sk_inst[id].color;

--- a/Examples/Assets/inflatable.hlsl
+++ b/Examples/Assets/inflatable.hlsl
@@ -16,22 +16,21 @@ struct vsIn {
 	float2 uv   : TEXCOORD0;
 	float4 col  : COLOR0;
 };
-struct psIn {
+struct psIn : sk_ps_input_t {
 	float4 pos   : SV_POSITION;
 	float2 uv    : TEXCOORD0;
 	float4 color : COLOR0;
-	uint view_id : SV_RenderTargetArrayIndex;
 };
 
-psIn vs(vsIn input, uint id : SV_InstanceID) {
+psIn vs(vsIn input, sk_vs_input_t sk_in) {
 	psIn o;
-	o.view_id = id % sk_view_count;
-	id        = id / sk_view_count;
+	uint view_id = sk_view_init(sk_in, o);
+	uint id      = sk_inst_id  (sk_in);
 
 	float3 world  = mul(float4(input.pos.xyz, 1), sk_inst[id].world).xyz;
 	float3 normal = mul(input.norm, (float3x3)sk_inst[id].world);
 	world += normal * inflate;
-	o.pos = mul(float4(world, 1), sk_viewproj[o.view_id]);
+	o.pos = mul(float4(world, 1), sk_viewproj[view_id]);
 
 	o.uv    = input.uv;
 	o.color = input.col * color * sk_inst[id].color; 

--- a/Examples/Assets/interactable.hlsl
+++ b/Examples/Assets/interactable.hlsl
@@ -16,19 +16,18 @@ struct vsIn {
 	float2 uv   : TEXCOORD0;
 	float4 col  : COLOR0;
 };
-struct psIn {
+struct psIn : sk_ps_input_t {
 	float4 pos       : SV_POSITION;
 	float3 world_pos : TEXCOORD0;
 	float3 model_pos : TEXCOORD1;
 	half3  normal    : NORMAL0;
 	half4  color     : COLOR0;
-	uint view_id : SV_RenderTargetArrayIndex;
 };
 
-psIn vs(vsIn input, uint id : SV_InstanceID) {
+psIn vs(vsIn input, sk_vs_input_t sk_in) {
 	psIn o;
-	o.view_id = id % sk_view_count;
-	id        = id / sk_view_count;
+	uint view_id = sk_view_init(sk_in, o);
+	uint id      = sk_inst_id  (sk_in);
 
 	float4x4 world_mat = sk_inst[id].world;
 	float3   scale     = float3(
@@ -38,7 +37,7 @@ psIn vs(vsIn input, uint id : SV_InstanceID) {
 		
 	o.model_pos = input.pos.xyz * scale;
 	o.world_pos = mul(float4(input.pos.xyz, 1), world_mat).xyz;
-	o.pos       = mul(float4(o.world_pos,   1), sk_viewproj[o.view_id]);
+	o.pos       = mul(float4(o.world_pos,   1), sk_viewproj[view_id]);
 	o.color     = input.col * color * sk_inst[id].color;
 	o.normal    = input.norm;
 	return o;

--- a/Examples/Assets/matrix_param.hlsl
+++ b/Examples/Assets/matrix_param.hlsl
@@ -20,20 +20,19 @@ struct vsIn {
 	float2 uv   : TEXCOORD0;
 	float4 col  : COLOR0;
 };
-struct psIn {
+struct psIn : sk_ps_input_t {
 	float4 pos   : SV_POSITION;
 	float2 uv    : TEXCOORD0;
 	float4 color : COLOR0;
-	uint view_id : SV_RenderTargetArrayIndex;
 };
 
-psIn vs(vsIn input, uint id : SV_InstanceID) {
+psIn vs(vsIn input, sk_vs_input_t sk_in) {
 	psIn o;
-	o.view_id = id % sk_view_count;
-	id        = id / sk_view_count;
+	uint view_id = sk_view_init(sk_in, o);
+	uint id      = sk_inst_id  (sk_in);
 
 	float3 world = mul(float4(input.pos.xyz, 1), custom_transform).xyz;
-	o.pos        = mul(float4(world,         1), sk_viewproj[o.view_id]);
+	o.pos        = mul(float4(world,         1), sk_viewproj[view_id]);
 
 	o.uv    = input.uv;
 	o.color = input.col * color * sk_inst[id].color;

--- a/Examples/Assets/point_cloud.hlsl
+++ b/Examples/Assets/point_cloud.hlsl
@@ -13,28 +13,27 @@ struct vsIn {
 	float2 off  : TEXCOORD0;
 	float4 color: COLOR0;
 };
-struct psIn {
+struct psIn : sk_ps_input_t {
 	float4 pos   : SV_POSITION;
 	float2 uv    : TEXCOORD0;
 	float4 color : COLOR0;
-	uint view_id : SV_RenderTargetArrayIndex;
 };
 
-psIn vs(vsIn input, uint id : SV_InstanceID) {
+psIn vs(vsIn input, sk_vs_input_t sk_in) {
 	psIn o;
-	o.view_id = id % sk_view_count;
-	id        = id / sk_view_count;
+	uint view_id = sk_view_init(sk_in, o);
+	uint id      = sk_inst_id  (sk_in);
 
 	float4 world = mul(input.pos, sk_inst[id].world);
-	float4 view  = mul(world, sk_view[o.view_id]);
+	float4 view  = mul(world, sk_view[view_id]);
 	if (screen_size <= 0.1)
 		view.xy = point_size * input.off + view.xy;
-	o.pos        = mul(view, sk_proj[o.view_id]); 
+	o.pos        = mul(view, sk_proj[view_id]); 
 	o.uv         = input.off + 0.5;
 	o.color      = input.color;
 
 	if (screen_size > 0.1) {
-		float  aspect = sk_proj[o.view_id]._m11 / sk_proj[o.view_id]._m00;
+		float  aspect = sk_proj[view_id]._m11 / sk_proj[view_id]._m00;
 		o.pos.xy = ( point_size * input.off / float2(aspect,1) ) *o.pos.w + o.pos.xy;
 	}
 

--- a/Examples/Assets/shader_arrays.hlsl
+++ b/Examples/Assets/shader_arrays.hlsl
@@ -16,20 +16,19 @@ struct vsIn {
 	float2 uv   : TEXCOORD0;
 	float4 col  : COLOR0;
 };
-struct psIn {
+struct psIn : sk_ps_input_t {
 	float4 pos   : SV_POSITION;
 	float2 uv    : TEXCOORD0;
 	float4 color : COLOR0;
-	uint view_id : SV_RenderTargetArrayIndex;
 };
 
-psIn vs(vsIn input, uint id : SV_InstanceID) {
+psIn vs(vsIn input, sk_vs_input_t sk_in) {
 	psIn o;
-	o.view_id = id % sk_view_count;
-	id        = id / sk_view_count;
+	uint view_id = sk_view_init(sk_in, o);
+	uint id      = sk_inst_id  (sk_in);
 
 	float4 world = mul(input.pos, sk_inst[id].world);
-	o.pos        = mul(world,     sk_viewproj[o.view_id]);
+	o.pos        = mul(world,     sk_viewproj[view_id]);
 
 	o.uv    = input.uv + offsets[((uint)(sk_time*4))%10].xy;
 	o.color = input.col * color * sk_inst[id].color;

--- a/Examples/Assets/shader_param_types.hlsl
+++ b/Examples/Assets/shader_param_types.hlsl
@@ -27,20 +27,19 @@ struct vsIn {
 	float2 uv   : TEXCOORD0;
 	float4 col  : COLOR0;
 };
-struct psIn {
+struct psIn : sk_ps_input_t {
 	float4 pos   : SV_POSITION;
 	float2 uv    : TEXCOORD0;
 	float4 color : COLOR0;
-	uint view_id : SV_RenderTargetArrayIndex;
 };
 
-psIn vs(vsIn input, uint id : SV_InstanceID) {
+psIn vs(vsIn input, sk_vs_input_t sk_in) {
 	psIn o;
-	o.view_id = id % sk_view_count;
-	id        = id / sk_view_count;
+	uint view_id = sk_view_init(sk_in, o);
+	uint id      = sk_inst_id  (sk_in);
 
 	float4 world = mul(input.pos, sk_inst[id].world);
-	o.pos        = mul(world,     sk_viewproj[o.view_id]);
+	o.pos        = mul(world,     sk_viewproj[view_id]);
 
 	o.uv    = input.uv;
 	o.color = input.col * color * sk_inst[id].color;

--- a/Examples/StereoKitCTest/Shaders/blit.hlsl
+++ b/Examples/StereoKitCTest/Shaders/blit.hlsl
@@ -1,19 +1,11 @@
+#include "stereokit.hlsli"
+
 //--name = app/blit
 //--source = white
 
 Texture2D    source   : register(t0);
 SamplerState source_s : register(s0);
 
-cbuffer GlobalBuffer : register(b1) {
-	float4x4 sk_view[2];
-	float4x4 sk_proj[2];
-	float4x4 sk_viewproj[2];
-	float3   sk_lighting_sh[9];
-	float4   sk_camera_pos[2];
-	float4   sk_camera_dir[2];
-	float4   sk_fingertip[2];
-	float    sk_time;
-};
 cbuffer TransformBuffer : register(b2) {
 	float sk_width;
 	float sk_height;
@@ -27,18 +19,20 @@ struct vsIn {
 	float2 uv   : TEXCOORD0;
 	float4 col  : COLOR0;
 };
-struct psIn {
+struct psIn : sk_ps_input_t {
 	float4 pos : SV_POSITION;
 	float2 uv  : TEXCOORD0;
 };
 
-psIn vs(vsIn input) {
+psIn vs(vsIn input, sk_vs_input_t sk_in) {
 	psIn o;
+	sk_view_init(sk_in, o);
+	
 	o.pos = input.pos;
-	o.uv = input.uv;
+	o.uv  = input.uv;
 	return o;
 }
 
-float4 ps(psIn input) : SV_TARGET{
+float4 ps(psIn input) : SV_TARGET {
 	return pow(abs(source.Sample(source_s, input.uv)), 2.2);
 }

--- a/Examples/StereoKitCTest/Shaders/skt_default_lighting.hlsl
+++ b/Examples/StereoKitCTest/Shaders/skt_default_lighting.hlsl
@@ -19,20 +19,19 @@ struct Light {
 	float4 col;
 };
 cbuffer ParamBuffer : register(b3) {
-	Light lights[6];
+	Light lights[6]; 
 };
 
 struct vsIn {
 	float4 pos  : SV_POSITION;
 	float3 norm : NORMAL;
-	float4 col  : COLOR;
 	float2 uv   : TEXCOORD0;
+	float4 col  : COLOR;
 };
-struct psIn {
-	float4 pos   : SV_POSITION;
+struct psIn : sk_ps_input_t {
+	float4 pos   : SV_Position;
 	float4 color : COLOR0;
 	float2 uv    : TEXCOORD0;
-	uint view_id : SV_RenderTargetArrayIndex;
 };
 
 // y = 1/(x^2+1) * (1-x/6)
@@ -52,13 +51,13 @@ float3 sample_lights(float3 world_pos, float3 world_norm) {
 	return result;
 }
 
-psIn vs(vsIn input, uint id : SV_InstanceID) {
+psIn vs(vsIn input, sk_vs_input_t sk_in) {
 	psIn output;
-	output.view_id = id % sk_view_count;
-	id             = id / sk_view_count;
+	uint view_id = sk_view_init(sk_in, output);
+	uint id      = sk_inst_id  (sk_in);
 
 	float4 world = mul(input.pos, sk_inst[id].world);
-	output.pos   = mul(world,     sk_viewproj[output.view_id]);
+	output.pos   = mul(world,     sk_viewproj[view_id]);
 
 	float3 normal = normalize(mul(input.norm, (float3x3)sk_inst[id].world));
 

--- a/Examples/StereoKitCTest/Shaders/skt_light_only.hlsl
+++ b/Examples/StereoKitCTest/Shaders/skt_light_only.hlsl
@@ -14,11 +14,10 @@ struct vsIn {
 	float4 pos  : SV_POSITION;
 	float3 norm : NORMAL;
 };
-struct psIn {
+struct psIn : sk_ps_input_t {
 	float4 pos   : SV_POSITION;
 	float3 world : TEXCOORD0;
 	float3 normal: NORMAL;
-	uint view_id : SV_RenderTargetArrayIndex;
 };
 
 // y = 1/(x^2+1) * (1-x/6)
@@ -38,13 +37,13 @@ float3 sample_lights(float3 world_pos, float3 world_norm) {
 	return result;
 }
 
-psIn vs(vsIn input, uint id : SV_InstanceID) {
+psIn vs(vsIn input, sk_vs_input_t sk_in) {
 	psIn output;
-	output.view_id = id % sk_view_count;
-	id             = id / sk_view_count;
+	uint view_id = sk_view_init(sk_in, output);
+	uint id      = sk_inst_id  (sk_in);
 
 	float4 world  = mul(input.pos, sk_inst[id].world);
-	output.pos    = mul(world,     sk_viewproj[output.view_id]);
+	output.pos    = mul(world,     sk_viewproj[view_id]);
 	output.world  = world.xyz;
 	output.normal = normalize(mul(input.norm, (float3x3)sk_inst[id].world));
 	return output;

--- a/StereoKitC/shaders_builtin/shader_builtin_blit.hlsl
+++ b/StereoKitC/shaders_builtin/shader_builtin_blit.hlsl
@@ -18,15 +18,15 @@ struct vsIn {
 	float2 uv   : TEXCOORD0;
 	float4 col  : COLOR0;
 };
-struct psIn {
+struct psIn : sk_ps_input_t {
 	float4 pos : SV_POSITION;
 	float2 uv  : TEXCOORD0;
-	uint view_id : SV_RenderTargetArrayIndex;
 };
 
-psIn vs(vsIn input, uint id : SV_InstanceID) {
+psIn vs(vsIn input, sk_vs_input_t sk_in) {
 	psIn o;
-	o.view_id = id % sk_view_count;
+	sk_view_init(sk_in, o);
+	
 	o.pos     = input.pos;
 	o.uv      = input.uv;
 	return o;

--- a/StereoKitC/shaders_builtin/shader_builtin_default.hlsl
+++ b/StereoKitC/shaders_builtin/shader_builtin_default.hlsl
@@ -15,20 +15,19 @@ struct vsIn {
 	float2 uv   : TEXCOORD0;
 	float4 col  : COLOR0;
 };
-struct psIn {
+struct psIn : sk_ps_input_t {
 	float4 pos   : SV_Position;
 	float2 uv    : TEXCOORD0;
 	float4 color : COLOR0;
-	uint view_id : SV_RenderTargetArrayIndex;
 };
 
-psIn vs(vsIn input, uint id : SV_InstanceID) {
+psIn vs(vsIn input, sk_vs_input_t sk_in) {
 	psIn o;
-	o.view_id = id % sk_view_count;
-	id        = id / sk_view_count;
+	uint view_id = sk_view_init(sk_in, o);
+	uint id      = sk_inst_id  (sk_in);
 
 	float4 world = mul(input.pos, sk_inst[id].world);
-	o.pos        = mul(world,     sk_viewproj[o.view_id]);
+	o.pos        = mul(world,     sk_viewproj[view_id]);
 
 	float3 normal = normalize(mul(input.norm, (float3x3)sk_inst[id].world));
 

--- a/StereoKitC/shaders_builtin/shader_builtin_equirect.hlsl
+++ b/StereoKitC/shaders_builtin/shader_builtin_equirect.hlsl
@@ -24,10 +24,9 @@ struct vsIn {
 	float2 uv   : TEXCOORD0;
 	float4 col  : COLOR0;
 };
-struct psIn {
-	float4 pos : SV_POSITION;
+struct psIn : sk_ps_input_t {
+	float4 pos  : SV_POSITION;
 	float3 norm : TEXCOORD0;
-	uint view_id : SV_RenderTargetArrayIndex;
 };
 
 static const float2 invAtan = float2(0.1591, 0.3183);
@@ -38,11 +37,11 @@ float2 ToEquirect(float3 v) {
 	return uv;
 }
 
-psIn vs(vsIn input, uint id : SV_InstanceID) {
+psIn vs(vsIn input, sk_vs_input_t sk_in) {
 	psIn o;
-	o.view_id = id % sk_view_count;
+	sk_view_init(sk_in, o);
+	
 	o.pos     = input.pos;
-
 	float2 uv = input.uv * 2 - 1;
 	o.norm    = forward.xyz + right.xyz*uv.x + up.xyz*uv.y;
 	return o;

--- a/StereoKitC/shaders_builtin/shader_builtin_font.hlsl
+++ b/StereoKitC/shaders_builtin/shader_builtin_font.hlsl
@@ -13,20 +13,19 @@ struct vsIn {
 	float2 uv    : TEXCOORD0;
 	float4 color : COLOR0;
 };
-struct psIn {
+struct psIn : sk_ps_input_t {
 	float4 pos     : SV_Position;
 	float2 uv      : TEXCOORD0;
 	float4 color   : COLOR0;
-	uint   view_id : SV_RenderTargetArrayIndex;
 };
 
-psIn vs(vsIn input, uint id : SV_InstanceID) {
+psIn vs(vsIn input, sk_vs_input_t sk_in) {
 	psIn o;
-	o.view_id = id % sk_view_count;
-	id        = id / sk_view_count;
+	uint view_id = sk_view_init(sk_in, o);
+	uint id      = sk_inst_id  (sk_in);
 
 	float3 world = mul(float4(input.pos.xyz, 1), sk_inst[id].world).xyz;
-	o.pos        = mul(float4(world,         1), sk_viewproj[o.view_id]);
+	o.pos        = mul(float4(world,         1), sk_viewproj[view_id]);
 
 	o.uv    = input.uv;
 	o.color = input.color * color;

--- a/StereoKitC/shaders_builtin/shader_builtin_lightmap.hlsl
+++ b/StereoKitC/shaders_builtin/shader_builtin_lightmap.hlsl
@@ -16,20 +16,19 @@ struct vsIn {
 	float2 uv   : TEXCOORD0;
 	float4 col  : COLOR0;
 };
-struct psIn {
+struct psIn : sk_ps_input_t {
 	float4 pos   : SV_POSITION;
 	float2 uv1   : TEXCOORD0;
 	float2 uv2   : TEXCOORD1;
-	uint view_id : SV_RenderTargetArrayIndex;
 };
 
-psIn vs(vsIn input, uint id : SV_InstanceID) {
+psIn vs(vsIn input, sk_vs_input_t sk_in) {
 	psIn o;
-	o.view_id = id % sk_view_count;
-	id        = id / sk_view_count;
+	uint view_id = sk_view_init(sk_in, o);
+	uint id      = sk_inst_id  (sk_in);
 
 	float3 world = mul(float4(input.pos.xyz, 1), sk_inst[id].world).xyz;
-	o.pos        = mul(float4(world,         1), sk_viewproj[o.view_id]);
+	o.pos        = mul(float4(world,         1), sk_viewproj[view_id]);
 
 	o.uv1   = (input.uv * tex_trans.zw) + tex_trans.xy;
 	o.uv2   = input.norm.xy;

--- a/StereoKitC/shaders_builtin/shader_builtin_lines.hlsl
+++ b/StereoKitC/shaders_builtin/shader_builtin_lines.hlsl
@@ -10,27 +10,26 @@ struct vsIn {
 	float2 uv     : TEXCOORD0;
 	float4 col    : COLOR0;
 };
-struct psIn {
+struct psIn : sk_ps_input_t {
 	float4 pos   : SV_POSITION;
 	float4 color : COLOR0;
-	uint view_id : SV_RenderTargetArrayIndex;
 };
 
-psIn vs(vsIn input, uint id : SV_InstanceID) {
+psIn vs(vsIn input, sk_vs_input_t sk_in) {
 	psIn o;
-	o.view_id = id % sk_view_count;
-	id        = id / sk_view_count;
+	uint view_id = sk_view_init(sk_in, o);
+	uint id      = sk_inst_id  (sk_in);
 
-	float  aspect   = sk_aspect_ratio(o.view_id);
-	float4 pos      = mul(float4(input.pos.xyz, 1), sk_viewproj[o.view_id]);
-	float4 next     = mul(float4(input.next,    1), sk_viewproj[o.view_id]);
+	float  aspect   = sk_aspect_ratio(view_id);
+	float4 pos      = mul(float4(input.pos.xyz, 1), sk_viewproj[view_id]);
+	float4 next     = mul(float4(input.next,    1), sk_viewproj[view_id]);
 	float2 proj_pos = pos .xy / pos .w;
 	float2 proj_next= next.xy / next.w;
 	proj_pos.x     *= aspect;
 	proj_next.x    *= aspect;
 	float2 dir = normalize(proj_next - proj_pos);
 	dir = float2(dir.y, -dir.x) * input.uv.x * sign(next.w) * sign(pos.w); // Multiply by signs to fix a flipping issue when point is offscreen
-	dir = mul(float4(dir.x, dir.y, 0, 1), sk_proj[o.view_id]).xy;
+	dir = mul(float4(dir.x, dir.y, 0, 1), sk_proj[view_id]).xy;
 	pos.xy += dir;
 
 	o.pos   = pos;

--- a/StereoKitC/shaders_builtin/shader_builtin_pbr.hlsl
+++ b/StereoKitC/shaders_builtin/shader_builtin_pbr.hlsl
@@ -31,7 +31,7 @@ struct vsIn {
 	float2 uv      : TEXCOORD0;
 	float4 color   : COLOR0;
 };
-struct psIn {
+struct psIn : sk_ps_input_t {
 	float4 pos     : SV_POSITION;
 	float3 normal  : NORMAL0;
 	float2 uv      : TEXCOORD0;
@@ -39,22 +39,21 @@ struct psIn {
 	float3 irradiance: COLOR1;
 	float3 world   : TEXCOORD1;
 	float3 view_dir: TEXCOORD2;
-	uint   view_id : SV_RenderTargetArrayIndex;
 };
 
-psIn vs(vsIn input, uint id : SV_InstanceID) {
+psIn vs(vsIn input, sk_vs_input_t sk_in) {
 	psIn o;
-	o.view_id = id % sk_view_count;
-	id        = id / sk_view_count;
+	uint view_id = sk_view_init(sk_in, o);
+	uint id      = sk_inst_id  (sk_in);
 
 	o.world = mul(float4(input.pos.xyz, 1), sk_inst[id].world).xyz;
-	o.pos   = mul(float4(o.world,  1), sk_viewproj[o.view_id]);
+	o.pos   = mul(float4(o.world,  1), sk_viewproj[view_id]);
 
 	o.normal     = normalize(mul(float4(input.norm, 0), sk_inst[id].world).xyz);
 	o.uv         = (input.uv * tex_trans.zw) + tex_trans.xy;
 	o.color      = input.color * sk_inst[id].color * color;
 	o.irradiance = sk_lighting(o.normal);
-	o.view_dir   = sk_camera_pos[o.view_id].xyz - o.world;
+	o.view_dir   = sk_camera_pos[view_id].xyz - o.world;
 	return o;
 }
 

--- a/StereoKitC/shaders_builtin/shader_builtin_pbr_clip.hlsl
+++ b/StereoKitC/shaders_builtin/shader_builtin_pbr_clip.hlsl
@@ -33,7 +33,7 @@ struct vsIn {
 	float2 uv      : TEXCOORD0;
 	float4 color   : COLOR0;
 };
-struct psIn {
+struct psIn : sk_ps_input_t {
 	float4 pos     : SV_POSITION;
 	float3 normal  : NORMAL0;
 	float2 uv      : TEXCOORD0;
@@ -41,22 +41,21 @@ struct psIn {
 	float3 irradiance: COLOR1;
 	float3 world   : TEXCOORD1;
 	float3 view_dir: TEXCOORD2;
-	uint   view_id : SV_RenderTargetArrayIndex;
 };
 
-psIn vs(vsIn input, uint id : SV_InstanceID) {
+psIn vs(vsIn input, sk_vs_input_t sk_in) {
 	psIn o;
-	o.view_id = id % sk_view_count;
-	id        = id / sk_view_count;
+	uint view_id = sk_view_init(sk_in, o);
+	uint id      = sk_inst_id  (sk_in);
 
 	o.world = mul(float4(input.pos.xyz, 1), sk_inst[id].world).xyz;
-	o.pos   = mul(float4(o.world,  1), sk_viewproj[o.view_id]);
+	o.pos   = mul(float4(o.world,  1), sk_viewproj[view_id]);
 
 	o.normal     = normalize(mul(float4(input.norm, 0), sk_inst[id].world).xyz);
 	o.uv         = (input.uv * tex_trans.zw) + tex_trans.xy;
 	o.color      = input.color * sk_inst[id].color * color;
 	o.irradiance = sk_lighting(o.normal);
-	o.view_dir   = sk_camera_pos[o.view_id].xyz - o.world;
+	o.view_dir   = sk_camera_pos[view_id].xyz - o.world;
 	return o;
 }
 

--- a/StereoKitC/shaders_builtin/shader_builtin_skybox.hlsl
+++ b/StereoKitC/shaders_builtin/shader_builtin_skybox.hlsl
@@ -3,20 +3,20 @@
 struct vsIn {
 	float4 pos : SV_Position;
 };
-struct psIn {
+struct psIn : sk_ps_input_t {
 	float4 pos  : SV_Position;
 	float3 norm : NORMAL0;
-	uint view_id : SV_RenderTargetArrayIndex;
 };
 
-psIn vs(vsIn input, uint id : SV_InstanceID) {
+psIn vs(vsIn input, sk_vs_input_t sk_in) {
 	psIn o;
-	o.view_id = id % sk_view_count;
-	id        = id / sk_view_count;
-	o.pos     = float4(input.pos.xy, 1, 1);
+	uint view_id = sk_view_init(sk_in, o);
+	uint id      = sk_inst_id  (sk_in);
+	
+	o.pos = float4(input.pos.xy, 1, 1);
 
-	float4 proj_inv = mul(o.pos, sk_proj_inv[o.view_id]);
-	o.norm = mul(float4(proj_inv.xyz, 0), transpose(sk_view[o.view_id])).xyz;
+	float4 proj_inv = mul(o.pos, sk_proj_inv[view_id]);
+	o.norm = mul(float4(proj_inv.xyz, 0), transpose(sk_view[view_id])).xyz;
 	return o;
 }
 

--- a/StereoKitC/shaders_builtin/shader_builtin_ui.hlsl
+++ b/StereoKitC/shaders_builtin/shader_builtin_ui.hlsl
@@ -12,22 +12,21 @@ struct vsIn {
 	float2 uv   : TEXCOORD0;
 	float4 color: COLOR0;
 };
-struct psIn {
+struct psIn : sk_ps_input_t {
 	float4 pos     : SV_POSITION;
 	float2 uv      : TEXCOORD0;
 	float3 world   : TEXCOORD1;
 	half4  color   : COLOR0;
-	uint   view_id : SV_RenderTargetArrayIndex;
 };
 
-psIn vs(vsIn input, uint id : SV_InstanceID) {
+psIn vs(vsIn input, sk_vs_input_t sk_in) {
 	psIn o;
-	o.view_id = id % sk_view_count;
-	id        = id / sk_view_count;
+	uint view_id = sk_view_init(sk_in, o);
+	uint id      = sk_inst_id  (sk_in);
 
 	float3 normal = normalize(mul(input.norm, (float3x3) sk_inst[id].world));
 	float4 world  = mul(input.pos, sk_inst[id].world);
-	o.pos   = mul(world, sk_viewproj[o.view_id]);
+	o.pos   = mul(world, sk_viewproj[view_id]);
 	o.world = world.xyz;
 	o.uv    = input.uv;
 	o.color.rgb = color.rgb * input.color.rgb * sk_inst[id].color.rgb * sk_lighting(normal);

--- a/StereoKitC/shaders_builtin/shader_builtin_ui_aura.hlsl
+++ b/StereoKitC/shaders_builtin/shader_builtin_ui_aura.hlsl
@@ -11,17 +11,16 @@ struct vsIn {
 	float2 quadrant : TEXCOORD0;
 	float4 color    : COLOR0;
 };
-struct psIn {
+struct psIn : sk_ps_input_t {
 	float4 pos     : SV_Position;
 	float3 world   : TEXCOORD0;
 	half3  color   : COLOR0;
-	uint   view_id : SV_RenderTargetArrayIndex;
 };
 
-psIn vs(vsIn input, uint id : SV_InstanceID) {
+psIn vs(vsIn input, sk_vs_input_t sk_in) {
 	psIn o;
-	o.view_id = id % sk_view_count;
-	id        = id / sk_view_count;
+	uint view_id = sk_view_init(sk_in, o);
+	uint id      = sk_inst_id  (sk_in);
 	
 	// Extract scale from the matrix
 	float4x4 world_mat = sk_inst[id].world;
@@ -44,7 +43,7 @@ psIn vs(vsIn input, uint id : SV_InstanceID) {
 
 	float4 world = mul(sized_pos, world_mat);
 	float3 normal = normalize(mul(input.norm, (float3x3) world_mat));
-	o.pos   = mul(world, sk_viewproj[o.view_id]);
+	o.pos   = mul(world, sk_viewproj[view_id]);
 	o.world = world.xyz;
 	o.color = lerp(color.rgb, sk_inst[id].color.rgb, input.color.a) * sk_lighting(normal);
 	return o;

--- a/StereoKitC/shaders_builtin/shader_builtin_ui_box.hlsl
+++ b/StereoKitC/shaders_builtin/shader_builtin_ui_box.hlsl
@@ -16,19 +16,18 @@ struct vsIn {
 	float2 uv   : TEXCOORD0;
 	float4 col  : COLOR0;
 };
-struct psIn {
+struct psIn : sk_ps_input_t {
 	float4 pos   : SV_POSITION;
 	float2 uv    : TEXCOORD0;
 	float4 color : COLOR0;
 	float4 world : TEXCOORD1;
 	float2 scale : TEXCOORD2;
-	uint view_id : SV_RenderTargetArrayIndex;
 };
 
-psIn vs(vsIn input, uint id : SV_InstanceID) {
+psIn vs(vsIn input, sk_vs_input_t sk_in) {
 	psIn o;
-	o.view_id = id % sk_view_count;
-	id        = id / sk_view_count;
+	uint view_id = sk_view_init(sk_in, o);
+	uint id      = sk_inst_id  (sk_in);
 
 	// Extract scale from the matrix
 	float4x4 world_mat = sk_inst[id].world;
@@ -43,7 +42,7 @@ psIn vs(vsIn input, uint id : SV_InstanceID) {
 	else                               o.scale = scale.xy;
 
 	o.world = mul(input .pos, sk_inst    [id].world);
-	o.pos   = mul(o.world,    sk_viewproj[o.view_id]);
+	o.pos   = mul(o.world,    sk_viewproj[view_id]);
 
 	o.uv    = input.uv-0.5;
 	o.color = color * input.col * sk_inst[id].color;

--- a/StereoKitC/shaders_builtin/shader_builtin_ui_quadrant.hlsl
+++ b/StereoKitC/shaders_builtin/shader_builtin_ui_quadrant.hlsl
@@ -6,17 +6,16 @@ struct vsIn {
 	float2 quadrant : TEXCOORD0;
 	float4 color    : COLOR0;
 };
-struct psIn {
+struct psIn : sk_ps_input_t {
 	float4 pos     : SV_Position;
 	float3 world   : TEXCOORD1;
 	half4  color   : COLOR0;
-	uint   view_id : SV_RenderTargetArrayIndex;
 };
 
-psIn vs(vsIn input, uint id : SV_InstanceID) {
+psIn vs(vsIn input, sk_vs_input_t sk_in) {
 	psIn o;
-	o.view_id = id % sk_view_count;
-	id        = id / sk_view_count;
+	uint view_id = sk_view_init(sk_in, o);
+	uint id      = sk_inst_id  (sk_in);
 	
 	// Extract scale from the matrix
 	float4x4 world_mat = sk_inst[id].world;
@@ -35,7 +34,7 @@ psIn vs(vsIn input, uint id : SV_InstanceID) {
 	
 	float3 normal = normalize(mul(input.norm, (float3x3)world_mat));
 	float4 world  = mul(sized_pos, world_mat);
-	o.pos    = mul(world, sk_viewproj[o.view_id]);
+	o.pos    = mul(world, sk_viewproj[view_id]);
 	o.world  = world.xyz;
 	o.color.rgb = input.color.rgb * sk_inst[id].color.rgb * sk_lighting(normal);
 	o.color.a   = input.color.a;

--- a/StereoKitC/shaders_builtin/shader_builtin_unlit.hlsl
+++ b/StereoKitC/shaders_builtin/shader_builtin_unlit.hlsl
@@ -17,20 +17,19 @@ struct vsIn {
 	float2 uv   : TEXCOORD0;
 	float4 col  : COLOR0;
 };
-struct psIn {
+struct psIn : sk_ps_input_t {
 	float4 pos   : SV_POSITION;
 	float2 uv    : TEXCOORD0;
 	half4  color : COLOR0;
-	uint view_id : SV_RenderTargetArrayIndex;
 };
 
-psIn vs(vsIn input, uint id : SV_InstanceID) {
+psIn vs(vsIn input, sk_vs_input_t sk_in) {
 	psIn o;
-	o.view_id = id % sk_view_count;
-	id        = id / sk_view_count;
+	uint view_id = sk_view_init(sk_in, o);
+	uint id      = sk_inst_id  (sk_in);
 
 	float4 world = mul(float4(input.pos.xyz, 1), sk_inst[id].world);
-	o.pos        = mul(world,                    sk_viewproj[o.view_id]);
+	o.pos        = mul(world,                    sk_viewproj[view_id]);
 
 	o.uv    = (input.uv * tex_trans.zw) + tex_trans.xy;
 	o.color = input.col * color * sk_inst[id].color;

--- a/StereoKitC/shaders_builtin/shader_builtin_unlit_clip.hlsl
+++ b/StereoKitC/shaders_builtin/shader_builtin_unlit_clip.hlsl
@@ -17,20 +17,19 @@ struct vsIn {
 	float2 uv   : TEXCOORD0;
 	float4 col  : COLOR0;
 };
-struct psIn {
+struct psIn : sk_ps_input_t {
 	float4 pos   : SV_POSITION;
 	float2 uv    : TEXCOORD0;
 	half4  color : COLOR0;
-	uint view_id : SV_RenderTargetArrayIndex;
 };
 
-psIn vs(vsIn input, uint id : SV_InstanceID) {
+psIn vs(vsIn input, sk_vs_input_t sk_in) {
 	psIn o;
-	o.view_id = id % sk_view_count;
-	id        = id / sk_view_count;
+	uint view_id = sk_view_init(sk_in, o);
+	uint id      = sk_inst_id  (sk_in);
 
 	float4 world = mul(float4(input.pos.xyz, 1), sk_inst[id].world);
-	o.pos        = mul(world,                    sk_viewproj[o.view_id]);
+	o.pos        = mul(world,                    sk_viewproj[view_id]);
 
 	o.uv    = (input.uv * tex_trans.zw) + tex_trans.xy;
 	o.color = input.col * color * sk_inst[id].color;

--- a/StereoKitC/systems/render.h
+++ b/StereoKitC/systems/render.h
@@ -36,13 +36,13 @@ tex_format_   render_preferred_depth_fmt  ();
 void          render_blit_to_bound        (material_t material);
 void          render_set_sim_origin       (pose_t pose);
 void          render_set_sim_head         (pose_t pose);
-void          render_draw_queue           (render_list_t list, const matrix* views, const matrix* projections, int32_t eye_offset, int32_t view_count, render_layer_ filter);
+void          render_draw_queue           (render_list_t list, const matrix* views, const matrix* projections, int32_t eye_offset, int32_t view_count, int32_t inst_multiplier, render_layer_ filter);
 void          render_check_screenshots    ();
 void          render_check_viewpoints     ();
 void          render_check_pending_skytex ();
 
 void          render_list_destroy         (      render_list_t list);
-void          render_list_execute         (      render_list_t list, render_layer_ filter, uint32_t view_count, int32_t queue_start, int32_t queue_end);
-void          render_list_execute_material(      render_list_t list, render_layer_ filter, uint32_t view_count, int32_t queue_start, int32_t queue_end, material_t override_material);
+void          render_list_execute         (      render_list_t list, render_layer_ filter, uint32_t inst_multiplier, int32_t queue_start, int32_t queue_end);
+void          render_list_execute_material(      render_list_t list, render_layer_ filter, uint32_t inst_multiplier, int32_t queue_start, int32_t queue_end, material_t override_material);
 
 } // namespace sk

--- a/StereoKitC/systems/render_pipeline.h
+++ b/StereoKitC/systems/render_pipeline.h
@@ -7,7 +7,14 @@ namespace sk {
 
 typedef int32_t pipeline_surface_id;
 
-pipeline_surface_id render_pipeline_surface_create            (tex_format_ color, tex_format_ depth, int32_t array_count, int32_t quilt_width, int32_t quilt_height);
+typedef enum pipeline_render_strategy_ {
+	pipeline_render_strategy_none,
+	pipeline_render_strategy_sequential,
+	pipeline_render_strategy_simultaneous,
+	pipeline_render_strategy_multiview,
+} pipeline_render_strategy_;
+
+pipeline_surface_id render_pipeline_surface_create            (pipeline_render_strategy_ strategy, tex_format_ color, tex_format_ depth, int32_t array_count, int32_t quilt_width, int32_t quilt_height);
 void                render_pipeline_surface_destroy           (pipeline_surface_id surface);
 bool32_t            render_pipeline_surface_resize            (pipeline_surface_id surface, int32_t width, int32_t height, int32_t multisample);
 void                render_pipeline_surface_to_swapchain      (pipeline_surface_id surface, skg_swapchain_t* swapchain);

--- a/StereoKitC/xr_backends/openxr_view.cpp
+++ b/StereoKitC/xr_backends/openxr_view.cpp
@@ -479,7 +479,7 @@ bool openxr_display_swapchain_update(device_display_t *display) {
 	int32_t array_count  = display->view_cap;
 	int32_t quilt_width  = 1;
 	int32_t quilt_height = 1;
-	if (s != 1 && backend_graphics_get() != backend_graphics_d3d11 && (!skg_capability(skg_cap_multiview) || display->view_cap != 2)) {
+	if (s != 1 && backend_graphics_get() != backend_graphics_d3d11 && (!skg_capability(skg_cap_multiview_tiled_multisample) || display->view_cap != 2)) {
 		// GL can only support MSAA on double-wide and multiview surfaces.
 		// Regular array textures + MSAA doesn't work, so we go to a non-array
 		// "double-wide" strategy. SK also only supports multiview for 2
@@ -496,7 +496,13 @@ bool openxr_display_swapchain_update(device_display_t *display) {
 	if (!openxr_create_swapchain(&display->swapchain_color, display->type, true,  array_count, xr_preferred_color_format, w, h, 1)) return false;
 	if (!openxr_create_swapchain(&display->swapchain_depth, display->type, false, array_count, xr_preferred_depth_format, w, h, 1)) return false;
 
-	log_diagf("Set swapchain: <~grn>%s<~clr> to %d<~BLK>x<~clr>%d", openxr_view_name(display->type), sc_color->width, sc_color->height);
+	const char* strategy_name = "";
+	switch (strategy) {
+	case pipeline_render_strategy_sequential:   strategy_name = "sequential";   break;
+	case pipeline_render_strategy_simultaneous: strategy_name = "simultaneous"; break;
+	case pipeline_render_strategy_multiview:    strategy_name = "multiview";    break;
+	}
+	log_diagf("Set swapchain for <~grn>%s<~clr> using <~grn>%s<~clr> render.", openxr_view_name(display->type), strategy_name);
 
 	// Create texture objects if we don't have 'em
 	if (sc_color->textures == nullptr) {

--- a/StereoKitC/xr_backends/simulator.cpp
+++ b/StereoKitC/xr_backends/simulator.cpp
@@ -92,7 +92,7 @@ bool simulator_init() {
 	default: return false;
 	}
 
-	sim_surface = render_pipeline_surface_create(tex_format_rgba32, render_preferred_depth_fmt(), 1, 1, 1);
+	sim_surface = render_pipeline_surface_create(pipeline_render_strategy_sequential, tex_format_rgba32, render_preferred_depth_fmt(), 1, 1, 1);
 	skg_swapchain_t* swapchain = platform_win_get_swapchain(sim_window);
 	if (swapchain)
 		sim_surface_resize(sim_surface, swapchain->width, swapchain->height);

--- a/StereoKitC/xr_backends/window.cpp
+++ b/StereoKitC/xr_backends/window.cpp
@@ -81,7 +81,7 @@ bool window_init() {
 	default: return false;
 	}
 
-	local->surface = render_pipeline_surface_create(tex_format_rgba32, render_preferred_depth_fmt(), 1, 1, 1);
+	local->surface = render_pipeline_surface_create(pipeline_render_strategy_sequential, tex_format_rgba32, render_preferred_depth_fmt(), 1, 1, 1);
 	skg_swapchain_t* swapchain = platform_win_get_swapchain(local->window);
 	if (swapchain)
 		window_surface_resize(local->surface, swapchain->width, swapchain->height);

--- a/tools/include/stereokit.hlsli
+++ b/tools/include/stereokit.hlsli
@@ -28,6 +28,45 @@ TextureCube  sk_cubemap   : register(t11);
 SamplerState sk_cubemap_s : register(s11);
 
 ///////////////////////////////////////////
+// Multiview / Array texture abstraction //
+///////////////////////////////////////////
+
+struct sk_ps_input_t {
+#ifndef SK_OPENGL
+	uint _dest_view_id : SV_RenderTargetArrayIndex;
+#endif
+};
+
+///////////////////////////////////////////
+
+struct sk_vs_input_t {
+	uint id : SV_InstanceID;
+#ifdef SK_OPENGL
+	uint _view_id : SV_ViewID;
+#endif
+};
+
+///////////////////////////////////////////
+
+#ifdef SK_OPENGL
+#define sk_view_init(_input, _output) (_input._view_id)
+#else
+uint _sk_view_init(uint inst_id, inout uint dest_view_id) {
+	dest_view_id = inst_id % sk_view_count;
+	return dest_view_id;
+}
+#define sk_view_init(_input, _output) _sk_view_init(_input.id, _output._dest_view_id)
+#endif
+
+///////////////////////////////////////////
+
+#ifdef SK_OPENGL
+#define sk_inst_id(_input) (_input.id);
+#else
+#define sk_inst_id(_input) (_input.id / sk_view_count);
+#endif
+
+///////////////////////////////////////////
 
 // A spherical harmonics lighting lookup!
 // Some calculations have been offloaded to 'sh_to_fast'


### PR DESCRIPTION
This adds support for single-pass rendering (multiview) with in-tile MSAA resolve for OpenGL platforms! It is a **breaking change** for all shaders to support the different modes of surface selection! This improvement will drop the number of draw calls in half.

See the Unlit shader for an example of how shaders must change for this update:
https://github.com/StereoKit/StereoKit/commit/19bbb62c2817fd0439d1e4c22fafe25feebd0401#diff-310bca21d17b262a060e724d10e0ce38591c58d3b40ddb70774eb5395e52b690