### PR TITLE
`TextAlign` clarification

### DIFF
--- a/Examples/StereoKitCTest/demo_anchors.cpp
+++ b/Examples/StereoKitCTest/demo_anchors.cpp
@@ -36,7 +36,7 @@ void demo_anchors_update() {
 	// Draw a pose for each anchor
 	for (size_t i = 0; i < anchors.size(); i++) {
 		line_add_axis(anchor_get_pose(anchors[i]), 0.1f);
-		text_add_at(anchor_get_name(anchors[i]), pose_matrix(anchor_get_pose(anchors[i])), 0, text_align_top_center);
+		text_add_at(anchor_get_name(anchors[i]), pose_matrix(anchor_get_pose(anchors[i])), 0, pivot_top_center);
 	}
 
 	// Some interaction for adding anchors

--- a/Examples/StereoKitCTest/demo_mic.cpp
+++ b/Examples/StereoKitCTest/demo_mic.cpp
@@ -94,10 +94,10 @@ void demo_mic_update() {
 		float    scale = 0.1f + 0.1f*mic_intensity;
 		color128 color = { 1,1,1, fmaxf(0.1f,mic_intensity) };
 		render_add_mesh(mic_visual_mesh, mic_visual_mat, matrix_trs({0,0,-0.5f}, quat_identity, vec3_one*scale), color);
-		sprite_draw    (mic_sprite, matrix_ts({ 0,0,-0.5f }, vec3_one*0.06f), text_align_center);
+		sprite_draw    (mic_sprite, matrix_ts({ 0,0,-0.5f }, vec3_one*0.06f), pivot_center);
 	} else {
 		render_add_mesh(mic_visual_mesh, mic_visual_mat, matrix_trs({0,0,-0.5f}, quat_identity, vec3_one*0.1f), { 1,0,0, 0.1f });
-		sprite_draw    (mic_sprite, matrix_ts({ 0,0,-0.5f }, vec3_one*0.06f), text_align_center);
+		sprite_draw    (mic_sprite, matrix_ts({ 0,0,-0.5f }, vec3_one*0.06f), pivot_center);
 	}
 }
 

--- a/Examples/StereoKitCTest/demo_sprites.cpp
+++ b/Examples/StereoKitCTest/demo_sprites.cpp
@@ -26,7 +26,7 @@ void demo_sprites_init() {
 void demo_sprites_update() {
 	for (int32_t x = -2; x <= 2; x++) {
 		for (int32_t y = -2; y <= 2; y++) {
-			sprite_draw(sprite, matrix_trs({x*0.1f,y*0.1f,-0.5f}, quat_lookat(vec3_zero, -vec3_forward), vec3_one * 0.1f), text_align_center);
+			sprite_draw(sprite, matrix_trs({x*0.1f,y*0.1f,-0.5f}, quat_lookat(vec3_zero, -vec3_forward), vec3_one * 0.1f), pivot_center);
 		}
 	}
 }

--- a/Examples/StereoKitCTest/main.cpp
+++ b/Examples/StereoKitCTest/main.cpp
@@ -272,7 +272,7 @@ void ruler_window() {
 	text_add_at("Centimeters",
 				matrix_trs(vec3{14.5f*cm2m, -1.5f*cm2m, -0.6f*cm2m},
 						   quat_identity, vec3{0.3f, 0.3f, 0.3f}),
-				0, text_align_bottom_left);
+				0, pivot_bottom_left);
 	for (int d = 0; d <= 60; d++) {
 		float x = d / 2.0f;
 		float size = (d % 2 == 0) ? 1.0f : 0.15f;
@@ -285,7 +285,7 @@ void ruler_window() {
 						matrix_trs(vec3{(15 - x - 0.1f)*cm2m,
 										(2 - size)*cm2m, -0.6f*cm2m},
 									quat_identity, vec3{0.2f, 0.2f, 0.2f}),
-						0, text_align_bottom_left);
+						0, pivot_bottom_left);
 		}
 	}
 	ui_handle_end();

--- a/Examples/StereoKitTest/DebugToolWindow.cs
+++ b/Examples/StereoKitTest/DebugToolWindow.cs
@@ -389,14 +389,14 @@ class DebugToolWindow : IStepper
 	{
 		UI.HandleBegin("Ruler", ref rulerPose, new Bounds(new Vec3(31,4,1)*U.cm), true);
 		Color32 color = Color.HSV(.6f, 0.5f, 1);
-		Text.Add("Centimeters", Matrix.TS(new Vec3(14.5f, -1.5f, -.6f)*U.cm, .3f), TextAlign.BottomLeft);
+		Text.Add("Centimeters", Matrix.TS(new Vec3(14.5f, -1.5f, -.6f)*U.cm, .3f), Pivot.BottomLeft);
 		for (int d = 0; d <= 60; d+=1)
 		{
 			float x    = d/2.0f;
 			float size = d%2==0?.5f:0.15f;
 			if (d%10 == 0 && d/2 != 30) {
 				size = 1;
-				Text.Add(rulerLabels[d/10], Matrix.TS(new Vec3(15-x-0.1f, 2-size, -.6f) * U.cm, .2f), TextAlign.BottomLeft);
+				Text.Add(rulerLabels[d/10], Matrix.TS(new Vec3(15-x-0.1f, 2-size, -.6f) * U.cm, .2f), Pivot.BottomLeft);
 			}
 			Lines.Add(new Vec3(15-x, 1.8f, -.6f)*U.cm, new Vec3(15-x,1.8f-size, -.6f)*U.cm, color, U.mm*0.5f);
 		}

--- a/Examples/StereoKitTest/Demos/Demo.cs
+++ b/Examples/StereoKitTest/Demos/Demo.cs
@@ -35,7 +35,7 @@ abstract class Demo
 		}
 
 		Text.Add(title,       titlePose);
-		Text.Add(description, descPose, V.XY(0.4f, 0), TextFit.Wrap, TextAlign.TopCenter, TextAlign.TopLeft);
+		Text.Add(description, descPose, V.XY(0.4f, 0), TextFit.Wrap, Pivot.TopCenter, Align.TopLeft);
 		if (showBounds)
 			Mesh.Cube.Draw(Material.UIBox, Matrix.TS(experienceBounds.center, experienceBounds.dimensions) * contentPose);
 	}

--- a/Examples/StereoKitTest/Demos/DemoHands.cs
+++ b/Examples/StereoKitTest/Demos/DemoHands.cs
@@ -400,7 +400,7 @@ class DemoHands : ITest
 			Text.Add(
 				(hand.size * 100).ToString(".0")+"cm", 
 				Matrix.TRS(pos, rot, 0.3f),
-				TextAlign.XCenter|TextAlign.YBottom);
+				Pivot.XCenter|Pivot.YBottom);
 		}
 	}
 }

--- a/Examples/StereoKitTest/Demos/DemoMath.cs
+++ b/Examples/StereoKitTest/Demos/DemoMath.cs
@@ -152,9 +152,9 @@ class DemoMath : ITest
 		Lines.Add(crossStart, crossStart + Vec3.Up*0.05f,      new Color32(255,255,255,255), 2*Units.mm2m);
 		Lines.Add(crossStart, crossStart + Vec3.Forward*0.05f, new Color32(255,255,255,255), 2*Units.mm2m);
 		Lines.Add(crossStart, crossStart + right * 0.05f,      new Color32(0, 255, 0, 255),  2*Units.mm2m);
-		Text.Add("Up",                 Matrix.TRS(crossStart + Vec3.Up      * 0.05f, Quat.LookDir(-Vec3.Forward), 0.25f), TextAlign.BottomCenter);
-		Text.Add("Fwd",                Matrix.TRS(crossStart + Vec3.Forward * 0.05f, Quat.LookDir(-Vec3.Forward), 0.25f), TextAlign.BottomCenter);
-		Text.Add("Vec3.Cross(Fwd,Up)", Matrix.TRS(crossStart + right * 0.05f, Quat.LookDir(-Vec3.Forward), 0.25f), TextAlign.BottomCenter);
+		Text.Add("Up",                 Matrix.TRS(crossStart + Vec3.Up      * 0.05f, Quat.LookDir(-Vec3.Forward), 0.25f), Pivot.BottomCenter);
+		Text.Add("Fwd",                Matrix.TRS(crossStart + Vec3.Forward * 0.05f, Quat.LookDir(-Vec3.Forward), 0.25f), Pivot.BottomCenter);
+		Text.Add("Vec3.Cross(Fwd,Up)", Matrix.TRS(crossStart + right        * 0.05f, Quat.LookDir(-Vec3.Forward), 0.25f), Pivot.BottomCenter);
 
 		UI.HandleEnd();
 

--- a/Examples/StereoKitTest/Demos/DemoMicrophone.cs
+++ b/Examples/StereoKitTest/Demos/DemoMicrophone.cs
@@ -129,13 +129,13 @@ class DemoMicrophone : ITest
 			float scale = 0.1f + 0.06f * intensity;
 			Color color = new Color(1,1,1, Math.Max(0.1f, intensity));
 			Default.MeshSphere.Draw(micMaterial, Matrix.S(scale), color);
-			micSprite.Draw(Matrix.S(0.06f), TextAlign.Center);
+			micSprite.Draw(Matrix.S(0.06f), Pivot.Center);
 		}
 		else
 		{
 			// Draw it in red if we're not recording
 			Default.MeshSphere.Draw(micMaterial, Matrix.S(0.1f), new Color(1,0,0,0.1f));
-			micSprite.Draw(Matrix.S(0.06f), TextAlign.Center);
+			micSprite.Draw(Matrix.S(0.06f), Pivot.Center);
 		}
 		Hierarchy.Pop();
 

--- a/Examples/StereoKitTest/Demos/DemoPicker.cs
+++ b/Examples/StereoKitTest/Demos/DemoPicker.cs
@@ -122,7 +122,7 @@ class DemoPicker : ITest
 		{
 			var node = model.Nodes[n];
 			Mesh.Cube.Draw(jointMaterial, node.ModelTransform.Pose.ToMatrix(0.025f * scale));
-			Text.Add(node.Name, Matrix.S(scale)*node.ModelTransform, TextAlign.TopCenter, TextAlign.TopCenter);
+			Text.Add(node.Name, Matrix.S(scale)*node.ModelTransform, Pivot.TopCenter, Align.TopCenter);
 		}
 	}
 

--- a/Examples/StereoKitTest/Demos/DemoText.cs
+++ b/Examples/StereoKitTest/Demos/DemoText.cs
@@ -10,9 +10,9 @@ class DemoText : ITest
 	string title       = "Text";
 	string description = "";
 
-	TextAlign alignX      = TextAlign.XLeft;
-	TextAlign alignY      = TextAlign.YTop;
-	Pose      alignWindow = (Demo.contentPose * Matrix.T(0,-0.3f,0)).Pose;
+	Align alignX      = Align.XLeft;
+	Align alignY      = Align.YTop;
+	Pose  alignWindow = (Demo.contentPose * Matrix.T(0,-0.3f,0)).Pose;
 
 	/// :CodeSample: Text.MakeStyle Font.FromFile Text.Add
 	/// ### Drawing text with and without a TextStyle
@@ -40,30 +40,30 @@ class DemoText : ITest
 
 		UI.WindowBegin("Alignment", ref alignWindow);
 		Vec2 size = new Vec2(8 * U.cm, UI.LineHeight);
-		if (UI.Radio("Left"   , alignX == TextAlign.XLeft  , size)) alignX = TextAlign.XLeft;   UI.SameLine();
-		if (UI.Radio("CenterX", alignX == TextAlign.XCenter, size)) alignX = TextAlign.XCenter; UI.SameLine();
-		if (UI.Radio("Right"  , alignX == TextAlign.XRight , size)) alignX = TextAlign.XRight;
-		if (UI.Radio("Top"    , alignY == TextAlign.YTop   , size)) alignY = TextAlign.YTop;    UI.SameLine();
-		if (UI.Radio("CenterY", alignY == TextAlign.YCenter, size)) alignY = TextAlign.YCenter; UI.SameLine();
-		if (UI.Radio("Bottom" , alignY == TextAlign.YBottom, size)) alignY = TextAlign.YBottom;
+		if (UI.Radio("Left"   , alignX == Align.XLeft  , size)) alignX = Align.XLeft;   UI.SameLine();
+		if (UI.Radio("CenterX", alignX == Align.XCenter, size)) alignX = Align.XCenter; UI.SameLine();
+		if (UI.Radio("Right"  , alignX == Align.XRight , size)) alignX = Align.XRight;
+		if (UI.Radio("Top"    , alignY == Align.YTop   , size)) alignY = Align.YTop;    UI.SameLine();
+		if (UI.Radio("CenterY", alignY == Align.YCenter, size)) alignY = Align.YCenter; UI.SameLine();
+		if (UI.Radio("Bottom" , alignY == Align.YBottom, size)) alignY = Align.YBottom;
 		UI.WindowEnd();
 
 		Hierarchy.Push(Matrix.R(0, 180, 0) * Demo.contentPose);
 		Hierarchy.Push(Matrix.T(0.1f,0,0));
-		Text.Add("X Center", Matrix.TR(new Vec3(0,.1f, 0), Quat.LookDir(0,0,1)), TextAlign.Center,      alignX | alignY);
-		Text.Add("X Left",   Matrix.TR(new Vec3(0,.15f,0), Quat.LookDir(0,0,1)), TextAlign.CenterLeft,  alignX | alignY);
-		Text.Add("X Right",  Matrix.TR(new Vec3(0,.2f, 0), Quat.LookDir(0,0,1)), TextAlign.CenterRight, alignX | alignY);
+		Text.Add("X Center", Matrix.TR(new Vec3(0,.1f, 0), Quat.LookDir(0,0,1)), Pivot.Center,      alignX | alignY);
+		Text.Add("X Left",   Matrix.TR(new Vec3(0,.15f,0), Quat.LookDir(0,0,1)), Pivot.CenterLeft,  alignX | alignY);
+		Text.Add("X Right",  Matrix.TR(new Vec3(0,.2f, 0), Quat.LookDir(0,0,1)), Pivot.CenterRight, alignX | alignY);
 		Lines.Add(new Vec3(0,.05f,0), new Vec3(0,.25f,0), Color32.White, 0.001f);
 		Hierarchy.Pop();
 
 		Hierarchy.Push(Matrix.T(-0.1f,0,0));
-		Text.Add("Y Center", Matrix.TR(new Vec3(0,.1f, 0), Quat.LookDir(0,0,1)), TextAlign.YCenter|TextAlign.XCenter, alignX | alignY);
+		Text.Add("Y Center", Matrix.TR(new Vec3(0,.1f, 0), Quat.LookDir(0,0,1)), Pivot.YCenter|Pivot.XCenter, alignX | alignY);
 		Lines.Add(new Vec3(-0.05f, .1f, 0), new Vec3(.05f, .1f, 0), Color32.White, 0.001f);
 
-		Text.Add("Y Top",    Matrix.TR(new Vec3(0,.15f,0), Quat.LookDir(0,0,1)), TextAlign.YTop|TextAlign.XCenter, alignX | alignY);
+		Text.Add("Y Top",    Matrix.TR(new Vec3(0,.15f,0), Quat.LookDir(0,0,1)), Pivot.YTop|Pivot.XCenter, alignX | alignY);
 		Lines.Add(new Vec3(-0.05f, .15f, 0), new Vec3(.05f, .15f, 0), Color32.White, 0.001f);
 
-		Text.Add("Y Bottom", Matrix.TR(new Vec3(0,.2f, 0), Quat.LookDir(0,0,1)), TextAlign.YBottom|TextAlign.XCenter, alignX | alignY);
+		Text.Add("Y Bottom", Matrix.TR(new Vec3(0,.2f, 0), Quat.LookDir(0,0,1)), Pivot.YBottom|Pivot.XCenter, alignX | alignY);
 		Lines.Add(new Vec3(-0.05f,.2f, 0), new Vec3(.05f,.2f, 0), Color32.White, 0.001f);
 		Hierarchy.Pop();
 
@@ -91,7 +91,7 @@ class DemoText : ITest
 			Matrix.TR(new Vec3(0, 0.0f, 0), Quat.LookDir(0, 0, 1)),
 			new Vec2(SKMath.Cos(Time.Totalf)*10+11, 20) * U.cm,
 			TextFit.Clip,
-			style, TextAlign.Center, alignX | alignY);
+			style, Pivot.Center, alignX | alignY);
 		Hierarchy.Pop();
 
 		Hierarchy.Pop();

--- a/Examples/StereoKitTest/Demos/DemoUIGrabBar.cs
+++ b/Examples/StereoKitTest/Demos/DemoUIGrabBar.cs
@@ -30,7 +30,7 @@ class DemoUIGrabBar : ITest
 		UI.WindowBegin("Interface", ref windowPose, new Vec2(0.15f, 0), UIWin.Body, UIMove.None);
 
 		// Some UI to fill up space
-		UI.Text("Here's a window that can be moved via a bar below the window!", TextAlign.Center);
+		UI.Text("Here's a window that can be moved via a bar below the window!", Align.Center);
 		UI.HSeparator();
 		UI.Button("Testing!");
 

