### PR TITLE
IStepper Initialization order

### DIFF
--- a/StereoKit/Framework/Steppers.cs
+++ b/StereoKit/Framework/Steppers.cs
@@ -78,7 +78,7 @@ namespace StereoKit.Framework
 			return null;
 		}
 
-		public void Step()
+		public void DequeueActions()
 		{
 			// Execute all stepper actions on the main thread in the order they
 			// were given.
@@ -99,6 +99,11 @@ namespace StereoKit.Framework
 						break;
 				}
 			}
+		}
+
+		public void Step()
+		{
+			DequeueActions();
 
 			foreach (IStepper stepper in _steppers)
 				stepper.Step();

--- a/StereoKit/SK.cs
+++ b/StereoKit/SK.cs
@@ -157,10 +157,14 @@ namespace StereoKit
 			// of the final defaults or calculated settings.
 			Settings = NativeAPI.sk_get_settings();
 
-			// Get system information
+			// Do a few things on success
 			if (result) { 
 				_system = NativeAPI.sk_system_info();
 				Default.Initialize();
+
+				// Ensure any steppers already in the queue get initialized
+				// right away.
+				_steppers.DequeueActions();
 			}
 
 			Backend.OpenXR.CleanupInitialize();


### PR DESCRIPTION
Make sure `IStepper`s get initialized right after `SK.Initialize`, as stated in the docs! Mentioned in #1181

`ISteppers` would previously only be initialized at the beginning of `Step`. However, `IStepper`s being added before `SK.Initialize` is a common pattern due to the way OpenXR extensions need to happen, which meant the ISteppers would not be entirely ready during the initialization period between `SK.Initialize` and the first `Step`.

This change checks for initialization and removal of `ISteppers` at the tail end of `SK.Initialize`, so they can be used during app initialization code as expected!