### PR TITLE
Adds overload to get the `IntPtr` directly from `Anchor::TryGetPerceptionAnchor`

### DIFF
--- a/StereoKit/Assets/Anchor.cs
+++ b/StereoKit/Assets/Anchor.cs
@@ -68,6 +68,20 @@ namespace StereoKit {
 			}
 			return result;
 		}
+
+		/// <summary>Tries to get the underlying perception spatial anchor as a COM pointer.
+		/// Use this when you need the raw IntPtr for interop or custom marshalling.</summary>
+		/// <param name="spatialAnchor">The raw COM pointer to the spatial anchor.</param>
+		/// <returns>True if the pointer was successfully obtained, false otherwise.</returns>
+		public bool TryGetPerceptionAnchor(out IntPtr spatialAnchor)
+		{
+			bool result = NativeAPI.anchor_get_perception_anchor(_inst, out spatialAnchor);
+			if (!result)
+			{
+				spatialAnchor = IntPtr.Zero;
+			}
+			return result;
+		}
 		
 		internal Anchor(IntPtr anchor)
 		{


### PR DESCRIPTION
Thanks so much to @maluoi and @sjando for the very helpful UWP info in #1122! It helped modernize my UWP code to net9.0 pretty smoothly :)

This PR mainly addresses the need to get the pointer directly since interop has changed in newer .NET versions.
```
public SpatialAnchor WorldSpatialAnchor
{
	get
	{
#if WINDOWS
		SpatialAnchor anchor = null;
		if (Nakamir.World.WorldTransforms.WorldAnchor.TryGetPerceptionAnchor(out IntPtr anchorPtr))
		{
			anchor = MarshalInterface<SpatialAnchor>.FromAbi(anchorPtr);
		}
#else
		Nakamir.World.WorldTransforms.WorldAnchor.TryGetPerceptionAnchor(out SpatialAnchor anchor);
#endif
		return anchor;
	}
}
```

Unrelated but I experimented with [CsWinRT](https://github.com/microsoft/CsWinRT) and made [SkUwpSample](https://github.com/Nakamir-Code/SKUwpSample.NET) showing how to reference native WinRT components. The inclusion of `CsWinRT` allows you to reference `Microsoft.MixedReality.QR` like before!

Also, if anyone ever runs into this, here's one more gotcha of the newer interop. Since Com objects can't directly cast anymore, you can utilize `IWinRTObject`:
```
#if WINDOWS
	(reference as IWinRTObject).As<UnsafeNative.IMemoryBufferByteAccess>().GetBuffer(out byte* imageData, out uint size);
#else
	(reference as UnsafeNative.IMemoryBufferByteAccess).GetBuffer(out byte* imageData, out uint size);
#endif
```