--- a/Examples/StereoKitTest/Demos/DemoUITearsheet.cs
+++ b/Examples/StereoKitTest/Demos/DemoUITearsheet.cs
@@ -118,18 +118,18 @@ class DemoUITearsheet : ITest
 
 		UI.HSeparator();
 
-		UI.Text("UI.Text", TextAlign.TopLeft);
-		UI.Text("UI.Text", TextAlign.TopCenter);
-		UI.Text("UI.Text", TextAlign.TopRight);
+		UI.Text("UI.Text", Align.TopLeft);
+		UI.Text("UI.Text", Align.TopCenter);
+		UI.Text("UI.Text", Align.TopRight);
 
 		UI.HSeparator();
 
 		Vec2 size = new Vec2(0.14f, 0.03f);
-		UI.Text("UI.Text with a size overload + Clip",     TextAlign.TopLeft, TextFit.Clip,     size);
-		UI.Text("UI.Text with a size overload + Exact",    TextAlign.TopLeft, TextFit.Exact,    size);
-		UI.Text("UI.Text with a size overload + Overflow", TextAlign.TopLeft, TextFit.Overflow, size);
-		UI.Text("UI.Text with a size overload + Squeeze",  TextAlign.TopLeft, TextFit.Squeeze,  size);
-		UI.Text("UI.Text with a size overload + Wrap",     TextAlign.TopLeft, TextFit.Wrap,     size);
+		UI.Text("UI.Text with a size overload + Clip",     Align.TopLeft, TextFit.Clip,     size);
+		UI.Text("UI.Text with a size overload + Exact",    Align.TopLeft, TextFit.Exact,    size);
+		UI.Text("UI.Text with a size overload + Overflow", Align.TopLeft, TextFit.Overflow, size);
+		UI.Text("UI.Text with a size overload + Squeeze",  Align.TopLeft, TextFit.Squeeze,  size);
+		UI.Text("UI.Text with a size overload + Wrap",     Align.TopLeft, TextFit.Wrap,     size);
 
 		UI.HSeparator();
 

--- a/Examples/StereoKitTest/Demos/DemoWelcome.cs
+++ b/Examples/StereoKitTest/Demos/DemoWelcome.cs
@@ -21,7 +21,7 @@ class DemoWelcome : ITest
 		float scale = 1.3f;
 		Vec3  size  = logo.Bounds.dimensions * scale;
 		logo.Draw(Matrix.TRS(V.XYZ(0, size.y/2.0f + 0.05f, 0), Quat.Identity, scale));
-		Text.Add(message, Matrix.S(1.25f), V.XY(.6f, 0), TextFit.Wrap, TextAlign.TopCenter, TextAlign.TopLeft);
+		Text.Add(message, Matrix.S(1.25f), V.XY(.6f, 0), TextFit.Wrap, Pivot.TopCenter, Align.TopLeft);
 		Hierarchy.Pop();
 
 		Demo.ShowSummary("", "", new Bounds(new Vec3(0,-0.05f,0), new Vec3(1, .7f, 0.1f)));

--- a/Examples/StereoKitTest/Docs/DocAnim.cs
+++ b/Examples/StereoKitTest/Docs/DocAnim.cs
@@ -55,8 +55,8 @@ class DocAnim : ITest
 
 		// These are some labels for the progress bar that tell us more about
 		// the active animation.
-		Text.Add($"{model.ActiveAnim.Name} : {model.AnimMode}", Matrix.TS(0, -2*U.cm, 0, 3),        TextAlign.TopLeft);
-		Text.Add($"{model.AnimTime:F1}s",                       Matrix.TS(-progress, 2*U.cm, 0, 3), TextAlign.BottomCenter);
+		Text.Add($"{model.ActiveAnim.Name} : {model.AnimMode}", Matrix.TS(0, -2*U.cm, 0, 3),        Pivot.TopLeft);
+		Text.Add($"{model.AnimTime:F1}s",                       Matrix.TS(-progress, 2*U.cm, 0, 3), Pivot.BottomCenter);
 
 		Hierarchy.Pop();
 		/// :End:

--- a/Examples/StereoKitTest/Docs/DocLastElement.cs
+++ b/Examples/StereoKitTest/Docs/DocLastElement.cs
@@ -22,7 +22,7 @@ class DocLastElement : ITest
 		UI.WindowBegin("Last Element API", ref windowPose);
 
 		UI.HSlider("Slider", ref sliderVal, 0, 1, 0.1f, 0, UIConfirm.Pinch);
-		UI.Text("Element Info:", TextAlign.TopCenter);
+		UI.Text("Element Info:", Align.TopCenter);
 		if (UI.LastElementHandActive (Handed.Left ).IsActive()) UI.Label("Left Active");
 		if (UI.LastElementHandActive (Handed.Right).IsActive()) UI.Label("Right Active");
 		if (UI.LastElementHandFocused(Handed.Left ).IsActive()) UI.Label("Left Focused");

--- a/Examples/StereoKitTest/Docs/DocTexGenParticle.cs
+++ b/Examples/StereoKitTest/Docs/DocTexGenParticle.cs
@@ -36,7 +36,7 @@ class DocTexGenParticle: ITest
 		/// :CodeSample: Tex.GenParticle Sprite.FromTex
 		/// And here's what that looks like when you draw using this code!
 		for (int i = 0; i < sprites.Length; i++)
-			sprites[i].Draw(Matrix.TS(V.XY0(i%5, -i/5)*0.1f, 0.1f), TextAlign.TopRight);
+			sprites[i].Draw(Matrix.TS(V.XY0(i%5, -i/5)*0.1f, 0.1f), Pivot.TopRight);
 		/// ![Generated particle sprites]({{site.screen_url}}/TexGenParticles.jpg)
 		/// :End:
 

--- a/Examples/StereoKitTest/Docs/DocText.cs
+++ b/Examples/StereoKitTest/Docs/DocText.cs
@@ -32,7 +32,7 @@ class DocText : ITest
 		string text  = "lÔTy";
 		TextStyle style = TextStyle.Default;
 
-		Text.Add(text, Matrix.Identity, style, TextAlign.Center);
+		Text.Add(text, Matrix.Identity, style, Pivot.Center);
 
 		// Calculate the text sizes! Layout size is used for placing text, but
 		// render size indicates the total area where text could end up,
@@ -73,7 +73,7 @@ class DocText : ITest
 		string text = "lÔTy";
 
 		// Draw the text
-		Text.Add(text, Matrix.Identity, style, TextAlign.TopLeft, TextAlign.TopLeft);
+		Text.Add(text, Matrix.Identity, style, Pivot.TopLeft, Align.TopLeft);
 
 		// Show the bounding regions for the size of the text
 		Color colLayoutArea = new Color(0.1f,  0.1f, 0.1f);

--- a/Examples/StereoKitTest/Docs/DocUI.cs
+++ b/Examples/StereoKitTest/Docs/DocUI.cs
@@ -100,7 +100,7 @@ class DocUI : ITest
 		UI.Label("Content Header");
 		UI.HSeparator();
 		UI.Text("A separator can go a long way towards making your content "
-		      + "easier to look at!", TextAlign.TopCenter);
+		      + "easier to look at!", Align.TopCenter);
 
 		UI.WindowEnd();
 	}

--- a/Examples/StereoKitTest/Guides/GuideDrawing.cs
+++ b/Examples/StereoKitTest/Guides/GuideDrawing.cs
@@ -256,7 +256,7 @@ class GuideDrawing : ITest
 		/// that position instead! The scale here is also equivalent to the
 		/// size of the image's vertical axis, so this `Sprite` will be 0.5
 		/// meters tall.
-		sprite.Draw(Matrix.TS(0, 10, 0, 0.5f), TextAlign.Center);
+		sprite.Draw(Matrix.TS(0, 10, 0, 0.5f), Pivot.Center);
 		/// ![Drawing a sprite]({{site.screen_url}}/Drawing_Sprite.jpg)
 		/// 
 		/// If you already have a `Tex` with your image loaded, you can pretty

--- a/Examples/StereoKitTest/Guides/GuideUI.cs
+++ b/Examples/StereoKitTest/Guides/GuideUI.cs
@@ -290,9 +290,9 @@ class GuideUI : ITest
 		// then setting the text to align to the center of its element
 		// region.
 		UI.Text("Lorem Ipsum",
-		        TextAlign.Center,
-		        TextFit  .None,
-		        UI       .LayoutRemaining);
+		        Align  .Center,
+		        TextFit.None,
+		        UI     .LayoutRemaining);
 		UI.LayoutPop();
 
 		UI.LayoutPushCut(UICut.Left, 0.1f);

--- a/Examples/StereoKitTest/Tests/TestCustomButton.cs
+++ b/Examples/StereoKitTest/Tests/TestCustomButton.cs
@@ -71,7 +71,7 @@ internal class TestCustomButton : ITest
 		layout.center    .z -= offset / 2;
 		layout.dimensions.z  = offset;
 		Mesh.Cube.Draw(Material.UI, Matrix.TS(layout.center, layout.dimensions), UI.GetElementColor(UIVisual.Button, UI.GetAnimFocus(id, focus, state)));
-		Text.Add(text, Matrix.T(layout.center.x, layout.center.y, -(offset + 0.002f)), UI.TextStyle, TextAlign.Center);
+		Text.Add(text, Matrix.T(layout.center.x, layout.center.y, -(offset + 0.002f)), UI.TextStyle, Pivot.Center);
 
 		return state.IsJustInactive();
 	}
@@ -87,7 +87,7 @@ internal class TestCustomButton : ITest
 		layout.center.z    -= offset / 2;
 		layout.dimensions.z = offset;
 		UI.DrawElement(UIVisual.Button, layout.TLB, layout.dimensions, UI.GetAnimFocus(id, focus, state));
-		Text.Add(text, Matrix.T(layout.center.x, layout.center.y, -(offset + 0.002f)), UI.TextStyle, TextAlign.Center);
+		Text.Add(text, Matrix.T(layout.center.x, layout.center.y, -(offset + 0.002f)), UI.TextStyle, Pivot.Center);
 
 		return state.IsJustInactive();
 	}
@@ -103,7 +103,7 @@ internal class TestCustomButton : ITest
 		layout.center.z    -= offset / 2;
 		layout.dimensions.z = offset;
 		UI.DrawElement(CustomUIVisual.Button, layout.TLB, layout.dimensions, UI.GetAnimFocus(id, focus, state));
-		Text.Add(text, Matrix.T(layout.center.x, layout.center.y, -(offset + 0.002f)), UI.TextStyle, TextAlign.Center);
+		Text.Add(text, Matrix.T(layout.center.x, layout.center.y, -(offset + 0.002f)), UI.TextStyle, Pivot.Center);
 
 		return state.IsJustInactive();
 	}
@@ -119,7 +119,7 @@ internal class TestCustomButton : ITest
 		layout.center.z    -= offset / 2;
 		layout.dimensions.z = offset;
 		UI.DrawElement(CustomUIVisual.Nonexistent, layout.TLB, layout.dimensions, UI.GetAnimFocus(id, focus, state));
-		Text.Add(text, Matrix.T(layout.center.x, layout.center.y, -(offset + 0.002f)), UI.TextStyle, TextAlign.Center);
+		Text.Add(text, Matrix.T(layout.center.x, layout.center.y, -(offset + 0.002f)), UI.TextStyle, Pivot.Center);
 
 		return state.IsJustInactive();
 	}

--- a/Examples/StereoKitTest/Tests/TestFont.cs
+++ b/Examples/StereoKitTest/Tests/TestFont.cs
@@ -16,27 +16,27 @@ class TestFont : ITest
 		Color32 col = new Color32(0, 255, 0, 255);
 
 		Hierarchy.Push(Matrix.T(-0.06f, .05f, 0));
-		Text.Add("Y Top", Matrix.TR(new Vec3(0, .04f, 0), Quat.LookDir(0, 0, 1)), style, TextAlign.TopCenter);
+		Text.Add("Y Top", Matrix.TR(new Vec3(0, .04f, 0), Quat.LookDir(0, 0, 1)), style, Pivot.TopCenter);
 		Lines.Add(new Vec3(-0.05f, .04f, 0), new Vec3(.05f, .04f, 0), col, 0.001f);
 
-		Text.Add("Y Center", Matrix.TR(new Vec3(0, .0f, 0), Quat.LookDir(0, 0, 1)), style, TextAlign.Center);
+		Text.Add("Y Center", Matrix.TR(new Vec3(0, .0f, 0), Quat.LookDir(0, 0, 1)), style, Pivot.Center);
 		Lines.Add(new Vec3(-0.05f, 0, 0), new Vec3(.05f, 0, 0), col, 0.001f);
 
-		Text.Add("Y Bottom", Matrix.TR(new Vec3(0, -.04f, 0), Quat.LookDir(0, 0, 1)), style, TextAlign.BottomCenter);
+		Text.Add("Y Bottom", Matrix.TR(new Vec3(0, -.04f, 0), Quat.LookDir(0, 0, 1)), style, Pivot.BottomCenter);
 		Lines.Add(new Vec3(-0.05f, -.04f, 0), new Vec3(.05f, -.04f, 0), col, 0.001f);
 		Hierarchy.Pop();
 
 		Hierarchy.Push(Matrix.T(0.02f, 0.05f, 0));
-		Text.Add("2cm Tall", Matrix.R(Quat.LookDir(0, 0, 1)), style, TextAlign.CenterLeft);
+		Text.Add("2cm Tall", Matrix.R(Quat.LookDir(0, 0, 1)), style, Pivot.CenterLeft);
 		
 		Lines.Add(new Vec3(0, -.01f, 0), new Vec3( .11f, -.01f, 0), col, 0.001f);
 		Lines.Add(new Vec3(0,  .01f, 0), new Vec3( .11f,  .01f, 0), col, 0.001f);
 		Hierarchy.Pop();
 
 		Hierarchy.Push(Matrix.T(0, -0.06f, 0));
-		Text.Add("X Left",   Matrix.TR(new Vec3(0, 0.04f, 0), Quat.LookDir(0, 0, 1)), style, TextAlign.CenterLeft);
-		Text.Add("X Center", Matrix.TR(new Vec3(0, 0,     0), Quat.LookDir(0, 0, 1)), style, TextAlign.Center);
-		Text.Add("X Right",  Matrix.TR(new Vec3(0,-0.04f, 0), Quat.LookDir(0, 0, 1)), style, TextAlign.CenterRight);
+		Text.Add("X Left",   Matrix.TR(new Vec3(0, 0.04f, 0), Quat.LookDir(0, 0, 1)), style, Pivot.CenterLeft);
+		Text.Add("X Center", Matrix.TR(new Vec3(0, 0,     0), Quat.LookDir(0, 0, 1)), style, Pivot.Center);
+		Text.Add("X Right",  Matrix.TR(new Vec3(0,-0.04f, 0), Quat.LookDir(0, 0, 1)), style, Pivot.CenterRight);
 		Lines.Add(new Vec3(0, .06f, 0), new Vec3(0, -.06f, 0), col, 0.001f);
 		Hierarchy.Pop();
 

--- a/Examples/StereoKitTest/Tests/TestSprite.cs
+++ b/Examples/StereoKitTest/Tests/TestSprite.cs
@@ -17,16 +17,16 @@ class TestSprite : ITest
 		Lines.Add(V.XYZ( 0.1f,-1,    0), V.XYZ( 0.1f,1,    0), new Color32(0,255,0,128), 0.001f);
 		Lines.Add(V.XYZ(-0.1f,-1,    0), V.XYZ(-0.1f,1,    0), new Color32(0,255,0,128), 0.001f);
 		
-		sprite.Draw(Matrix.TS( 0.1f, 0.05f, 0, 0.03f), TextAlign.BottomRight);  // Left
-		sprite.Draw(Matrix.TS( 0,    0.05f, 0, 0.03f), TextAlign.BottomCenter); // Center
-		sprite.Draw(Matrix.TS(-0.1f, 0.05f, 0, 0.03f), TextAlign.BottomLeft);   // Right
+		sprite.Draw(Matrix.TS( 0.1f, 0.05f, 0, 0.03f), Pivot.BottomRight);  // Left
+		sprite.Draw(Matrix.TS( 0,    0.05f, 0, 0.03f), Pivot.BottomCenter); // Center
+		sprite.Draw(Matrix.TS(-0.1f, 0.05f, 0, 0.03f), Pivot.BottomLeft);   // Right
 		
-		sprite.Draw(Matrix.TS( 0.1f, 0, 0, 0.03f), TextAlign.CenterRight);      // Left
-		sprite.Draw(Matrix.S ( 0.03f),             TextAlign.Center);           // Center
-		sprite.Draw(Matrix.TS(-0.1f, 0, 0, 0.03f), TextAlign.CenterLeft);       // Right
+		sprite.Draw(Matrix.TS( 0.1f, 0, 0, 0.03f), Pivot.CenterRight);      // Left
+		sprite.Draw(Matrix.S ( 0.03f),             Pivot.Center);           // Center
+		sprite.Draw(Matrix.TS(-0.1f, 0, 0, 0.03f), Pivot.CenterLeft);       // Right
 
