### PR TITLE
Update sk_gpu for Linux multiview fix.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -217,8 +217,8 @@ add_compile_definitions(BASISD_SUPPORT_BC7_MODE5=0)
 
 #### sk_gpu - https://github.com/StereoKit/sk_gpu ####
 CPMAddPackage( # We're scraping the comment after the NAME for some other scripts
-  NAME sk_gpu # 2025.3.11
-  URL https://github.com/StereoKit/sk_gpu/releases/download/v2025.3.11/sk_gpu.v2025.3.11.zip
+  NAME sk_gpu # 2025.3.14
+  URL https://github.com/StereoKit/sk_gpu/releases/download/v2025.3.14/sk_gpu.v2025.3.14.zip
 )
 # For building directly with in-progress sk_gpu changes, point this to your
 # local sk_gpu clone, and use it instead of CPM.


### PR DESCRIPTION
Linux devices that did not support the multiview2 extension would not fall back gracefully. This adds some additional shader code to prevent glsl shaders from hard requiring the extension.