-		sprite.Draw(Matrix.TS( 0.1f, -0.05f, 0, 0.03f), TextAlign.TopRight);    // Left
-		sprite.Draw(Matrix.TS( 0,    -0.05f, 0, 0.03f), TextAlign.TopCenter);   // Center
-		sprite.Draw(Matrix.TS(-0.1f, -0.05f, 0, 0.03f), TextAlign.TopLeft);     // Right
+		sprite.Draw(Matrix.TS( 0.1f, -0.05f, 0, 0.03f), Pivot.TopRight);    // Left
+		sprite.Draw(Matrix.TS( 0,    -0.05f, 0, 0.03f), Pivot.TopCenter);   // Center
+		sprite.Draw(Matrix.TS(-0.1f, -0.05f, 0, 0.03f), Pivot.TopLeft);     // Right
 	}
 }

--- a/Examples/StereoKitTest/Tests/TestText.cs
+++ b/Examples/StereoKitTest/Tests/TestText.cs
@@ -24,7 +24,7 @@ class TestText : ITest
 
 		Quat r  = Quat.FromAngles(0, 180, 0);
 		Vec3 at = new Vec3(0.52f,0.35f,-0.5f);
-		Text.Add(scenders, Matrix.TR(at, r), style, TextAlign.TopLeft, TextAlign.TopLeft);
+		Text.Add(scenders, Matrix.TR(at, r), style, Pivot.TopLeft, Align.TopLeft);
 		Vec2 s = Text.SizeLayout(scenders, style);
 		Mesh.Cube.Draw(Material.Unlit, Matrix.TS(at.x + s.x / 2, at.y - s.y / 2, at.z - 0.001f, new Vec3(s.x, s.y, 0.001f)), colLayout);
 		s = Text.SizeRender(s, style, out float offset);
@@ -36,27 +36,27 @@ class TestText : ITest
 
 		at = new Vec3(0.52f, 0.15f, -0.5f);
 		s = Text.SizeLayout(shortText, style, 0.5f);
-		Text.Add(shortText, Matrix.TR(at, r), new Vec2(0.5f, s.y), TextFit.Wrap, style, TextAlign.TopLeft, TextAlign.TopLeft);
+		Text.Add(shortText, Matrix.TR(at, r), new Vec2(0.5f, s.y), TextFit.Wrap, style, Pivot.TopLeft, Align.TopLeft);
 		Mesh.Cube.Draw(Material.Unlit, Matrix.TS(at.x + s.x / 2, at.y - s.y / 2, at.z - 0.001f, new Vec3(s.x, s.y, 0.001f)), colLayout);
 		s = Text.SizeRender(s, style, out offset);
 		Mesh.Cube.Draw(Material.Unlit, Matrix.TS(at.x + s.x / 2, at.y - s.y / 2 + offset, at.z - 0.002f, new Vec3(s.x, s.y, 0.001f)), colRender);
 
 		at = new Vec3(0, 0.35f, -0.5f);
 		s = Text.SizeLayout(longText, style, 0.5f);
-		Text.Add(longText, Matrix.TR(at, r), new Vec2(0.5f,s.y), TextFit.Wrap, style, TextAlign.TopLeft, TextAlign.TopLeft);
+		Text.Add(longText, Matrix.TR(at, r), new Vec2(0.5f,s.y), TextFit.Wrap, style, Pivot.TopLeft, Align.TopLeft);
 		Mesh.Cube.Draw(Material.Unlit, Matrix.TS(at.x + s.x / 2, at.y - s.y / 2, at.z - 0.001f, new Vec3(s.x, s.y, 0.001f)), colLayout);
 		s = Text.SizeRender(s, style, out offset);
 		Mesh.Cube.Draw(Material.Unlit, Matrix.TS(at.x + s.x / 2, at.y - s.y / 2 + offset, at.z - 0.002f, new Vec3(s.x, s.y, 0.001f)), colRender);
 
 		at = new Vec3(0.52f, 0.2f, -0.5f);
-		Text.Add(shortText, Matrix.TR(at, r), style, TextAlign.TopLeft, TextAlign.TopLeft);
+		Text.Add(shortText, Matrix.TR(at, r), style, Pivot.TopLeft, Align.TopLeft);
 		s = Text.SizeLayout(shortText, style);
 		Mesh.Cube.Draw(Material.Unlit, Matrix.TS(at.x + s.x / 2, at.y - s.y / 2, at.z - 0.001f, new Vec3(s.x, s.y, 0.001f)), colLayout);
 		s = Text.SizeRender(s, style, out offset);
 		Mesh.Cube.Draw(Material.Unlit, Matrix.TS(at.x + s.x / 2, at.y - s.y / 2 + offset, at.z - 0.002f, new Vec3(s.x, s.y, 0.001f)), colRender);
 
 		at = new Vec3(0, 0.05f, -0.5f);
-		Text.Add(longText, Matrix.TR(at, r), style, TextAlign.TopLeft, TextAlign.TopLeft);
+		Text.Add(longText, Matrix.TR(at, r), style, Pivot.TopLeft, Align.TopLeft);
 		s = Text.SizeLayout(longText, style);
 		Mesh.Cube.Draw(Material.Unlit, Matrix.TS(at.x + s.x / 2, at.y - s.y / 2, at.z - 0.001f, new Vec3(s.x, s.y, 0.001f)), colLayout);
 		s = Text.SizeRender(s, style, out offset);

--- a/Examples/StereoKitTest/Tests/TestTextConstraint.cs
+++ b/Examples/StereoKitTest/Tests/TestTextConstraint.cs
@@ -15,7 +15,7 @@ class TestTextConstraint : ITest
 	static void Show(string text, Vec2 at, float width)
 	{
 		Vec2 size = Text.SizeLayout(text, TextStyle.Default, width);
-		Text.Add(text, Matrix.T(at.x, at.y, 0), new Vec2(width, 0), TextFit.Wrap | TextFit.Clip, TextAlign.TopLeft, TextAlign.TopLeft);
+		Text.Add(text, Matrix.T(at.x, at.y, 0), new Vec2(width, 0), TextFit.Wrap | TextFit.Clip, Pivot.TopLeft, Align.TopLeft);
 		Lines.Add(new Vec3(at.XY0), new Vec3(at.x, at.y - size.y,0), Color.Black, 0.001f);
 		Lines.Add(new Vec3(at.x-size.x, at.y, 0), new Vec3((at-size).XY0), Color.Black, 0.001f);
 	}

--- a/Examples/StereoKitTest/Tests/TestUIDisabled.cs
+++ b/Examples/StereoKitTest/Tests/TestUIDisabled.cs
@@ -84,7 +84,7 @@ class TestUIDisabled : ITest
 			Log.Err("Text Input field value modified.");
 		}
 		UI.HProgressBar(percent);
-		UI.Text("UI.Text", TextAlign.TopLeft);
+		UI.Text("UI.Text", Align.TopLeft);
 		if (UI.VSlider("UI.VSlider", ref vSliderVal, 0, 1, 0, 0.15f, UIConfirm.Push))
 		{
 			controlsEnabled++;

--- a/Examples/StereoKitTest/Tests/TestUILayoutCuts.cs
+++ b/Examples/StereoKitTest/Tests/TestUILayoutCuts.cs
@@ -59,7 +59,7 @@ class TestUILayoutCuts : ITest
 		UI.LayoutPushCut(UICut.Top, UI.LineHeight);
 		UI.Button  ("Back");
 		UI.SameLine();
-		UI.Text    ("Dagoth Wave", TextAlign.Center, TextFit.Clip, new Vec2(UI.LayoutRemaining.x, UI.LineHeight));
+		UI.Text    ("Dagoth Wave", Align.Center, TextFit.Clip, new Vec2(UI.LayoutRemaining.x, UI.LineHeight));
 		UI.LayoutPop();
 
 		float width = 0.1f;

--- a/Examples/StereoKitTest/Tools/LogWindow.cs
+++ b/Examples/StereoKitTest/Tools/LogWindow.cs
@@ -109,12 +109,12 @@ namespace StereoKit.Framework
 					_                  => styleInfo,
 				};
 				float y = (i - index) * -textSize.y;
-				Text.Add(item.text, Matrix.T(start + new Vec3(0,y, -.004f)), textSize, TextFit.Clip | TextFit.Wrap, ts, TextAlign.TopLeft, TextAlign.CenterLeft);
+				Text.Add(item.text, Matrix.T(start + new Vec3(0,y, -.004f)), textSize, TextFit.Clip | TextFit.Wrap, ts, Pivot.TopLeft, Align.CenterLeft);
 
 				if (item.count > 1)
 				{
 					Vec3 at = V.XYZ(start.x - textSize.x, start.y + y, start.z-0.014f);
-					Text.Add(item.count.ToString(), Matrix.T(at), V.XY(textSize.y, textSize.y), TextFit.Clip, styleInfo, TextAlign.TopRight, TextAlign.Center);
+					Text.Add(item.count.ToString(), Matrix.T(at), V.XY(textSize.y, textSize.y), TextFit.Clip, styleInfo, Pivot.TopRight, Align.Center);
 				}
 			}
 			UI.LayoutPop();
@@ -206,10 +206,9 @@ namespace StereoKit.Framework
 				}
 				Lines.Add(points);
 
-				Text.Add(((int)max).ToString(), Matrix.TS(at.x-size.x, at.y,        at.z, textScale), V.XY(labelWidth*textScale, 1), TextFit.Overflow, style, TextAlign.TopLeft,    TextAlign.TopLeft);
-				Text.Add(((int)min).ToString(), Matrix.TS(at.x-size.x, at.y-size.y, at.z, textScale), V.XY(labelWidth*textScale, 1), TextFit.Overflow, style, TextAlign.BottomLeft, TextAlign.BottomLeft);
-				Text.Add(label,                 Matrix.TS(at.x,        at.y,        at.z, textScale),                                                  style, TextAlign.TopLeft,    TextAlign.TopLeft);
-
+				Text.Add(((int)max).ToString(), Matrix.TS(at.x-size.x, at.y,        at.z, textScale), V.XY(labelWidth*textScale, 1), TextFit.Overflow, style, Pivot.TopLeft,    Align.TopLeft);
+				Text.Add(((int)min).ToString(), Matrix.TS(at.x-size.x, at.y-size.y, at.z, textScale), V.XY(labelWidth*textScale, 1), TextFit.Overflow, style, Pivot.BottomLeft, Align.BottomLeft);
+				Text.Add(label,                 Matrix.TS(at.x,        at.y,        at.z, textScale),                                                  style, Pivot.TopLeft,    Align.TopLeft);
 				Lines.Add(at+V.XY0(-Text.SizeLayout(label, style).x*textScale - 0.002f, 0), at + V.XY0(-size.x, 0), new Color32(255,255,255,20), 0.001f);
 				Lines.Add(at+V.XY0(0, -size.y), at + V.XY0(-size.x, -size.y), new Color32(255, 255, 255, 20), 0.001f);
 

--- a/Examples/StereoKitTest/Tools/RenderCamera.cs
+++ b/Examples/StereoKitTest/Tools/RenderCamera.cs
@@ -78,7 +78,7 @@ namespace StereoKit.Framework
 			{
 				Hierarchy.Push(Matrix.TR(previewAt, Quat.LookAt(previewAt, Input.Head.position)));
 				Default.MeshQuad.Draw(_frameMaterial, Matrix.S(V.XYZ(0.08f * ((float)Width / Height), 0.08f, 1)));
-				Text.Add(""+(int)fov, Matrix.TS(-0.03f,0,0, 0.5f), TextAlign.CenterLeft);
+				Text.Add(""+(int)fov, Matrix.TS(-0.03f,0,0, 0.5f), Pivot.CenterLeft);
 				Hierarchy.Pop();
 
 				Matrix glFix = Backend.Graphics == BackendGraphics.D3D11 ? Matrix.Identity : Matrix.R(0,0,180);

--- a/StereoKit/Assets/Sprite.cs
+++ b/StereoKit/Assets/Sprite.cs
@@ -72,17 +72,17 @@ namespace StereoKit
 		/// space as 1 x Aspect meters on the x and y axes respectively, so
 		/// scale appropriately and remember that your anchor position may
 		/// affect the transform as well.</param>
-		/// <param name="anchorPosition">Describes what corner of the sprite
-		/// you're specifying the transform of. The 'Anchor' point or
+		/// <param name="pivotPosition">Describes what corner of the sprite
+		/// you're specifying the transform of. The 'Pivot' point or
 		/// 'Origin' of the Sprite.</param>
-		public void Draw(in Matrix transform, TextAlign anchorPosition)
-			=> NativeAPI.sprite_draw(_inst, transform, anchorPosition, Color32.White);
+		public void Draw(in Matrix transform, Pivot pivotPosition)
+			=> NativeAPI.sprite_draw(_inst, transform, pivotPosition, Color32.White);
 
-		/// <inheritdoc cref="Draw(in Matrix, TextAlign)"/>
+		/// <inheritdoc cref="Draw(in Matrix, Pivot)"/>
 		/// <param name="linearColor">Per-instance color data for this render
 		/// item. It is unmodified by StereoKit, and is generally interpreted
 		/// as linear.</param>
-		public void Draw(in Matrix transform, TextAlign anchorPosition, Color32 linearColor)
+		public void Draw(in Matrix transform, Pivot anchorPosition, Color32 linearColor)
 			=> NativeAPI.sprite_draw(_inst, transform, anchorPosition, linearColor);
 
 		/// <summary>Finds a sprite that matches the given id! Check out the

--- a/StereoKit/Framework/HandMenu/HandMenuItem.cs
+++ b/StereoKit/Framework/HandMenu/HandMenuItem.cs
@@ -64,13 +64,13 @@ namespace StereoKit.Framework
 				float height = TextStyle.Default.LayoutHeight;
 				Vec3  offset = new Vec3(0, height * 0.75f, 0);
 				Hierarchy.Push(Matrix.TS(at, focused ? 1.2f : 1));
-					image.Draw(Matrix.TS(offset, height), TextAlign.Center);
-					Text.Add(name, Matrix.TS(-offset, .5f), TextAlign.BottomCenter);
+					image.Draw(Matrix.TS(offset, height), Pivot.Center);
+					Text.Add(name, Matrix.TS(-offset, .5f), Pivot.BottomCenter);
 				Hierarchy.Pop();
 			}
 			else
 			{
-				Text.Add(name, Matrix.TS(at, focused ? 0.6f : 0.5f), TextAlign.BottomCenter);
+				Text.Add(name, Matrix.TS(at, focused ? 0.6f : 0.5f), Pivot.BottomCenter);
 			}
 		}
 	}

--- a/StereoKit/Native/NativeAPI.cs
+++ b/StereoKit/Native/NativeAPI.cs
@@ -315,8 +315,8 @@ namespace StereoKit
 		[DllImport(dll, CharSet = cSet,            CallingConvention = call)] public static extern TextStyle text_make_style                (IntPtr font, float character_height, Color color);
 		[DllImport(dll, CharSet = cSet,            CallingConvention = call)] public static extern TextStyle text_make_style_shader         (IntPtr font, float character_height, IntPtr shader, Color color);
 		[DllImport(dll, CharSet = cSet,            CallingConvention = call)] public static extern TextStyle text_make_style_mat            (IntPtr font, float character_height, IntPtr material, Color color);
-		[DllImport(dll, CharSet = CharSet.Unicode, CallingConvention = call)] public static extern void      text_add_at_16                 (string text, in Matrix transform, TextStyle style, TextAlign position, TextAlign align, float off_x, float off_y, float off_z, Color vertex_tint_linear);
-		[DllImport(dll, CharSet = CharSet.Unicode, CallingConvention = call)] public static extern float     text_add_in_16                 (string text, in Matrix transform, Vec2 size, TextFit fit, TextStyle style, TextAlign position, TextAlign align, float off_x, float off_y, float off_z, Color vertex_tint_linear);
+		[DllImport(dll, CharSet = CharSet.Unicode, CallingConvention = call)] public static extern void      text_add_at_16                 (string text, in Matrix transform, TextStyle style, Pivot position, Align align, float off_x, float off_y, float off_z, Color vertex_tint_linear);
+		[DllImport(dll, CharSet = CharSet.Unicode, CallingConvention = call)] public static extern float     text_add_in_16                 (string text, in Matrix transform, Vec2 size, TextFit fit, TextStyle style, Pivot position, Align align, float off_x, float off_y, float off_z, Color vertex_tint_linear);
 		[DllImport(dll, CharSet = CharSet.Unicode, CallingConvention = call)] public static extern Vec2      text_size_layout_16            (string text, TextStyle style);
 		[DllImport(dll, CharSet = CharSet.Unicode, CallingConvention = call)] public static extern Vec2      text_size_layout_constrained_16(string text, TextStyle style, float max_width);
 		[DllImport(dll, CharSet = CharSet.Unicode, CallingConvention = call)] public static extern Vec2      text_size_render               (Vec2 layout_size, TextStyle style, out float out_y_offset);
@@ -412,7 +412,7 @@ namespace StereoKit
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr sprite_get_id     (IntPtr sprite);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   sprite_release    (IntPtr sprite);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern float  sprite_get_aspect (IntPtr sprite);
-		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   sprite_draw       (IntPtr sprite, Matrix transform, TextAlign position, Color32 color);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   sprite_draw       (IntPtr sprite, Matrix transform, Pivot position, Color32 color);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern int    sprite_get_width  (IntPtr sprite);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern int    sprite_get_height (IntPtr sprite);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern Vec2   sprite_get_dimensions_normalized(IntPtr sprite);
@@ -832,17 +832,17 @@ namespace StereoKit
 		[DllImport(dll, CharSet = CharSet.Unicode, CallingConvention = call)] public static extern void ui_label_16        (string text, [MarshalAs(UnmanagedType.Bool)] bool use_padding);
 		[DllImport(dll, CharSet = CharSet.Unicode, CallingConvention = call)] public static extern void ui_label_sz_16     (string text, Vec2 size, [MarshalAs(UnmanagedType.Bool)] bool use_padding);
 		[return: MarshalAs(UnmanagedType.Bool)]
-		[DllImport(dll, CharSet = CharSet.Unicode, CallingConvention = call)] public static extern bool ui_text_16         (string text, ref Vec2 scroll, UIScroll scrollDirection, float height, TextAlign text_align, TextFit fit);
+		[DllImport(dll, CharSet = CharSet.Unicode, CallingConvention = call)] public static extern bool ui_text_16         (string text, ref Vec2 scroll, UIScroll scrollDirection, float height, Align text_align, TextFit fit);
 		[return: MarshalAs(UnmanagedType.Bool)]
-		[DllImport(dll, CharSet = CharSet.Unicode, CallingConvention = call)] public static extern bool ui_text_16         (string text, IntPtr   scroll, UIScroll scrollDirection, float height, TextAlign text_align, TextFit fit);
+		[DllImport(dll, CharSet = CharSet.Unicode, CallingConvention = call)] public static extern bool ui_text_16         (string text, IntPtr   scroll, UIScroll scrollDirection, float height, Align text_align, TextFit fit);
 		[return: MarshalAs(UnmanagedType.Bool)]
-		[DllImport(dll, CharSet = CharSet.Unicode, CallingConvention = call)] public static extern bool ui_text_sz_16      (string text, ref Vec2 scroll, UIScroll scrollDirection, Vec2  size,   TextAlign text_align, TextFit fit);
+		[DllImport(dll, CharSet = CharSet.Unicode, CallingConvention = call)] public static extern bool ui_text_sz_16      (string text, ref Vec2 scroll, UIScroll scrollDirection, Vec2  size,   Align text_align, TextFit fit);
 		[return: MarshalAs(UnmanagedType.Bool)]
-		[DllImport(dll, CharSet = CharSet.Unicode, CallingConvention = call)] public static extern bool ui_text_sz_16      (string text, IntPtr   scroll, UIScroll scrollDirection, Vec2  size,   TextAlign text_align, TextFit fit);
+		[DllImport(dll, CharSet = CharSet.Unicode, CallingConvention = call)] public static extern bool ui_text_sz_16      (string text, IntPtr   scroll, UIScroll scrollDirection, Vec2  size,   Align text_align, TextFit fit);
 		[return: MarshalAs(UnmanagedType.Bool)]
-		[DllImport(dll, CharSet = CharSet.Unicode, CallingConvention = call)] public static extern bool ui_text_at_16      (string text, ref Vec2 scroll, UIScroll scrollDirection, TextAlign text_align, TextFit fit, Vec3 window_relative_pos, Vec2 size);
+		[DllImport(dll, CharSet = CharSet.Unicode, CallingConvention = call)] public static extern bool ui_text_at_16      (string text, ref Vec2 scroll, UIScroll scrollDirection, Align text_align, TextFit fit, Vec3 window_relative_pos, Vec2 size);
 		[return: MarshalAs(UnmanagedType.Bool)]
-		[DllImport(dll, CharSet = CharSet.Unicode, CallingConvention = call)] public static extern bool ui_text_at_16      (string text, IntPtr   scroll, UIScroll scrollDirection, TextAlign text_align, TextFit fit, Vec3 window_relative_pos, Vec2 size);
+		[DllImport(dll, CharSet = CharSet.Unicode, CallingConvention = call)] public static extern bool ui_text_at_16      (string text, IntPtr   scroll, UIScroll scrollDirection, Align text_align, TextFit fit, Vec3 window_relative_pos, Vec2 size);
 		[DllImport(dll, CharSet = cSet,            CallingConvention = call)] public static extern void ui_image           (IntPtr sprite_image, Vec2 size);
 		[return: MarshalAs(UnmanagedType.Bool)]
 		[DllImport(dll, CharSet = CharSet.Unicode, CallingConvention = call)] public static extern bool ui_button_16       (string text);

--- a/StereoKit/Native/NativeEnums.cs
+++ b/StereoKit/Native/NativeEnums.cs
@@ -680,9 +680,14 @@ namespace StereoKit
 	}
 
 	/// <summary>A bit-flag enum for describing alignment or positioning.
-	/// Items can be combined using the '|' operator, like so:</summary>
+	/// Items can be combined using the '|' operator, like so:
+	/// `Align alignment = Align.YTop | Align.XLeft;`
+	/// Avoid combining multiple items of the same axis. There are also a
+	/// complete list of valid bit flag combinations! These are the values
+	/// without an axis listed in their names, 'TopLeft', 'BottomCenter',
+	/// etc.</summary>
 	[Flags]
-	public enum TextAlign {
+	public enum Align {
 		/// <summary>On the x axis, this item should start on the left.</summary>
 		XLeft        = 1 << 0,
 		/// <summary>On the y axis, this item should start at the top.</summary>
@@ -695,13 +700,63 @@ namespace StereoKit
 		XRight       = 1 << 4,
 		/// <summary>On the y axis, this item should start on the bottom.</summary>
 		YBottom      = 1 << 5,
-		/// <summary>Center on both X and Y axes. This is a combination of 
+		/// <summary>Center on both X and Y axes. This is a combination of
 		/// XCenter and YCenter.</summary>
 		Center       = XCenter | YCenter,
-		/// <summary>Start on the left of the X axis, center on the Y axis. 
+		/// <summary>Start on the left of the X axis, center on the Y axis.
 		/// This is a combination of XLeft and YCenter.</summary>
 		CenterLeft   = XLeft | YCenter,
-		/// <summary>Start on the right of the X axis, center on the Y axis. 
+		/// <summary>Start on the right of the X axis, center on the Y axis.
+		/// This is a combination of XRight and YCenter.</summary>
+		CenterRight  = XRight | YCenter,
+		/// <summary>Center on the X axis, and top on the Y axis. This is a
+		/// combination of XCenter and YTop.</summary>
+		TopCenter    = XCenter | YTop,
+		/// <summary>Start on the left of the X axis, and top on the Y axis.
+		/// This is a combination of XLeft and YTop.</summary>
+		TopLeft      = XLeft | YTop,
+		/// <summary>Start on the right of the X axis, and top on the Y axis.
+		/// This is a combination of XRight and YTop.</summary>
+		TopRight     = XRight | YTop,
+		/// <summary>Center on the X axis, and bottom on the Y axis. This is
+		/// a combination of XCenter and YBottom.</summary>
+		BottomCenter = XCenter | YBottom,
+		/// <summary>Start on the left of the X axis, and bottom on the Y
+		/// axis. This is a combination of XLeft and YBottom.</summary>
+		BottomLeft   = XLeft | YBottom,
+		/// <summary>Start on the right of the X axis, and bottom on the Y
+		/// axis.This is a combination of XRight and YBottom.</summary>
+		BottomRight  = XRight | YBottom,
+	}
+
+	/// <summary>A bit-flag enum for describing alignment or positioning.
+	/// Items can be combined using the '|' operator, like so:
+	/// `Align alignment = Align.YTop | Align.XLeft;`
+	/// Avoid combining multiple items of the same axis. There are also a
+	/// complete list of valid bit flag combinations! These are the values
+	/// without an axis listed in their names, 'TopLeft', 'BottomCenter',
+	/// etc.</summary>
+	[Flags]
+	public enum Pivot {
+		/// <summary>On the x axis, this item should start on the left.</summary>
+		XLeft        = 1 << 0,
+		/// <summary>On the y axis, this item should start at the top.</summary>
+		YTop         = 1 << 1,
+		/// <summary>On the x axis, the item should be centered.</summary>
+		XCenter      = 1 << 2,
+		/// <summary>On the y axis, the item should be centered.</summary>
+		YCenter      = 1 << 3,
+		/// <summary>On the x axis, this item should start on the right.</summary>
+		XRight       = 1 << 4,
+		/// <summary>On the y axis, this item should start on the bottom.</summary>
+		YBottom      = 1 << 5,
+		/// <summary>Center on both X and Y axes. This is a combination of
+		/// XCenter and YCenter.</summary>
+		Center       = XCenter | YCenter,
+		/// <summary>Start on the left of the X axis, center on the Y axis.
+		/// This is a combination of XLeft and YCenter.</summary>
+		CenterLeft   = XLeft | YCenter,
+		/// <summary>Start on the right of the X axis, center on the Y axis.
 		/// This is a combination of XRight and YCenter.</summary>
 		CenterRight  = XRight | YCenter,
 		/// <summary>Center on the X axis, and top on the Y axis. This is a

--- a/StereoKit/Native/NativeTypes.cs
+++ b/StereoKit/Native/NativeTypes.cs
@@ -945,4 +945,94 @@ namespace StereoKit
 		/// focus of the slider. Or -1 if there is no interaction.</summary>
 		public int      interactor;
 	}
+
+    /// <summary>A bit-flag enum for describing alignment or positioning.
+    /// Items can be combined using the '|' operator, like so:
+    /// `Align alignment = Align.YTop | Align.XLeft;`
+    /// Avoid combining multiple items of the same axis. There are also a
+    /// complete list of valid bit flag combinations! These are the values
+    /// without an axis listed in their names, 'TopLeft', 'BottomCenter',
+    /// etc.</summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct TextAlign
+    {
+		private int value;
+		private TextAlign(int v) => value = v;
+		private TextAlign(TextAlign v) => value = v.value;
+
+        /// <summary>On the x axis, this item should start on the left.</summary>
+        public static TextAlign XLeft = new TextAlign(1 << 0);
+		/// <summary>On the y axis, this item should start at the top.</summary>
+		public static TextAlign YTop = new TextAlign(1 << 1);
+		/// <summary>On the x axis, the item should be centered.</summary>
+		public static TextAlign XCenter = new TextAlign(1 << 2);
+		/// <summary>On the y axis, the item should be centered.</summary>
+		public static TextAlign YCenter = new TextAlign(1 << 3);
+		/// <summary>On the x axis, this item should start on the right.</summary>
+		public static TextAlign XRight = new TextAlign(1 << 4);
+		/// <summary>On the y axis, this item should start on the bottom.</summary>
+		public static TextAlign YBottom = new TextAlign(1 << 5);
+		/// <summary>Center on both X and Y axes. This is a combination of 
+		/// XCenter and YCenter.</summary>
+		public static TextAlign Center = new TextAlign(XCenter | YCenter);
+		/// <summary>Start on the left of the X axis, center on the Y axis. 
+		/// This is a combination of XLeft and YCenter.</summary>
+		public static TextAlign CenterLeft = new TextAlign(XLeft | YCenter);
+		/// <summary>Start on the right of the X axis, center on the Y axis. 
+		/// This is a combination of XRight and YCenter.</summary>
+		public static TextAlign CenterRight = new TextAlign(XRight | YCenter);
+		/// <summary>Center on the X axis, and top on the Y axis. This is a
+		/// combination of XCenter and YTop.</summary>
+		public static TextAlign TopCenter = new TextAlign(XCenter | YTop);
+		/// <summary>Start on the left of the X axis, and top on the Y axis.
+		/// This is a combination of XLeft and YTop.</summary>
+		public static TextAlign TopLeft = new TextAlign(XLeft | YTop);
+		/// <summary>Start on the right of the X axis, and top on the Y axis.
+		/// This is a combination of XRight and YTop.</summary>
+		public static TextAlign TopRight = new TextAlign(XRight | YTop);
+		/// <summary>Center on the X axis, and bottom on the Y axis. This is
+		/// a combination of XCenter and YBottom.</summary>
+		public static TextAlign BottomCenter = new TextAlign(XCenter | YBottom);
+		/// <summary>Start on the left of the X axis, and bottom on the Y
+		/// axis. This is a combination of XLeft and YBottom.</summary>
+		public static TextAlign BottomLeft = new TextAlign(XLeft | YBottom);
+		/// <summary>Start on the right of the X axis, and bottom on the Y
+		/// axis.This is a combination of XRight and YBottom.</summary>
+		public static TextAlign BottomRight = new TextAlign(XRight | YBottom);
+
+		/// <summary>Allow Flag-like enum behavior.</summary>
+		/// <param name="a">First TextAlign</param>
+		/// <param name="b">Second TextAlign</param>
+		/// <returns>Bitwise operation of a and b.</returns>
+		public static TextAlign operator |(TextAlign a, TextAlign b) => new TextAlign(a.value | b.value);
+        /// <summary>Allow Flag-like enum behavior.</summary>
+        /// <param name="a">First TextAlign</param>
+        /// <param name="b">Second TextAlign</param>
+        /// <returns>Bitwise operation of a and b.</returns>
+        public static TextAlign operator &(TextAlign a, TextAlign b) => new TextAlign(a.value & b.value);
+        /// <summary>Allow Flag-like enum behavior.</summary>
+        /// <param name="a">First TextAlign</param>
+        /// <param name="b">Second TextAlign</param>
+        /// <returns>Bitwise operation of a and b.</returns>
+        public static TextAlign operator ^(TextAlign a, TextAlign b) => new TextAlign(a.value ^ b.value);
+        /// <summary>Allow Flag-like enum behavior.</summary>
+        /// <param name="a">First TextAlign</param>
+        /// <returns>Bitwise operation of a.</returns>
+        public static TextAlign operator ~(TextAlign a) => new TextAlign(~a.value);
+
+        /// <summary>For back compatibility, allows conversion from a TextAlign
+        /// into an Align while providing a good obsolescence message for it.
+		/// </summary>
+        /// <param name="a">Source TextAlign.</param>
+        /// <returns>An equivalent Align.</returns>
+        [Obsolete("Use Align instead")]
+        public static implicit operator Align(TextAlign a) => (Align)a;
+        /// <summary>For back compatibility, allows conversion from a TextAlign
+        /// into a Pivot while providing a good obsolescence message for it.
+		/// </summary>
+        /// <param name="a">Source TextAlign.</param>
+        /// <returns>An equivalent Pivot.</returns>
+        [Obsolete("Use Pivot instead")]
+        public static implicit operator Pivot(TextAlign a) => (Pivot)a;
+    }
 }

--- a/StereoKit/Systems/Text.cs
+++ b/StereoKit/Systems/Text.cs
@@ -246,7 +246,7 @@ namespace StereoKit
 		/// <param name="offX">An additional offset on the X axis.</param>
 		/// <param name="offY">An additional offset on the Y axis.</param>
 		/// <param name="offZ">An additional offset on the Z axis.</param>
-		public static void Add(string text, Matrix transform, TextStyle style, TextAlign position = TextAlign.Center, TextAlign align = TextAlign.Center, float offX=0, float offY=0, float offZ=0) 
+		public static void Add(string text, Matrix transform, TextStyle style, Pivot position = Pivot.Center, Align align = Align.Center, float offX=0, float offY=0, float offZ=0) 
 			=> NativeAPI.text_add_at_16(text, transform, style, position, align, offX, offY, offZ, Color.White);
 
 		/// <summary>Renders text at the given location! Must be called every
@@ -261,21 +261,21 @@ namespace StereoKit
 		/// <param name="offX">An additional offset on the X axis.</param>
 		/// <param name="offY">An additional offset on the Y axis.</param>
 		/// <param name="offZ">An additional offset on the Z axis.</param>
-		public static void Add(string text, Matrix transform, TextAlign position = TextAlign.Center, TextAlign align = TextAlign.Center, float offX = 0, float offY = 0, float offZ = 0)
+		public static void Add(string text, Matrix transform, Pivot position = Pivot.Center, Align align = Align.Center, float offX = 0, float offY = 0, float offZ = 0)
 			=> NativeAPI.text_add_at_16(text, transform, TextStyle.Default, position, align, offX, offY, offZ, Color.White);
 
-		/// <inheritdoc cref="Add(string, Matrix, TextStyle, TextAlign, TextAlign, float, float, float)"/>
+		/// <inheritdoc cref="Add(string, Matrix, TextStyle, Pivot, Align, float, float, float)"/>
 		/// <param name="vertexTintLinear">The vertex color of the text gets
 		/// multiplied by this color. This is a linear color value, not a gamma
 		/// corrected color value.</param>
-		public static void Add(string text, Matrix transform, TextStyle style, Color vertexTintLinear, TextAlign position = TextAlign.Center, TextAlign align = TextAlign.Center, float offX = 0, float offY = 0, float offZ = 0)
+		public static void Add(string text, Matrix transform, TextStyle style, Color vertexTintLinear, Pivot position = Pivot.Center, Align align = Align.Center, float offX = 0, float offY = 0, float offZ = 0)
 			=> NativeAPI.text_add_at_16(text, transform, style, position, align, offX, offY, offZ, vertexTintLinear);
 
-		/// <inheritdoc cref="Add(string, Matrix, TextAlign, TextAlign, float, float, float)"/>
+		/// <inheritdoc cref="Add(string, Matrix, Pivot, Align, float, float, float)"/>
 		/// <param name="vertexTintLinear">The vertex color of the text gets
 		/// multiplied by this color. This is a linear color value, not a gamma
 		/// corrected color value.</param>
-		public static void Add(string text, Matrix transform, Color vertexTintLinear, TextAlign position = TextAlign.Center, TextAlign align = TextAlign.Center, float offX = 0, float offY = 0, float offZ = 0)
+		public static void Add(string text, Matrix transform, Color vertexTintLinear, Pivot position = Pivot.Center, Align align = Align.Center, float offX = 0, float offY = 0, float offZ = 0)
 			=> NativeAPI.text_add_at_16(text, transform, TextStyle.Default, position, align, offX, offY, offZ, vertexTintLinear);
 
 		/// <summary>Renders text at the given location! Must be called every
@@ -299,7 +299,7 @@ namespace StereoKit
 		/// <param name="offY">An additional offset on the Y axis.</param>
 		/// <param name="offZ">An additional offset on the Z axis.</param>
 		/// <returns>Returns the vertical space used by this text.</returns>
-		public static float Add(string text, Matrix transform, Vec2 size, TextFit fit, TextStyle style, TextAlign position = TextAlign.Center, TextAlign align = TextAlign.Center, float offX = 0, float offY = 0, float offZ = 0)
+		public static float Add(string text, Matrix transform, Vec2 size, TextFit fit, TextStyle style, Pivot position = Pivot.Center, Align align = Align.Center, float offX = 0, float offY = 0, float offZ = 0)
 			=> NativeAPI.text_add_in_16(text, transform, size, fit, style, position, align, offX, offY, offZ, Color.White);
 
 		/// <summary>Renders text at the given location! Must be called every
@@ -321,21 +321,21 @@ namespace StereoKit
 		/// <param name="offY">An additional offset on the Y axis.</param>
 		/// <param name="offZ">An additional offset on the Z axis.</param>
 		/// <returns>Returns the vertical space used by this text.</returns>
-		public static float Add(string text, Matrix transform, Vec2 size, TextFit fit, TextAlign position = TextAlign.Center, TextAlign align = TextAlign.Center, float offX = 0, float offY = 0, float offZ = 0)
+		public static float Add(string text, Matrix transform, Vec2 size, TextFit fit, Pivot position = Pivot.Center, Align align = Align.Center, float offX = 0, float offY = 0, float offZ = 0)
 			=> NativeAPI.text_add_in_16(text, transform, size, fit, TextStyle.Default, position, align, offX, offY, offZ, Color.White);
 
-		/// <inheritdoc cref="Add(string, Matrix, Vec2, TextFit, TextAlign, TextAlign, float, float, float)"/>
+		/// <inheritdoc cref="Add(string, Matrix, Vec2, TextFit, Pivot, Align, float, float, float)"/>
 		/// <param name="vertexTintLinear">The vertex color of the text gets
 		/// multiplied by this color. This is a linear color value, not a gamma
 		/// corrected color value.</param>
-		public static float Add(string text, Matrix transform, Vec2 size, TextFit fit, Color vertexTintLinear, TextAlign position = TextAlign.Center, TextAlign align = TextAlign.Center, float offX = 0, float offY = 0, float offZ = 0)
+		public static float Add(string text, Matrix transform, Vec2 size, TextFit fit, Color vertexTintLinear, Pivot position = Pivot.Center, Align align = Align.Center, float offX = 0, float offY = 0, float offZ = 0)
 			=> NativeAPI.text_add_in_16(text, transform, size, fit, TextStyle.Default, position, align, offX, offY, offZ, vertexTintLinear);
 
-		/// <inheritdoc cref="Add(string, Matrix, Vec2, TextFit, TextStyle, TextAlign, TextAlign, float, float, float)"/>
+		/// <inheritdoc cref="Add(string, Matrix, Vec2, TextFit, TextStyle, Pivot, Align, float, float, float)"/>
 		/// <param name="vertexTintLinear">The vertex color of the text gets
 		/// multiplied by this color. This is a linear color value, not a gamma
 		/// corrected color value.</param>
-		public static float Add(string text, Matrix transform, Vec2 size, TextFit fit, TextStyle style, Color vertexTintLinear, TextAlign position = TextAlign.Center, TextAlign align = TextAlign.Center, float offX = 0, float offY = 0, float offZ = 0)
+		public static float Add(string text, Matrix transform, Vec2 size, TextFit fit, TextStyle style, Color vertexTintLinear, Pivot position = Pivot.Center, Align align = Align.Center, float offX = 0, float offY = 0, float offZ = 0)
 			=> NativeAPI.text_add_in_16(text, transform, size, fit, style, position, align, offX, offY, offZ, vertexTintLinear);
 
 		/// <summary>Sometimes you just need to know how much room some text

--- a/StereoKit/Systems/UI.cs
+++ b/StereoKit/Systems/UI.cs
@@ -376,9 +376,9 @@ namespace StereoKit
 		/// additional parsing done to this text, so put it in as you want to
 		/// see it!</param>
 		/// <param name="textAlign">Where should the text position itself
-		/// within its bounds? TextAlign.TopLeft is how most English text is
+		/// within its bounds? Align.TopLeft is how most English text is
 		/// aligned.</param>
-		public static void Text(string text, TextAlign textAlign = TextAlign.TopLeft)
+		public static void Text(string text, Align textAlign = Align.TopLeft)
 			=> NativeAPI.ui_text_16(text, IntPtr.Zero, UIScroll.None, 0, textAlign, TextFit.Wrap);
 
 		/// <summary>Displays a large chunk of text on the current layout.
@@ -389,7 +389,7 @@ namespace StereoKit
 		/// additional parsing done to this text, so put it in as you want to
 		/// see it!</param>
 		/// <param name="textAlign">Where should the text position itself
-		/// within its bounds? TextAlign.TopLeft is how most English text is
+		/// within its bounds? Align.TopLeft is how most English text is
 		/// aligned.</param>
 		/// <param name="fit">Describe how the text should behave when one of
 		/// its size dimensions conflicts with the provided 'size' parameter.
@@ -398,7 +398,7 @@ namespace StereoKit
 		/// space. If an axis is left as zero, it will be auto-calculated. For
 		/// X this is the remaining width of the current layout, and for Y this
 		/// is UI.LineHeight.</param>
-		public static void Text(string text, TextAlign textAlign, TextFit fit, Vec2 size)
+		public static void Text(string text, Align textAlign, TextFit fit, Vec2 size)
 			=> NativeAPI.ui_text_sz_16(text, IntPtr.Zero, UIScroll.None, size, textAlign, fit);
 
 		/// <summary>Displays a large chunk of text on the current layout.
@@ -409,7 +409,7 @@ namespace StereoKit
 		/// additional parsing done to this text, so put it in as you want to
 		/// see it!</param>
 		/// <param name="textAlign">Where should the text position itself
-		/// within its bounds? TextAlign.TopLeft is how most English text is
+		/// within its bounds? Align.TopLeft is how most English text is
 		/// aligned.</param>
 		/// <param name="fit">Describe how the text should behave when one of
 		/// its size dimensions conflicts with the provided 'size' parameter.
@@ -418,7 +418,7 @@ namespace StereoKit
 		/// element relative to the current Hierarchy.</param>
 		/// <param name="size">The layout size for this element in Hierarchy
 		/// space.</param>
-		public static void TextAt(string text, TextAlign textAlign, TextFit fit, Vec3 topLeftCorner, Vec2 size)
+		public static void TextAt(string text, Align textAlign, TextFit fit, Vec3 topLeftCorner, Vec2 size)
 			=> NativeAPI.ui_text_at_16(text, IntPtr.Zero, UIScroll.None, textAlign, fit, topLeftCorner, size);
 
 		/// <summary>A scrolling text element! This is for reading large chunks
@@ -444,7 +444,7 @@ namespace StereoKit
 		/// overload will always add `TextFit.Clip` internally.</param>
 		/// <returns>Returns true if any of the scroll bars have changed this
 		/// frame.</returns>
-		public static bool Text(string text, ref Vec2 scroll, UIScroll scrollDirection, Vec2 size, TextAlign textAlign = TextAlign.TopLeft, TextFit fit = TextFit.Wrap)
+		public static bool Text(string text, ref Vec2 scroll, UIScroll scrollDirection, Vec2 size, Align textAlign = Align.TopLeft, TextFit fit = TextFit.Wrap)
 			=> NativeAPI.ui_text_sz_16(text, ref scroll, scrollDirection, size, textAlign, fit);
 
 		/// <summary>A scrolling text element! This is for reading large chunks
@@ -471,15 +471,15 @@ namespace StereoKit
 		/// overload will always add `TextFit.Clip` internally.</param>
 		/// <returns>Returns true if any of the scroll bars have changed this
 		/// frame.</returns>
-		public static bool Text(string text, ref Vec2 scroll, UIScroll scrollDirection, float height, TextAlign textAlign = TextAlign.TopLeft, TextFit fit = TextFit.Wrap)
+		public static bool Text(string text, ref Vec2 scroll, UIScroll scrollDirection, float height, Align textAlign = Align.TopLeft, TextFit fit = TextFit.Wrap)
 			=> NativeAPI.ui_text_16(text, ref scroll, scrollDirection, height, textAlign, fit);
 
-		/// <inheritdoc cref="Text(string, ref Vec2, UIScroll, Vec2, TextAlign, TextFit)"/>
+		/// <inheritdoc cref="Text(string, ref Vec2, UIScroll, Vec2, Align, TextFit)"/>
 		/// <param name="topLeftCorner">This is the top left corner of the UI
 		/// element relative to the current Hierarchy.</param>
 		/// <param name="size">The layout size for this element in Hierarchy
 		/// space.</param>
-		public static bool TextAt(string text, ref Vec2 scroll, UIScroll scrollDirection, TextAlign textAlign, TextFit fit, Vec3 topLeftCorner, Vec2 size)
+		public static bool TextAt(string text, ref Vec2 scroll, UIScroll scrollDirection, Align textAlign, TextFit fit, Vec3 topLeftCorner, Vec2 size)
 			=> NativeAPI.ui_text_at_16(text, ref scroll, scrollDirection, textAlign, fit, topLeftCorner, size);
 
 		/// <summary>Adds an image to the UI!</summary>

--- a/StereoKitC/asset_types/sprite.cpp
+++ b/StereoKitC/asset_types/sprite.cpp
@@ -212,8 +212,8 @@ void sprite_destroy(sprite_t sprite) {
 
 ///////////////////////////////////////////
 
-void sprite_draw(sprite_t sprite, matrix transform, text_align_ anchor_position, color32 color) {
-	sprite_drawer_add_at(sprite, transform, anchor_position, color);
+void sprite_draw(sprite_t sprite, matrix transform, pivot_ pivot_position, color32 color) {
+	sprite_drawer_add_at(sprite, transform, pivot_position, color);
 }
 
 

--- a/StereoKitC/stereokit.h
+++ b/StereoKitC/stereokit.h
@@ -1338,74 +1338,141 @@ typedef enum text_fit_ {
 } text_fit_;
 SK_MakeFlag(text_fit_)
 
+/*Use align_ or pivot_ instead*/
+SK_DEPRECATED typedef enum text_align_ {
+	text_align_x_left       = 1 << 0,
+	text_align_y_top        = 1 << 1,
+	text_align_x_center     = 1 << 2,
+	text_align_y_center     = 1 << 3,
+	text_align_x_right      = 1 << 4,
+	text_align_y_bottom     = 1 << 5,
+	text_align_center       = text_align_x_center | text_align_y_center,
+	text_align_center_left  = text_align_x_left   | text_align_y_center,
+	text_align_center_right = text_align_x_right  | text_align_y_center,
+	text_align_top_center   = text_align_x_center | text_align_y_top,
+	text_align_top_left     = text_align_x_left   | text_align_y_top,
+	text_align_top_right    = text_align_x_right  | text_align_y_top,
+	text_align_bottom_center= text_align_x_center | text_align_y_bottom,
+	text_align_bottom_left  = text_align_x_left   | text_align_y_bottom,
+	text_align_bottom_right = text_align_x_right  | text_align_y_bottom,
+} text_align_;
+
 /*A bit-flag enum for describing alignment or positioning.
   Items can be combined using the '|' operator, like so:
-  
-  `TextAlign alignment = TextAlign.YTop | TextAlign.XLeft;`
-  
+  `Align alignment = Align.YTop | Align.XLeft;`
   Avoid combining multiple items of the same axis. There are also a
   complete list of valid bit flag combinations! These are the values
   without an axis listed in their names, 'TopLeft', 'BottomCenter',
   etc.*/
-typedef enum text_align_ {
+typedef enum align_ {
 	/*On the x axis, this item should start on the left.*/
-	text_align_x_left       = 1 << 0,
+	align_x_left = 1 << 0,
 	/*On the y axis, this item should start at the top.*/
-	text_align_y_top        = 1 << 1,
+	align_y_top = 1 << 1,
 	/*On the x axis, the item should be centered.*/
-	text_align_x_center     = 1 << 2,
+	align_x_center = 1 << 2,
 	/*On the y axis, the item should be centered.*/
-	text_align_y_center     = 1 << 3,
+	align_y_center = 1 << 3,
 	/*On the x axis, this item should start on the right.*/
-	text_align_x_right      = 1 << 4,
+	align_x_right = 1 << 4,
 	/*On the y axis, this item should start on the bottom.*/
-	text_align_y_bottom     = 1 << 5,
-	/*Center on both X and Y axes. This is a combination of 
+	align_y_bottom = 1 << 5,
+	/*Center on both X and Y axes. This is a combination of
 	  XCenter and YCenter.*/
-	text_align_center       = text_align_x_center | text_align_y_center,
-	/*Start on the left of the X axis, center on the Y axis. 
+	align_center = align_x_center | align_y_center,
+	/*Start on the left of the X axis, center on the Y axis.
 	  This is a combination of XLeft and YCenter.*/
-	text_align_center_left  = text_align_x_left   | text_align_y_center,
-	/*Start on the right of the X axis, center on the Y axis. 
+	align_center_left = align_x_left | align_y_center,
+	/*Start on the right of the X axis, center on the Y axis.
 	  This is a combination of XRight and YCenter.*/
-	text_align_center_right = text_align_x_right  | text_align_y_center,
+	align_center_right = align_x_right | align_y_center,
 	/*Center on the X axis, and top on the Y axis. This is a
 	  combination of XCenter and YTop.*/
-	text_align_top_center   = text_align_x_center | text_align_y_top,
+	align_top_center = align_x_center | align_y_top,
 	/*Start on the left of the X axis, and top on the Y axis.
 	  This is a combination of XLeft and YTop.*/
-	text_align_top_left     = text_align_x_left   | text_align_y_top,
+	align_top_left = align_x_left | align_y_top,
 	/*Start on the right of the X axis, and top on the Y axis.
 	  This is a combination of XRight and YTop.*/
-	text_align_top_right    = text_align_x_right  | text_align_y_top,
+	align_top_right = align_x_right | align_y_top,
 	/*Center on the X axis, and bottom on the Y axis. This is
 	  a combination of XCenter and YBottom.*/
-	text_align_bottom_center= text_align_x_center | text_align_y_bottom,
+	align_bottom_center = align_x_center | align_y_bottom,
 	/*Start on the left of the X axis, and bottom on the Y
 	  axis. This is a combination of XLeft and YBottom.*/
-	text_align_bottom_left  = text_align_x_left   | text_align_y_bottom,
+	align_bottom_left = align_x_left | align_y_bottom,
 	/*Start on the right of the X axis, and bottom on the Y
 	  axis.This is a combination of XRight and YBottom.*/
-	text_align_bottom_right = text_align_x_right  | text_align_y_bottom,
-} text_align_;
-SK_MakeFlag(text_align_);
+	align_bottom_right = align_x_right | align_y_bottom,
+} align_;
+SK_MakeFlag(align_);
+
+/*A bit-flag enum for describing alignment or positioning.
+  Items can be combined using the '|' operator, like so:
+  `Align alignment = Align.YTop | Align.XLeft;`
+  Avoid combining multiple items of the same axis. There are also a
+  complete list of valid bit flag combinations! These are the values
+  without an axis listed in their names, 'TopLeft', 'BottomCenter',
+  etc.*/
+typedef enum pivot_ {
+	/*On the x axis, this item should start on the left.*/
+	pivot_x_left = 1 << 0,
+	/*On the y axis, this item should start at the top.*/
+	pivot_y_top = 1 << 1,
+	/*On the x axis, the item should be centered.*/
+	pivot_x_center = 1 << 2,
+	/*On the y axis, the item should be centered.*/
+	pivot_y_center = 1 << 3,
+	/*On the x axis, this item should start on the right.*/
+	pivot_x_right = 1 << 4,
+	/*On the y axis, this item should start on the bottom.*/
+	pivot_y_bottom = 1 << 5,
+	/*Center on both X and Y axes. This is a combination of
+	  XCenter and YCenter.*/
+	pivot_center = pivot_x_center | pivot_y_center,
+	/*Start on the left of the X axis, center on the Y axis.
+	  This is a combination of XLeft and YCenter.*/
+	pivot_center_left = pivot_x_left | pivot_y_center,
+	/*Start on the right of the X axis, center on the Y axis.
+	  This is a combination of XRight and YCenter.*/
+	pivot_center_right = pivot_x_right | pivot_y_center,
+	/*Center on the X axis, and top on the Y axis. This is a
+	  combination of XCenter and YTop.*/
+	pivot_top_center = pivot_x_center | pivot_y_top,
+	/*Start on the left of the X axis, and top on the Y axis.
+	  This is a combination of XLeft and YTop.*/
+	pivot_top_left = pivot_x_left | pivot_y_top,
+	/*Start on the right of the X axis, and top on the Y axis.
+	  This is a combination of XRight and YTop.*/
+	pivot_top_right = pivot_x_right | pivot_y_top,
+	/*Center on the X axis, and bottom on the Y axis. This is
+	  a combination of XCenter and YBottom.*/
+	pivot_bottom_center = pivot_x_center | pivot_y_bottom,
+	/*Start on the left of the X axis, and bottom on the Y
+	  axis. This is a combination of XLeft and YBottom.*/
+	pivot_bottom_left = pivot_x_left | pivot_y_bottom,
+	/*Start on the right of the X axis, and bottom on the Y
+	  axis.This is a combination of XRight and YBottom.*/
+	pivot_bottom_right = pivot_x_right | pivot_y_bottom,
+} pivot_;
+SK_MakeFlag(pivot_);
 
 typedef uint32_t text_style_t;
 
 SK_API text_style_t  text_make_style                (font_t font, float layout_height,                      color128 color_gamma);
 SK_API text_style_t  text_make_style_shader         (font_t font, float layout_height, shader_t   shader,   color128 color_gamma);
 SK_API text_style_t  text_make_style_mat            (font_t font, float layout_height, material_t material, color128 color_gamma);
-SK_API void          text_add_at                    (const char*     text_utf8,  const sk_ref(matrix)  transform, text_style_t style sk_default(0), text_align_ position sk_default(text_align_center), text_align_ align sk_default(text_align_center), float off_x sk_default(0), float off_y sk_default(0), float off_z sk_default(0), color128 vertex_tint_linear sk_default({1,1,1,1}));
-SK_API void          text_add_at_16                 (const char16_t* text_utf16, const sk_ref(matrix)  transform, text_style_t style sk_default(0), text_align_ position sk_default(text_align_center), text_align_ align sk_default(text_align_center), float off_x sk_default(0), float off_y sk_default(0), float off_z sk_default(0), color128 vertex_tint_linear sk_default({1,1,1,1}));
-SK_API float         text_add_in                    (const char*     text_utf8,  const sk_ref(matrix)  transform, vec2 size, text_fit_ fit, text_style_t style sk_default(0), text_align_ position sk_default(text_align_center), text_align_ align sk_default(text_align_center), float off_x sk_default(0), float off_y sk_default(0), float off_z sk_default(0), color128 vertex_tint_linear sk_default({1,1,1,1}));
-SK_API float         text_add_in_16                 (const char16_t* text_utf16, const sk_ref(matrix)  transform, vec2 size, text_fit_ fit, text_style_t style sk_default(0), text_align_ position sk_default(text_align_center), text_align_ align sk_default(text_align_center), float off_x sk_default(0), float off_y sk_default(0), float off_z sk_default(0), color128 vertex_tint_linear sk_default({1,1,1,1}));
+SK_API void          text_add_at                    (const char*     text_utf8,  const sk_ref(matrix)  transform, text_style_t style sk_default(0), pivot_ position sk_default(pivot_center), align_ align sk_default(align_center), float off_x sk_default(0), float off_y sk_default(0), float off_z sk_default(0), color128 vertex_tint_linear sk_default({1,1,1,1}));
+SK_API void          text_add_at_16                 (const char16_t* text_utf16, const sk_ref(matrix)  transform, text_style_t style sk_default(0), pivot_ position sk_default(pivot_center), align_ align sk_default(align_center), float off_x sk_default(0), float off_y sk_default(0), float off_z sk_default(0), color128 vertex_tint_linear sk_default({1,1,1,1}));
+SK_API float         text_add_in                    (const char*     text_utf8,  const sk_ref(matrix)  transform, vec2 size, text_fit_ fit, text_style_t style sk_default(0), pivot_ position sk_default(pivot_center), align_ align sk_default(align_center), float off_x sk_default(0), float off_y sk_default(0), float off_z sk_default(0), color128 vertex_tint_linear sk_default({1,1,1,1}));
+SK_API float         text_add_in_16                 (const char16_t* text_utf16, const sk_ref(matrix)  transform, vec2 size, text_fit_ fit, text_style_t style sk_default(0), pivot_ position sk_default(pivot_center), align_ align sk_default(align_center), float off_x sk_default(0), float off_y sk_default(0), float off_z sk_default(0), color128 vertex_tint_linear sk_default({1,1,1,1}));
 SK_API vec2          text_size_layout               (const char*     text_utf8,  text_style_t style sk_default(0));
 SK_API vec2          text_size_layout_16            (const char16_t* text_utf16, text_style_t style sk_default(0));
 SK_API vec2          text_size_layout_constrained   (const char*     text_utf8,  text_style_t style, float max_width);
 SK_API vec2          text_size_layout_constrained_16(const char16_t* text_utf16, text_style_t style, float max_width);
 SK_API vec2          text_size_render               (vec2 layout_size,           text_style_t style, float* out_y_offset);
-SK_API vec2          text_char_at                   (const char*     text_utf8,  text_style_t style, int32_t char_index, vec2 *opt_size, text_fit_ fit, text_align_ position, text_align_ align);
-SK_API vec2          text_char_at_16                (const char16_t* text_utf16, text_style_t style, int32_t char_index, vec2 *opt_size, text_fit_ fit, text_align_ position, text_align_ align);
+SK_API vec2          text_char_at                   (const char*     text_utf8,  text_style_t style, int32_t char_index, vec2 *opt_size, text_fit_ fit, pivot_ position, align_ align);
+SK_API vec2          text_char_at_16                (const char16_t* text_utf16, text_style_t style, int32_t char_index, vec2 *opt_size, text_fit_ fit, pivot_ position, align_ align);
 
 SK_API float         text_style_get_line_height_pct (text_style_t style);
 SK_API void          text_style_set_line_height_pct (text_style_t style, float height_percentage);
@@ -1537,7 +1604,7 @@ SK_API float       sprite_get_aspect (sprite_t sprite);
 SK_API int32_t     sprite_get_width  (sprite_t sprite);
 SK_API int32_t     sprite_get_height (sprite_t sprite);
 SK_API vec2        sprite_get_dimensions_normalized(sprite_t sprite);
-SK_API void        sprite_draw       (sprite_t sprite, matrix transform, text_align_ anchor_position, color32 color sk_default({255,255,255,255}));
+SK_API void        sprite_draw       (sprite_t sprite, matrix transform, pivot_ pivot_position, color32 color sk_default({255,255,255,255}));
 
 ///////////////////////////////////////////
 

--- a/StereoKitC/stereokit_ui.h
+++ b/StereoKitC/stereokit_ui.h
@@ -237,12 +237,12 @@ SK_API void     ui_label             (const char*     text, bool32_t use_padding
 SK_API void     ui_label_16          (const char16_t* text, bool32_t use_padding sk_default(true));
 SK_API void     ui_label_sz          (const char*     text, vec2 size, bool32_t use_padding sk_default(true));
 SK_API void     ui_label_sz_16       (const char16_t* text, vec2 size, bool32_t use_padding sk_default(true));
-SK_API bool32_t ui_text              (const char*     text, vec2* opt_ref_scroll sk_default(nullptr), ui_scroll_ scroll_direction sk_default(ui_scroll_vertical), float height sk_default(0), text_align_ text_align sk_default(text_align_top_left), text_fit_ fit sk_default(text_fit_wrap));
-SK_API bool32_t ui_text_16           (const char16_t* text, vec2* opt_ref_scroll sk_default(nullptr), ui_scroll_ scroll_direction sk_default(ui_scroll_vertical), float height sk_default(0), text_align_ text_align sk_default(text_align_top_left), text_fit_ fit sk_default(text_fit_wrap));
-SK_API bool32_t ui_text_sz           (const char*     text, vec2* opt_ref_scroll, ui_scroll_ scroll_direction, vec2 size, text_align_ text_align sk_default(text_align_top_left), text_fit_ fit sk_default(text_fit_wrap));
-SK_API bool32_t ui_text_sz_16        (const char16_t* text, vec2* opt_ref_scroll, ui_scroll_ scroll_direction, vec2 size, text_align_ text_align sk_default(text_align_top_left), text_fit_ fit sk_default(text_fit_wrap));
-SK_API bool32_t ui_text_at           (const char*     text, vec2* opt_ref_scroll, ui_scroll_ scroll_direction,            text_align_ text_align, text_fit_ fit, vec3 window_relative_pos, vec2 size);
-SK_API bool32_t ui_text_at_16        (const char16_t* text, vec2* opt_ref_scroll, ui_scroll_ scroll_direction,            text_align_ text_align, text_fit_ fit, vec3 window_relative_pos, vec2 size);
+SK_API bool32_t ui_text              (const char*     text, vec2* opt_ref_scroll sk_default(nullptr), ui_scroll_ scroll_direction sk_default(ui_scroll_vertical), float height sk_default(0), align_ text_align sk_default(align_top_left), text_fit_ fit sk_default(text_fit_wrap));
+SK_API bool32_t ui_text_16           (const char16_t* text, vec2* opt_ref_scroll sk_default(nullptr), ui_scroll_ scroll_direction sk_default(ui_scroll_vertical), float height sk_default(0), align_ text_align sk_default(align_top_left), text_fit_ fit sk_default(text_fit_wrap));
+SK_API bool32_t ui_text_sz           (const char*     text, vec2* opt_ref_scroll, ui_scroll_ scroll_direction, vec2 size, align_ text_align sk_default(align_top_left), text_fit_ fit sk_default(text_fit_wrap));
+SK_API bool32_t ui_text_sz_16        (const char16_t* text, vec2* opt_ref_scroll, ui_scroll_ scroll_direction, vec2 size, align_ text_align sk_default(align_top_left), text_fit_ fit sk_default(text_fit_wrap));
+SK_API bool32_t ui_text_at           (const char*     text, vec2* opt_ref_scroll, ui_scroll_ scroll_direction,            align_ text_align, text_fit_ fit, vec3 window_relative_pos, vec2 size);
+SK_API bool32_t ui_text_at_16        (const char16_t* text, vec2* opt_ref_scroll, ui_scroll_ scroll_direction,            align_ text_align, text_fit_ fit, vec3 window_relative_pos, vec2 size);
 SK_API bool32_t ui_button            (const char*     text);
 SK_API bool32_t ui_button_16         (const char16_t* text);
 SK_API bool32_t ui_button_sz         (const char*     text, vec2 size);

--- a/StereoKitC/systems/sprite_drawer.cpp
+++ b/StereoKitC/systems/sprite_drawer.cpp
@@ -93,16 +93,16 @@ void sprite_drawer_add     (sprite_t sprite, const matrix &at, color32 color) {
 
 ///////////////////////////////////////////
 
-void sprite_drawer_add_at(sprite_t sprite, matrix at, text_align_ anchor_position, color32 color) {
+void sprite_drawer_add_at(sprite_t sprite, matrix at, pivot_ pivot_position, color32 color) {
 	// Check if this one does get batched
 	if (sprite->buffer_index == -1) {
 		// Just plop a quad onto the render queue
 		vec3  offset = vec3_zero;
 		float aspect = sprite_get_aspect(sprite);
-		if      (anchor_position & text_align_x_left  ) offset.x = -aspect/2;
-		else if (anchor_position & text_align_x_right ) offset.x = aspect /2;
-		if      (anchor_position & text_align_y_bottom) offset.y =  0.5f;
-		else if (anchor_position & text_align_y_top   ) offset.y = -0.5f;
+		if      (pivot_position & pivot_x_left  ) offset.x = -aspect/2;
+		else if (pivot_position & pivot_x_right ) offset.x =  aspect/2;
+		if      (pivot_position & pivot_y_bottom) offset.y =  0.5f;
+		else if (pivot_position & pivot_y_top   ) offset.y = -0.5f;
 		render_add_mesh(sprite_quad, sprite->material, matrix_ts(offset, {aspect, 1, 1}) * at, { color.r / 255.f, color.g / 255.f, color.b / 255.f, color.a / 255.f });
 		return;
 	} else {

--- a/StereoKitC/systems/sprite_drawer.h
+++ b/StereoKitC/systems/sprite_drawer.h
@@ -15,7 +15,7 @@ struct sprite_buffer_t {
 
 void sprite_drawer_add_buffer(material_t material);
 void sprite_drawer_add       (sprite_t sprite, const matrix &at, color32 color = {255,255,255,255});
-void sprite_drawer_add_at    (sprite_t sprite, matrix at, text_align_ anchor_position, color32 color);
+void sprite_drawer_add_at    (sprite_t sprite, matrix at, pivot_ pivot_position, color32 color);
 bool sprite_drawer_init      ();
 void sprite_drawer_step      ();
 void sprite_drawer_shutdown  ();

--- a/StereoKitC/systems/text.cpp
+++ b/StereoKitC/systems/text.cpp
@@ -425,12 +425,12 @@ float text_step_height(const C *text, int32_t *out_length, const _text_style_t *
 ///////////////////////////////////////////
 
 template<typename C, bool (*char_decode_b_T)(const C*, const C**, char32_t*)>
-void text_step_next_line(const C* start, const _text_style_t* style, text_align_ align, bool wrap, float max_width, float start_x, int32_t* out_line_remaining, vec2* ref_pos) {
+void text_step_next_line(const C* start, const _text_style_t* style, align_ align, bool wrap, float max_width, float start_x, int32_t* out_line_remaining, vec2* ref_pos) {
 	const C* next;
 	float line_size = text_step_line_length<C, char_decode_b_T>(start, out_line_remaining, &next, style, wrap, max_width);
 	float align_x = 0;
-	if (align & text_align_x_center) align_x = ((max_width - line_size) / 2.f);
-	if (align & text_align_x_right)  align_x = (max_width - line_size);
+	if (align & align_x_center) align_x = ((max_width - line_size) / 2.f);
+	if (align & align_x_right)  align_x = (max_width - line_size);
 	ref_pos->x = start_x - align_x;
 	ref_pos->y -= style->line_baseline * style->scale;
 }
@@ -438,7 +438,7 @@ void text_step_next_line(const C* start, const _text_style_t* style, text_align_
 ///////////////////////////////////////////
 
 template<typename C, bool (*char_decode_b_T)(const C*, const C**, char32_t*)>
-void text_step_position(char32_t ch, const font_char_t* char_info, const C* next, const _text_style_t* style, text_align_ align, bool wrap, float max_width, float start_x, int32_t* ref_line_remaining, vec2* ref_pos) {
+void text_step_position(char32_t ch, const font_char_t* char_info, const C* next, const _text_style_t* style, align_ align, bool wrap, float max_width, float start_x, int32_t* ref_line_remaining, vec2* ref_pos) {
 	*ref_line_remaining = *ref_line_remaining - 1;
 	if (*ref_line_remaining <= 0) {
 		text_step_next_line<C, char_decode_b_T>(next, style, align, wrap, max_width, start_x, ref_line_remaining, ref_pos);
@@ -454,7 +454,7 @@ void text_step_position(char32_t ch, const font_char_t* char_info, const C* next
 ///////////////////////////////////////////
 
 template<typename C, bool (*char_decode_b_T)(const C *, const C **, char32_t *)>
-inline vec2 text_char_at_g(const C *text, text_style_t style_id, int32_t char_index, vec2 *opt_size, text_fit_ fit, text_align_ position, text_align_ align) {
+inline vec2 text_char_at_g(const C *text, text_style_t style_id, int32_t char_index, vec2 *opt_size, text_fit_ fit, pivot_ position, align_ align) {
 	if (text == nullptr) return {};
 	vec2 size = opt_size == nullptr
 		? text_size_layout_g<C, char_decode_b_T>(text, style_id)
@@ -488,15 +488,15 @@ inline vec2 text_char_at_g(const C *text, text_style_t style_id, int32_t char_in
 
 	// Align the start based on the size of the bounds
 	vec2 start = { 0, style->scale };
-	if      (position & text_align_x_center) start.x += bounds.x / 2.f;
-	else if (position & text_align_x_right)  start.x += bounds.x;
-	if      (position & text_align_y_center) start.y += bounds.y / 2.f;
-	else if (position & text_align_y_bottom) start.y += bounds.y;
+	if      (position & pivot_x_center) start.x += bounds.x / 2.f;
+	else if (position & pivot_x_right)  start.x += bounds.x;
+	if      (position & pivot_y_center) start.y += bounds.y / 2.f;
+	else if (position & pivot_y_bottom) start.y += bounds.y;
 	vec2 pos = start;
 
 	// Figure out the vertical align of the text
-	if      (align & text_align_y_center) pos.y -= (bounds.y-text_height) / 2.f;
-	else if (align & text_align_y_bottom) pos.y -=  bounds.y-text_height;
+	if      (align & align_y_center) pos.y -= (bounds.y-text_height) / 2.f;
+	else if (align & align_y_bottom) pos.y -=  bounds.y-text_height;
 
 	// Core loop for drawing the text
 	vec2     bounds_min     = start - bounds;
@@ -524,8 +524,8 @@ inline vec2 text_char_at_g(const C *text, text_style_t style_id, int32_t char_in
 	return pos;
 }
 
-vec2 text_char_at   (const char*     text_utf8,  text_style_t style, int32_t char_index, vec2 *opt_size, text_fit_ fit, text_align_ position, text_align_ align) { return text_char_at_g<char,     utf8_decode_fast_b >(text_utf8,  style, char_index, opt_size, fit, position, align); }
-vec2 text_char_at_16(const char16_t* text_utf16, text_style_t style, int32_t char_index, vec2 *opt_size, text_fit_ fit, text_align_ position, text_align_ align) { return text_char_at_g<char16_t, utf16_decode_fast_b>(text_utf16, style, char_index, opt_size, fit, position, align); }
+vec2 text_char_at   (const char*     text_utf8,  text_style_t style, int32_t char_index, vec2 *opt_size, text_fit_ fit, pivot_ position, align_ align) { return text_char_at_g<char,     utf8_decode_fast_b >(text_utf8,  style, char_index, opt_size, fit, position, align); }
+vec2 text_char_at_16(const char16_t* text_utf16, text_style_t style, int32_t char_index, vec2 *opt_size, text_fit_ fit, pivot_ position, align_ align) { return text_char_at_g<char16_t, utf16_decode_fast_b>(text_utf16, style, char_index, opt_size, fit, position, align); }
 
 ///////////////////////////////////////////
 
@@ -588,20 +588,20 @@ void text_add_quad_clipped(float x, float y, float off_z, vec2 bounds_min, vec2 
 
 ///////////////////////////////////////////
 
-void text_add_at(const char* text, const matrix &transform, text_style_t style, text_align_ position, text_align_ align, float off_x, float off_y, float off_z, color128 vertex_tint_linear) {
+void text_add_at(const char* text, const matrix &transform, text_style_t style, pivot_ position, align_ align, float off_x, float off_y, float off_z, color128 vertex_tint_linear) {
 	text_add_in(text, transform, text_size_layout(text, style), text_fit_exact, style, position, align, off_x, off_y, off_z, vertex_tint_linear);
 }
 
 ///////////////////////////////////////////
 
-void text_add_at_16(const char16_t* text, const matrix &transform, text_style_t style, text_align_ position, text_align_ align, float off_x, float off_y, float off_z, color128 vertex_tint_linear) {
+void text_add_at_16(const char16_t* text, const matrix &transform, text_style_t style, pivot_ position, align_ align, float off_x, float off_y, float off_z, color128 vertex_tint_linear) {
 	text_add_in_16(text, transform, text_size_layout_16(text, style), text_fit_exact, style, position, align, off_x, off_y, off_z, vertex_tint_linear);
 }
 
 ///////////////////////////////////////////
 
 template<typename C, bool (*char_decode_b_T)(const C *, const C **, char32_t *)>
-float text_add_in_g(const C* text, const matrix& transform, vec2 size, text_fit_ fit, text_style_t style_id, text_align_ position, text_align_ align, float off_x, float off_y, float off_z, color128 vertex_tint_linear) {
+float text_add_in_g(const C* text, const matrix& transform, vec2 size, text_fit_ fit, text_style_t style_id, pivot_ position, align_ align, float off_x, float off_y, float off_z, color128 vertex_tint_linear) {
 	if (text == nullptr) return 0;
 	if (size.x <= 0) return 0; // Zero width text isn't visible, and causes issues when trying to determine text height.
 
@@ -656,18 +656,18 @@ float text_add_in_g(const C* text, const matrix& transform, vec2 size, text_fit_
 
 	// Align the start based on the size of the bounds
 	vec2 start = {};
-	if      (position & text_align_x_center) start.x += bounds.x / 2.f;
-	else if (position & text_align_x_right)  start.x += bounds.x;
-	if      (position & text_align_y_center) start.y += bounds.y / 2.f;
-	else if (position & text_align_y_bottom) start.y += bounds.y;
+	if      (position & pivot_x_center) start.x += bounds.x / 2.f;
+	else if (position & pivot_x_right)  start.x += bounds.x;
+	if      (position & pivot_y_center) start.y += bounds.y / 2.f;
+	else if (position & pivot_y_bottom) start.y += bounds.y;
 	vec2 bounds_min = start - bounds;
 	vec2 bounds_max = start;
 	start += vec2{ off_x, off_y };
 	vec2 pos = start;
 
 	// Figure out the vertical align of the text
-	if      (align & text_align_y_center) pos.y -= (bounds.y-text_height) / 2.f;
-	else if (align & text_align_y_bottom) pos.y -=  bounds.y-text_height;
+	if      (align & align_y_center) pos.y -= (bounds.y-text_height) / 2.f;
+	else if (align & align_y_bottom) pos.y -=  bounds.y-text_height;
 
 	// Ensure text capacity
 	text_buffer_t &buffer = text_buffers[style->buffer_index];
@@ -702,10 +702,10 @@ float text_add_in_g(const C* text, const matrix& transform, vec2 size, text_fit_
 }
 
 
-float text_add_in(const char *text, const matrix &transform, vec2 size, text_fit_ fit, text_style_t style, text_align_ position, text_align_ align, float off_x, float off_y, float off_z, color128 vertex_tint_linear) {
+float text_add_in(const char *text, const matrix &transform, vec2 size, text_fit_ fit, text_style_t style, pivot_ position, align_ align, float off_x, float off_y, float off_z, color128 vertex_tint_linear) {
 	return text_add_in_g<char, utf8_decode_fast_b>(text, transform, size, fit, style, position, align, off_x, off_y, off_z, vertex_tint_linear);
 }
-float text_add_in_16(const char16_t *text, const matrix &transform, vec2 size, text_fit_ fit, text_style_t style, text_align_ position, text_align_ align, float off_x, float off_y, float off_z, color128 vertex_tint_linear) {
+float text_add_in_16(const char16_t *text, const matrix &transform, vec2 size, text_fit_ fit, text_style_t style, pivot_ position, align_ align, float off_x, float off_y, float off_z, color128 vertex_tint_linear) {
 	return text_add_in_g<char16_t, utf16_decode_fast_b>(text, transform, size, fit, style, position, align, off_x, off_y, off_z, vertex_tint_linear);
 }
 

--- a/StereoKitC/tools/file_picker.cpp
+++ b/StereoKitC/tools/file_picker.cpp
@@ -481,7 +481,7 @@ void file_picker_update() {
 			ui_push_enabled(fp_active != nullptr);
 			if (ui_button("Open")) { snprintf(fp_filename, sizeof(fp_filename), "%s%c%s", fp_path.folder, platform_path_separator_c, fp_active); fp_call = true; fp_call_status = true; }
 			ui_sameline();
-			ui_text(fp_active ? fp_active : "None selected...", nullptr, ui_scroll_none, ui_line_height(), text_align_center_left, text_fit_none);
+			ui_text(fp_active ? fp_active : "None selected...", nullptr, ui_scroll_none, ui_line_height(), align_center_left, text_fit_none);
 			ui_pop_enabled();
 		} break;
 		}
@@ -557,7 +557,7 @@ void file_picker_update() {
 				if (fp_items[i].file_attr.file) {
 					char buffer[128];
 					snprintf(buffer, sizeof(buffer), "%d KB ", (int32_t)(fp_items[i].file_attr.size / 1024));
-					ui_text_sz(buffer, nullptr, ui_scroll_none, size, text_align_center_right, text_fit_clip);
+					ui_text_sz(buffer, nullptr, ui_scroll_none, size, align_center_right, text_fit_clip);
 					ui_sameline();
 				} else {
 					ui_layout_reserve(size);

--- a/StereoKitC/ui/stereokit_ui.cpp
+++ b/StereoKitC/ui/stereokit_ui.cpp
@@ -36,7 +36,7 @@ const float    skui_aura_radius    = 0.02f;
 
 ///////////////////////////////////////////
 
-bool32_t ui_text_at(const char16_t* text, vec2* opt_ref_scroll, ui_scroll_ scroll_direction, text_fit_ fit, text_align_ text_align, vec3 window_relative_pos, vec2 size);
+bool32_t ui_text_at(const char16_t* text, vec2* opt_ref_scroll, ui_scroll_ scroll_direction, text_fit_ fit, align_ text_align, vec3 window_relative_pos, vec2 size);
 
 ///////////////////////////////////////////
 
@@ -148,8 +148,8 @@ void ui_hseparator() {
 vec2 text_size_layout            (const char16_t* text_utf16, text_style_t style)                  { return text_size_layout_16(text_utf16, style); }
 vec2 text_size_layout_constrained(const char16_t* text_utf16, text_style_t style, float max_width) { return text_size_layout_constrained_16(text_utf16, style, max_width); }
 
-float ui_text_in  (const char*     text, text_align_ position, text_align_ align, text_fit_ fit, vec3 start, vec2 size, vec2 offset) { return text_add_in   (text, matrix_t(start), size, fit, ui_get_text_style(), position, align, offset.x,offset.y,0, ui_is_enabled() ? color128{ 1, 1, 1, 1 } : color128{ .5f, .5f, .5f, 1 }); }
-float ui_text_in  (const char16_t* text, text_align_ position, text_align_ align, text_fit_ fit, vec3 start, vec2 size, vec2 offset) { return text_add_in_16(text, matrix_t(start), size, fit, ui_get_text_style(), position, align, offset.x,offset.y,0, ui_is_enabled() ? color128{ 1, 1, 1, 1 } : color128{ .5f, .5f, .5f, 1 }); }
+float ui_text_in  (const char*     text, pivot_ position, align_ align, text_fit_ fit, vec3 start, vec2 size, vec2 offset) { return text_add_in   (text, matrix_t(start), size, fit, ui_get_text_style(), position, align, offset.x,offset.y,0, ui_is_enabled() ? color128{ 1, 1, 1, 1 } : color128{ .5f, .5f, .5f, 1 }); }
+float ui_text_in  (const char16_t* text, pivot_ position, align_ align, text_fit_ fit, vec3 start, vec2 size, vec2 offset) { return text_add_in_16(text, matrix_t(start), size, fit, ui_get_text_style(), position, align, offset.x,offset.y,0, ui_is_enabled() ? color128{ 1, 1, 1, 1 } : color128{ .5f, .5f, .5f, 1 }); }
 
 ///////////////////////////////////////////
 
@@ -162,7 +162,7 @@ void ui_label_sz_g(const C *text, vec2 size, bool32_t use_padding) {
 	vec2 padding = use_padding
 		? vec2{ skui_settings.padding, skui_settings.padding }
 		: vec2{ 0, skui_settings.padding };
-	ui_text_in(text, text_align_top_left, text_align_center_left, text_fit_squeeze, final_pos - vec3{ padding.x, 0, skui_settings.depth/2}, vec2{final_size.x-padding.x*2, final_size.y}, vec2_zero);
+	ui_text_in(text, pivot_top_left, align_center_left, text_fit_squeeze, final_pos - vec3{ padding.x, 0, skui_settings.depth/2}, vec2{final_size.x-padding.x*2, final_size.y}, vec2_zero);
 }
 void ui_label_sz   (const char     *text, vec2 size, bool32_t use_padding) { ui_label_sz_g<char    >(text, size, use_padding); }
 void ui_label_sz_16(const char16_t *text, vec2 size, bool32_t use_padding) { ui_label_sz_g<char16_t>(text, size, use_padding); }
@@ -185,56 +185,56 @@ void ui_image(sprite_t image, vec2 size) {
 	ui_layout_reserve_sz(size, false, &final_pos, &final_size);
 	
 	sprite_draw(image, matrix_ts(final_pos - vec3{size.x / 2, size.y / 2, 2 * mm2m }, vec3{ scale, scale, 1 }),
-		text_align_center, ui_is_enabled() ? color32{255, 255, 255, 255} : color32{128, 128, 128, 255});
+		pivot_center, ui_is_enabled() ? color32{255, 255, 255, 255} : color32{128, 128, 128, 255});
 }
 
 ///////////////////////////////////////////
 template<typename C>
-void _ui_button_img_surface(const C* text, sprite_t image, ui_btn_layout_ image_layout, text_align_ text_layout, vec3 window_relative_pos, vec2 size, float finger_offset, color128 image_tint) {
-	float pad2       = skui_settings.padding * 2;
-	float depth      = finger_offset + 2 * mm2m;
-	vec3  image_at   = {};
-	float image_size;
-	text_align_ image_align = text_align_x_left;
-	vec3  text_at;
-	vec2  text_size;
-	text_align_ text_align;
+void _ui_button_img_surface(const C* text, sprite_t image, ui_btn_layout_ image_layout, align_ text_layout, vec3 window_relative_pos, vec2 size, float finger_offset, color128 image_tint) {
+	float  pad2       = skui_settings.padding * 2;
+	float  depth      = finger_offset + 2 * mm2m;
+	vec3   image_at   = {};
+	float  image_size;
+	pivot_ image_pivot = pivot_x_left;
+	vec3   text_at;
+	vec2   text_size;
+	pivot_ text_pivot;
 	float aspect = image != nullptr ? sprite_get_aspect(image) : 1.0f;
 	float font_size = text_style_get_baseline(ui_get_text_style());
 	switch (image_layout) {
 	default:
 	case ui_btn_layout_left:
-		image_align = text_align_center;
+		image_pivot = pivot_center;
 		image_size  = fminf(size.y - pad2, font_size);
 		image_at    = window_relative_pos - vec3{ size.y/2.0f, size.y/2.0f, depth };
 
-		text_align = text_align_center_right;
+		text_pivot = pivot_center_right;
 		text_at    = window_relative_pos - vec3{ size.x-skui_settings.padding, size.y/2, depth };
 		text_size  = { size.x - ((size.y+image_size)/2.0f + pad2), size.y - pad2 };
 		break;
 	case ui_btn_layout_right:
-		image_align = text_align_center;
+		image_pivot = pivot_center;
 		image_at    = window_relative_pos - vec3{ size.x-(size.y/2), size.y / 2, depth };
 		image_size  = fminf(size.y - pad2, font_size);
 
-		text_align = text_align_center_left;
+		text_pivot = pivot_center_left;
 		text_at    = window_relative_pos - vec3{ skui_settings.padding, size.y / 2, depth };
 		text_size  = { size.x - ((size.y+image_size)/2.0f + pad2), size.y - pad2 };
 		break;
 	case ui_btn_layout_none:
 		image_size = 0;
 
-		text_align = text_align_top_left;
+		text_pivot = pivot_top_left;
 		text_at    = window_relative_pos - vec3{ skui_settings.padding, skui_settings.padding, depth };
 		text_size  = vec2{ size.x - pad2, size.y - pad2 };
 		break;
 	case ui_btn_layout_center_no_text:
 	case ui_btn_layout_center:
-		image_align = text_align_center;
+		image_pivot = pivot_center;
 		image_size  = fminf(size.y - pad2, (size.x - pad2) / aspect);
 		image_at    = window_relative_pos - vec3{ size.x/2, size.y / 2, depth }; 
 
-		text_align = text_align_top_center;
+		text_pivot = pivot_top_center;
 		float y = size.y / 2 + image_size / 2;
 		text_at    = window_relative_pos - vec3{size.x/2, y, depth};
 		text_size  = { size.x-pad2, (size.y-skui_settings.padding*0.25f)-y };
@@ -245,10 +245,10 @@ void _ui_button_img_surface(const C* text, sprite_t image, ui_btn_layout_ image_
 		color128 final_color = image_tint;
 		if (!ui_is_enabled()) final_color = final_color * color128{ .5f, .5f, .5f, 1 };
 	
-		sprite_draw(image, matrix_ts(image_at, { image_size, image_size, image_size }), image_align, color_to_32( final_color ));
+		sprite_draw(image, matrix_ts(image_at, { image_size, image_size, image_size }), image_pivot, color_to_32( final_color ));
 	}
 	if (image_layout != ui_btn_layout_center_no_text)
-		ui_text_in(text, text_align, text_layout, text_fit_squeeze, text_at, text_size, vec2_zero);
+		ui_text_in(text, text_pivot, text_layout, text_fit_squeeze, text_at, text_size, vec2_zero);
 }
 
 ///////////////////////////////////////////
@@ -287,7 +287,7 @@ bool32_t ui_button_img_at_g(const C* text, sprite_t image, ui_btn_layout_ image_
 
 	float min_activation = 1 - (finger_offset / skui_settings.depth);
 	ui_draw_element(ui_vis_button, window_relative_pos, vec3{ size.x,size.y,finger_offset }, fmaxf(min_activation, ui_get_anim_focus(id, focus, state)));
-	_ui_button_img_surface(text, image, image_layout, text_align_center, window_relative_pos, size, finger_offset, image_tint);
+	_ui_button_img_surface(text, image, image_layout, align_center, window_relative_pos, size, finger_offset, image_tint);
 
 	return state & button_state_just_inactive;
 }
@@ -356,7 +356,7 @@ bool32_t ui_toggle_img_at_g(const C* text, bool32_t& pressed, sprite_t toggle_of
 
 	float min_activation = 1 - (finger_offset / skui_settings.depth);
 	ui_draw_element(ui_vis_toggle, window_relative_pos, vec3{ size.x,size.y,finger_offset }, fmaxf(min_activation, ui_get_anim_focus(id, focus, state)));
-	_ui_button_img_surface(text, pressed?toggle_on:toggle_off, image_layout, text_align_center, window_relative_pos, size, finger_offset, color128{1,1,1,1});
+	_ui_button_img_surface(text, pressed?toggle_on:toggle_off, image_layout, align_center, window_relative_pos, size, finger_offset, color128{1,1,1,1});
 
 	return state & button_state_just_inactive;
 }
@@ -422,7 +422,7 @@ bool32_t ui_button_round_at_g(const C *text, sprite_t image, vec3 window_relativ
 
 	float sprite_scale = fmaxf(1, sprite_get_aspect(image));
 	float sprite_size  = (diameter * 0.7f) / sprite_scale;
-	sprite_draw(image, matrix_ts(window_relative_pos + vec3{ -diameter/2, -diameter/2, -(finger_offset + 2*mm2m) }, vec3{ sprite_size, sprite_size, 1 }), text_align_center);
+	sprite_draw(image, matrix_ts(window_relative_pos + vec3{ -diameter/2, -diameter/2, -(finger_offset + 2*mm2m) }, vec3{ sprite_size, sprite_size, 1 }), pivot_center);
 
 	return state & button_state_just_inactive;
 }
@@ -472,8 +472,8 @@ void ui_model(model_t model, vec2 ui_size, float model_scale) {
 
 ///////////////////////////////////////////
 
-inline vec2 text_char_at_o(const char*     text, text_style_t style, int32_t char_index, vec2* opt_size, text_fit_ fit, text_align_ position, text_align_ align) { return text_char_at   (text, style, char_index, opt_size, fit, position, align); }
-inline vec2 text_char_at_o(const char16_t* text, text_style_t style, int32_t char_index, vec2* opt_size, text_fit_ fit, text_align_ position, text_align_ align) { return text_char_at_16(text, style, char_index, opt_size, fit, position, align); }
+inline vec2 text_char_at_o(const char*     text, text_style_t style, int32_t char_index, vec2* opt_size, text_fit_ fit, pivot_ position, align_ align) { return text_char_at   (text, style, char_index, opt_size, fit, position, align); }
+inline vec2 text_char_at_o(const char16_t* text, text_style_t style, int32_t char_index, vec2* opt_size, text_fit_ fit, pivot_ position, align_ align) { return text_char_at_16(text, style, char_index, opt_size, fit, position, align); }
 
 template<typename C>
 bool32_t ui_input_at_g(const C* id, C* buffer, int32_t buffer_size, vec3 window_relative_pos, vec2 size, text_context_ type) {
@@ -593,18 +593,18 @@ bool32_t ui_input_at_g(const C* id, C* buffer, int32_t buffer_size, vec3 window_
 		float carat_sz = baseline * 0.1f;
 
 		int32_t carat_at      = skui_input_carat;
-		vec2    carat_pos     = text_char_at_o(draw_text, style, carat_at, &text_bounds, text_fit_clip, text_align_top_left, text_align_center_left);
+		vec2    carat_pos     = text_char_at_o(draw_text, style, carat_at, &text_bounds, text_fit_clip, pivot_top_left, align_center_left);
 		float   scroll_margin = text_bounds.x - baseline;
 		while (carat_pos.x < -scroll_margin && *draw_text != '\0' && carat_at >= 0) {
 			draw_text += 1;
 			carat_at  -= 1;
-			carat_pos = text_char_at_o(draw_text, style, carat_at, &text_bounds, text_fit_clip, text_align_top_left, text_align_center_left);
+			carat_pos = text_char_at_o(draw_text, style, carat_at, &text_bounds, text_fit_clip, pivot_top_left, align_center_left);
 		}
 
 		// Display a selection box for highlighted text
 		if (skui_input_carat != skui_input_carat_end) {
 			int32_t end       = maxi(0, carat_at + (skui_input_carat_end - skui_input_carat));
-			vec2    carat_end = text_char_at_o(draw_text, style, end, &text_bounds, text_fit_clip, text_align_top_left, text_align_center_left);
+			vec2    carat_end = text_char_at_o(draw_text, style, end, &text_bounds, text_fit_clip, pivot_top_left, align_center_left);
 			float   left      =       fmaxf(carat_pos.x, carat_end.x);
 			float   right     = fmaxf(fminf(carat_pos.x, carat_end.x), -text_bounds.x);
 
@@ -619,7 +619,7 @@ bool32_t ui_input_at_g(const C* id, C* buffer, int32_t buffer_size, vec3 window_
 		}
 	}
 
-	ui_text_in(draw_text, text_align_top_left, text_align_center_left, text_fit_clip, window_relative_pos - vec3{ skui_settings.padding, 0, text_depth }, text_bounds, vec2_zero);
+	ui_text_in(draw_text, pivot_top_left, align_center_left, text_fit_clip, window_relative_pos - vec3{ skui_settings.padding, 0, text_depth }, text_bounds, vec2_zero);
 
 	return result;
 }
@@ -821,7 +821,7 @@ bool32_t ui_vslider_f64_16(const char16_t* name, double& value, double min, doub
 ///////////////////////////////////////////
 
 template<typename C>
-bool32_t ui_text_at_g(const C* text, vec2* opt_ref_scroll, ui_scroll_ scroll_direction, text_align_ text_align, text_fit_ fit, vec3 window_relative_pos, vec2 size) {
+bool32_t ui_text_at_g(const C* text, vec2* opt_ref_scroll, ui_scroll_ scroll_direction, align_ text_align, text_fit_ fit, vec3 window_relative_pos, vec2 size) {
 	vec2 txt_bounds = size;
 	bool result     = false;
 
@@ -852,19 +852,19 @@ bool32_t ui_text_at_g(const C* text, vec2* opt_ref_scroll, ui_scroll_ scroll_dir
 			fit |= text_fit_clip;
 	}
 
-	ui_text_in(text, text_align_top_left, text_align, fit, window_relative_pos - vec3{ 0, 0, skui_settings.depth / 2 }, txt_bounds, opt_ref_scroll == nullptr ? vec2_zero : *opt_ref_scroll);
+	ui_text_in(text, pivot_top_left, text_align, fit, window_relative_pos - vec3{ 0, 0, skui_settings.depth / 2 }, txt_bounds, opt_ref_scroll == nullptr ? vec2_zero : *opt_ref_scroll);
 
 	return result;
 }
 
-bool32_t ui_text_at   (const char16_t* text, vec2* opt_ref_scroll, ui_scroll_ scroll_direction, text_align_ text_align, text_fit_ fit, vec3 window_relative_pos, vec2 size) { return ui_text_at_g<char16_t>(text, opt_ref_scroll, scroll_direction, text_align, fit, window_relative_pos, size); }
-bool32_t ui_text_at   (const char*     text, vec2* opt_ref_scroll, ui_scroll_ scroll_direction, text_align_ text_align, text_fit_ fit, vec3 window_relative_pos, vec2 size) { return ui_text_at_g<char    >(text, opt_ref_scroll, scroll_direction, text_align, fit, window_relative_pos, size); }
-bool32_t ui_text_at_16(const char16_t* text, vec2* opt_ref_scroll, ui_scroll_ scroll_direction, text_align_ text_align, text_fit_ fit, vec3 window_relative_pos, vec2 size) { return ui_text_at_g<char16_t>(text, opt_ref_scroll, scroll_direction, text_align, fit, window_relative_pos, size); }
+bool32_t ui_text_at   (const char16_t* text, vec2* opt_ref_scroll, ui_scroll_ scroll_direction, align_ text_align, text_fit_ fit, vec3 window_relative_pos, vec2 size) { return ui_text_at_g<char16_t>(text, opt_ref_scroll, scroll_direction, text_align, fit, window_relative_pos, size); }
+bool32_t ui_text_at   (const char*     text, vec2* opt_ref_scroll, ui_scroll_ scroll_direction, align_ text_align, text_fit_ fit, vec3 window_relative_pos, vec2 size) { return ui_text_at_g<char    >(text, opt_ref_scroll, scroll_direction, text_align, fit, window_relative_pos, size); }
+bool32_t ui_text_at_16(const char16_t* text, vec2* opt_ref_scroll, ui_scroll_ scroll_direction, align_ text_align, text_fit_ fit, vec3 window_relative_pos, vec2 size) { return ui_text_at_g<char16_t>(text, opt_ref_scroll, scroll_direction, text_align, fit, window_relative_pos, size); }
 
 ///////////////////////////////////////////
 
 template<typename C>
-bool32_t ui_text_sz_g(const C* text, vec2* opt_ref_scroll, ui_scroll_ scroll_direction, vec2 size, text_align_ text_align, text_fit_ fit) {
+bool32_t ui_text_sz_g(const C* text, vec2* opt_ref_scroll, ui_scroll_ scroll_direction, vec2 size, align_ text_align, text_fit_ fit) {
 	if (size.x == 0) size.x = ui_layout_remaining().x;
 	if (size.y == 0) size.y = (fit & text_fit_wrap) > 0
 		? text_size_layout_constrained(text, ui_get_text_style(), size.x).y
@@ -877,11 +877,11 @@ bool32_t ui_text_sz_g(const C* text, vec2* opt_ref_scroll, ui_scroll_ scroll_dir
 	return ui_text_at_g<C>(text, opt_ref_scroll, scroll_direction, text_align, fit, final_pos, final_size);
 }
 
-bool32_t ui_text_sz   (const char*     text, vec2* opt_ref_scroll, ui_scroll_ scroll_direction, vec2 size, text_align_ text_align, text_fit_ fit) { return ui_text_sz_g<char    >(text, opt_ref_scroll, scroll_direction, size, text_align, fit); }
-bool32_t ui_text_sz_16(const char16_t* text, vec2* opt_ref_scroll, ui_scroll_ scroll_direction, vec2 size, text_align_ text_align, text_fit_ fit) { return ui_text_sz_g<char16_t>(text, opt_ref_scroll, scroll_direction, size, text_align, fit); }
+bool32_t ui_text_sz   (const char*     text, vec2* opt_ref_scroll, ui_scroll_ scroll_direction, vec2 size, align_ text_align, text_fit_ fit) { return ui_text_sz_g<char    >(text, opt_ref_scroll, scroll_direction, size, text_align, fit); }
+bool32_t ui_text_sz_16(const char16_t* text, vec2* opt_ref_scroll, ui_scroll_ scroll_direction, vec2 size, align_ text_align, text_fit_ fit) { return ui_text_sz_g<char16_t>(text, opt_ref_scroll, scroll_direction, size, text_align, fit); }
 
-bool32_t ui_text      (const char*     text, vec2* opt_ref_scroll, ui_scroll_ scroll_direction, float height, text_align_ text_align, text_fit_ fit) { return ui_text_sz_g<char    >(text, opt_ref_scroll, scroll_direction, { 0, height }, text_align, fit); }
-bool32_t ui_text_16   (const char16_t* text, vec2* opt_ref_scroll, ui_scroll_ scroll_direction, float height, text_align_ text_align, text_fit_ fit) { return ui_text_sz_g<char16_t>(text, opt_ref_scroll, scroll_direction, { 0, height }, text_align, fit); }
+bool32_t ui_text      (const char*     text, vec2* opt_ref_scroll, ui_scroll_ scroll_direction, float height, align_ text_align, text_fit_ fit) { return ui_text_sz_g<char    >(text, opt_ref_scroll, scroll_direction, { 0, height }, text_align, fit); }
+bool32_t ui_text_16   (const char16_t* text, vec2* opt_ref_scroll, ui_scroll_ scroll_direction, float height, align_ text_align, text_fit_ fit) { return ui_text_sz_g<char16_t>(text, opt_ref_scroll, scroll_direction, { 0, height }, text_align, fit); }
 
 ///////////////////////////////////////////
 
@@ -929,7 +929,7 @@ void ui_window_begin_g(const C *text, pose_t &pose, vec2 window_size, ui_win_ wi
 		vec2 size     = vec2{ window_size.x == 0 ? txt_size.x : window_size.x-(skui_settings.margin*2), ui_line_height() };
 		vec3 at       = layout->offset - vec3{ skui_settings.padding, -(size.y+skui_settings.margin), 2*mm2m };
 
-		ui_text_in(text, text_align_top_left, text_align_center_left, text_fit_squeeze, at, size, vec2_zero);
+		ui_text_in(text, pivot_top_left, align_center_left, text_fit_squeeze, at, size, vec2_zero);
 
 		float header_width = window_size.x == 0 ? size.x + skui_settings.padding * 2 + skui_settings.margin * 2 : size.x;
 		if (win->curr_size.x < header_width)

--- a/StereoKitC/ui/ui_layout.cpp
+++ b/StereoKitC/ui/ui_layout.cpp
@@ -311,13 +311,13 @@ void _ui_visualize_layout(ui_layout_t* layout) {
 
 	char text[256];
 	snprintf(text, 256, "layout\n%.2gx%.2g", size.x * 100, size.y * 100);
-	text_add_at(text, matrix_ts(start - vec3{ size.x, 0, z_offset }, vec3_one * 0.5f), 0, text_align_top_left, text_align_top_left, 0, 0, 0, color32_to_128(col));
+	text_add_at(text, matrix_ts(start - vec3{ size.x, 0, z_offset }, vec3_one * 0.5f), 0, pivot_top_left, align_top_left, 0, 0, 0, color32_to_128(col));
 
 	snprintf(text, 256, "%.2g,%.2g", start.x * 100, start.y * 100);
-	text_add_at(text, matrix_ts(start - vec3{ 0, 0, z_offset }, vec3_one * 0.5f), 0, text_align_top_left, text_align_top_left, 0, 0, 0, color32_to_128(col));
+	text_add_at(text, matrix_ts(start - vec3{ 0, 0, z_offset }, vec3_one * 0.5f), 0, pivot_top_left, align_top_left, 0, 0, 0, color32_to_128(col));
 
 	snprintf(text, 256, "%.2g,%.2g", (start.x - size.x) * 100, start.y * 100);
-	text_add_at(text, matrix_ts(start - vec3{ size.x, 0, z_offset }, vec3_one * 0.5f), 0, text_align_top_right, text_align_top_left, 0, 0, 0, color32_to_128(col));
+	text_add_at(text, matrix_ts(start - vec3{ size.x, 0, z_offset }, vec3_one * 0.5f), 0, pivot_top_right, align_top_left, 0, 0, 0, color32_to_128(col));
 
 	if (layout->window != -1) {
 		ui_window_t *win = &skui_windows[layout->window];
@@ -332,7 +332,7 @@ void _ui_visualize_layout(ui_layout_t* layout) {
 		line_add(start - vec3{ 0, size.y, z_offset }, start - vec3{ size.x, size.y, z_offset }, col, col, weight);
 
 		snprintf(text, 256, "win %.2gx%.2g", size.x * 100, size.y * 100);
-		text_add_at(text, matrix_ts(start - vec3{ 0, 0, z_offset }, vec3_one * 0.5f), 0, text_align_bottom_left, text_align_top_left, 0, 0, 0, color32_to_128(col));
+		text_add_at(text, matrix_ts(start - vec3{ 0, 0, z_offset }, vec3_one * 0.5f), 0, pivot_bottom_left, align_top_left, 0, 0, 0, color32_to_128(col));
 	}
 }
 


### PR DESCRIPTION
This splits `TextAlign` into `Align` and `Pivot`! This addresses occasions where `TextAlign` would be re-used in non-text contexts, and visually and contextually distinguish between function parameters where `TextAlign` was re-used for both text alignment and text positioning. Notably, `Text.Add` calls should be much more clear at a glance.

`Align` and `Pivot` have the exact same layout as eachother, as well as the previous `TextAlign` definition. PInvoke style code binding may continue to work, but should be updated. @mvvvv

In C#, `TextAlign` remains present with an obsolete warning and implicit conversions to gently redirect users to the new usage. However, `TextAlign` is now a struct instead of enum, so certain use patterns may be breaking.

In C, `text_align_` remains present and is marked as deprecated. No implicit conversion are provided, and existing usage will break.