### PR TITLE
Added hash APIs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -147,7 +147,7 @@ jobs:
 ###########################################
 
   build-linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       CPM_SOURCE_CACHE: .deps_cache
 

--- a/.github/workflows/verify_compile.yml
+++ b/.github/workflows/verify_compile.yml
@@ -34,7 +34,7 @@ jobs:
         cmake --build --preset Uwp_x64_Release
 
   native-linux-android-dotnet:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       CPM_SOURCE_CACHE: .deps_cache
 

--- a/StereoKit/Native/NativeAPI.cs
+++ b/StereoKit/Native/NativeAPI.cs
@@ -67,6 +67,13 @@ namespace StereoKit
 
 		///////////////////////////////////////////
 
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IdHash hash_string     ([In] byte[] str_utf8);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IdHash hash_string_with([In] byte[] str_utf8, IdHash root);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IdHash hash_int        (int val);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IdHash hash_int_with   (int val, IdHash root);
+
+		///////////////////////////////////////////
+
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern Quat quat_difference (in Quat a, in Quat b);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern Quat quat_lookat     (in Vec3 from, in Vec3 at);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern Quat quat_lookat_up  (in Vec3 from, in Vec3 at, in Vec3 up);

--- a/StereoKit/Util/Hash.cs
+++ b/StereoKit/Util/Hash.cs
@@ -1,0 +1,58 @@
+﻿// SPDX-License-Identifier: MIT
+// The authors below grant copyright rights under the MIT license:
+// Copyright (c) 2025 Nick Klingensmith
+// Copyright (c) 2025 Qualcomm Technologies, Inc.
+
+namespace StereoKit
+{
+	/// <summary>This class contains some tools for hashing data within
+	/// StereoKit! Certain systems in StereoKit use string hashes instead of
+	/// full strings for faster search and compare, like UI and Materials, so
+	/// this class gives access to the code SK uses for hashing.
+	/// 
+	/// StereoKit currently internally uses a 64 bit FNV hash, though this
+	/// detail should be pretty transparent to developers.</summary>
+	public static class Hash
+	{
+		/// <summary>This will hash the UTF8 representation of the given string
+		/// into a hash value that StereoKit can use.</summary>
+		/// <param name="str">A C# string that will be converted to UTF8, and
+		/// then hashed.</param>
+		/// <returns>A StereoKit hash representing the provided string.</returns>
+		public static IdHash String(string str)
+			=> NativeAPI.hash_string (NativeHelper.ToUtf8(str));
+
+		/// <summary>This will hash the UTF8 representation of the given string
+		/// into a hash value that StereoKit can use. This overload allows you
+		/// to combine your hash with an existing hash.</summary>
+		/// <param name="str">A C# string that will be converted to UTF8, and
+		/// then hashed.</param>
+		/// <param name="root">The hash value this new hash will start from.
+		/// </param>
+		/// <returns>A StereoKit hash representing a combination of the
+		/// provided string and the root hash.</returns>
+		public static IdHash String(string str, IdHash root)
+			=> NativeAPI.hash_string_with(NativeHelper.ToUtf8(str), root);
+
+		/// <summary>This will hash an integer into a hash value that StereoKit
+		/// can use. This is helpful for adding in some uniqueness using
+		/// something like a for loop index. This may be best when combined
+		/// with additional hashes.</summary>
+		/// <param name="val">An integer that will be hashed.</param>
+		/// <returns>A StereoKit hash representing the provided integer.</returns>
+		public static IdHash Int(int val)
+				=> NativeAPI.hash_int(val);
+
+		/// <summary>This will hash an integer into a hash value that StereoKit
+		/// can use. This is helpful for adding in some uniqueness using
+		/// something like a for loop index. This overload allows you to
+		/// combine your hash with an existing hash.</summary>
+		/// <param name="val">An integer that will be hashed.</param>
+		/// <param name="root">The hash value this new hash will start from.
+		/// </param>
+		/// <returns>A StereoKit hash representing a combination of the
+		/// provided string and the root hash.</returns>
+		public static IdHash Int(int val, IdHash root)
+			=> NativeAPI.hash_int_with(val, root);
+	}
+}

--- a/StereoKitC/_stereokit.h
+++ b/StereoKitC/_stereokit.h
@@ -5,6 +5,8 @@
 
 namespace sk {
 
+const id_hash_t default_hash_root = 14695981039346656037UL;
+
 void     sk_assert_thread_valid();
 bool32_t sk_has_stepped        ();
 bool32_t sk_is_initialized     ();

--- a/StereoKitC/asset_types/assets.cpp
+++ b/StereoKitC/asset_types/assets.cpp
@@ -19,7 +19,6 @@
 #include "anchor.h"
 #include "../platforms/platform.h"
 #include "../libraries/stref.h"
-#include "../libraries/ferr_hash.h"
 #include "../libraries/array.h"
 #include "../libraries/sokol_time.h"
 #include "../libraries/atomic_util.h"
@@ -79,12 +78,12 @@ void    asset_step_task();
 ///////////////////////////////////////////
 
 void *assets_find(const char *id, asset_type_ type) {
-	return assets_find(hash_fnv64_string(id), type);
+	return assets_find(hash_string(id), type);
 }
 
 ///////////////////////////////////////////
 
-void *assets_find(uint64_t id, asset_type_ type) {
+void *assets_find(id_hash_t id, asset_type_ type) {
 	void* result = nullptr;
 	ft_mutex_lock(assets_lock);
 	for (int32_t i = 0; i < assets.count; i++) {
@@ -101,11 +100,11 @@ void *assets_find(uint64_t id, asset_type_ type) {
 
 void assets_unique_name(asset_type_ type, const char *root_name, char *dest, int dest_size) {
 	snprintf(dest, dest_size, "%s", root_name);
-	uint64_t id    = hash_fnv64_string(dest);
-	int      count = 1;
+	id_hash_t id    = hash_string(dest);
+	int       count = 1;
 	while (assets_find(dest, type) != nullptr) {
 		snprintf(dest, dest_size, "%s%d", root_name, count);
-		id = hash_fnv64_string(dest);
+		id = hash_string(dest);
 		count += 1;
 	}
 }
@@ -138,7 +137,7 @@ void *assets_allocate(asset_type_ type) {
 	ft_mutex_lock(assets_lock);
 	char name[64];
 	snprintf(name, sizeof(name), "auto/%s_%d", type_name, assets.count);
-	header->id      = hash_fnv64_string(name);
+	header->id      = hash_string(name);
 	header->id_text = string_copy(name);
 	header->index   = assets.count;
 
@@ -150,7 +149,7 @@ void *assets_allocate(asset_type_ type) {
 ///////////////////////////////////////////
 
 void assets_set_id(asset_header_t *header, const char *id) {
-	assets_set_id(header, hash_fnv64_string(id));
+	assets_set_id(header, hash_string(id));
 	char* old_text = header->id_text;
 	header->id_text = string_copy(id);
 	sk_free(old_text);
@@ -158,7 +157,7 @@ void assets_set_id(asset_header_t *header, const char *id) {
 
 ///////////////////////////////////////////
 
-void assets_set_id(asset_header_t *header, uint64_t id) {
+void assets_set_id(asset_header_t *header, id_hash_t id) {
 #if defined(SK_DEBUG)
 	asset_header_t *other = (asset_header_t *)assets_find(id, header->type);
 	if (other != nullptr) {
@@ -554,7 +553,7 @@ asset_type_ asset_get_type(asset_t asset) {
 ///////////////////////////////////////////
 
 void asset_set_id(asset_t asset, const char* id) {
-	assets_set_id((asset_header_t*)asset, hash_fnv64_string(id));
+	assets_set_id((asset_header_t*)asset, hash_string(id));
 }
 
 ///////////////////////////////////////////

--- a/StereoKitC/asset_types/assets.h
+++ b/StereoKitC/asset_types/assets.h
@@ -8,7 +8,7 @@ namespace sk {
 struct asset_header_t {
 	asset_type_  type;
 	asset_state_ state;
-	uint64_t     id;
+	id_hash_t    id;
 	uint64_t     index;
 	int32_t      refs;
 	char        *id_text;
@@ -48,7 +48,7 @@ struct asset_task_t {
 };
 
 void *assets_find          (const char *id, asset_type_ type);
-void *assets_find          (uint64_t    id, asset_type_ type);
+void *assets_find          (id_hash_t   id, asset_type_ type);
 void *assets_allocate      (asset_type_ type);
 void  assets_destroy       (asset_header_t *asset);
 void  assets_set_id        (asset_header_t *header, const char *id);

--- a/StereoKitC/asset_types/font.cpp
+++ b/StereoKitC/asset_types/font.cpp
@@ -1,8 +1,8 @@
 ﻿#include "font.h"
 
+#include "../_stereokit.h"
 #include "../libraries/stb_truetype.h"
 #include "../libraries/aileron_font_data.h"
-#include "../libraries/ferr_hash.h"
 #include "../libraries/stref.h"
 #include "../libraries/sk_fontfile.h"
 #include "../rect_atlas.h"
@@ -16,7 +16,7 @@
 namespace sk {
 
 typedef struct font_source_t {
-	int64_t        name_hash;
+	id_hash_t      name_hash;
 	char          *name;
 	int32_t        references;
 	stbtt_fontinfo info;
@@ -94,8 +94,8 @@ void         font_source_release  (int32_t id);
 ///////////////////////////////////////////
 
 int32_t font_source_add(const char *filename) {
-	int64_t hash = hash_fnv64_string(filename);
-	int32_t id   = font_sources.index_where(&font_source_t::name_hash, hash);
+	id_hash_t hash = hash_string(filename);
+	int32_t   id   = font_sources.index_where(&font_source_t::name_hash, hash);
 
 	if (id == -1) {
 		font_source_t new_file = {};
@@ -123,8 +123,8 @@ int32_t font_source_add(const char *filename) {
 ///////////////////////////////////////////
 
 int32_t font_source_add_data(const char *name, const void *data, size_t data_size) {
-	int64_t hash = hash_fnv64_string(name);
-	int32_t id   = font_sources.index_where(&font_source_t::name_hash, hash);
+	id_hash_t hash = hash_string(name);
+	int32_t   id   = font_sources.index_where(&font_source_t::name_hash, hash);
 
 	if (id == -1) {
 		font_source_t new_file = {};
@@ -270,9 +270,9 @@ font_t font_create_files(const char **files, int32_t file_count) {
 	}
 
 	// Hash the names of all of the files together
-	uint64_t hash = HASH_FNV64_START;
+	id_hash_t hash = default_hash_root;
 	for (int32_t i = 0; i < file_count; i++) {
-		hash = hash_fnv64_string(files[i], hash);
+		hash = hash_string_with(files[i], hash);
 	}
 	char file_id[64];
 	snprintf(file_id, sizeof(file_id), "sk/font/%" PRIu64, hash);

--- a/StereoKitC/asset_types/material.cpp
+++ b/StereoKitC/asset_types/material.cpp
@@ -2,7 +2,6 @@
 #include "shader.h"
 #include "texture.h"
 #include "../libraries/stref.h"
-#include "../libraries/ferr_hash.h"
 #include "../libraries/array.h"
 #include "../sk_memory.h"
 #include "../systems/defaults.h"
@@ -590,7 +589,7 @@ void material_set_matrix(material_t material, const char *name, matrix value) {
 
 ///////////////////////////////////////////
 
-bool32_t material_set_texture_id(material_t material, uint64_t id, tex_t value) {
+bool32_t material_set_texture_id(material_t material, id_hash_t id, tex_t value) {
 
 	for (uint32_t i = 0; i < material->shader->shader.meta->resource_count; i++) {
 		const skg_shader_resource_t *resource = &material->shader->shader.meta->resources[i];
@@ -628,8 +627,7 @@ bool32_t material_set_texture_id(material_t material, uint64_t id, tex_t value) 
 ///////////////////////////////////////////
 
 bool32_t material_set_texture(material_t material, const char *name, tex_t value) {
-	uint64_t id = hash_fnv64_string(name);
-	return material_set_texture_id(material, id, value);
+	return material_set_texture_id(material, hash_string(name), value);
 }
 
 ///////////////////////////////////////////
@@ -698,7 +696,7 @@ matrix material_get_matrix(material_t material, const char* name) {
 ///////////////////////////////////////////
 
 tex_t material_get_texture(material_t material, const char* name) {
-	uint64_t id = hash_fnv64_string(name);
+	id_hash_t id = hash_string(name);
 	for (uint32_t i = 0; i < material->shader->shader.meta->resource_count; i++) {
 		const skg_shader_resource_t* resource = &material->shader->shader.meta->resources[i];
 		if (resource->name_hash == id) {
@@ -713,7 +711,7 @@ tex_t material_get_texture(material_t material, const char* name) {
 ///////////////////////////////////////////
 
 bool32_t material_has_param(material_t material, const char *name, material_param_ type) {
-	uint64_t id = hash_fnv64_string(name);
+	id_hash_t id = hash_string(name);
 
 	if (type == material_param_texture) {
 		for (uint32_t i = 0; i < material->shader->shader.meta->resource_count; i++) {
@@ -730,12 +728,12 @@ bool32_t material_has_param(material_t material, const char *name, material_para
 ///////////////////////////////////////////
 
 void material_set_param(material_t material, const char *name, material_param_ type, const void *value) {
-	material_set_param_id(material, hash_fnv64_string(name), type, value);
+	material_set_param_id(material, hash_string(name), type, value);
 }
 
 ///////////////////////////////////////////
 
-void material_set_param_id(material_t material, uint64_t id, material_param_ type, const void *value) {
+void material_set_param_id(material_t material, id_hash_t id, material_param_ type, const void *value) {
 	if (type == material_param_texture) {
 		material_set_texture_id(material, id, (tex_t)value);
 	} else {
@@ -751,12 +749,12 @@ void material_set_param_id(material_t material, uint64_t id, material_param_ typ
 ///////////////////////////////////////////
 
 bool32_t material_get_param(material_t material, const char *name, material_param_ type, void *out_value) {
-	return material_get_param_id(material, hash_fnv64_string(name), type, out_value);
+	return material_get_param_id(material, hash_string(name), type, out_value);
 }
 
 ///////////////////////////////////////////
 
-bool32_t material_get_param_id(material_t material, uint64_t id, material_param_ type, void *out_value) {
+bool32_t material_get_param_id(material_t material, id_hash_t id, material_param_ type, void *out_value) {
 	if (type == material_param_texture) {
 		for (uint32_t i = 0; i < material->shader->shader.meta->resource_count; i++) {
 			if (material->shader->shader.meta->resources[i].name_hash == id) {
@@ -872,8 +870,8 @@ void material_check_tex_changes(material_t material) {
 				: curr->tex->fallback;
 			curr->meta_hash = curr->tex->meta_hash;
 
-			uint64_t tex_info_hash = hash_fnv64_string("_i", material->shader->shader.meta->resources[i].name_hash);
-			vec4     info = { (float)physical_tex->width, (float)physical_tex->height, (float)(uint32_t)log2(physical_tex->width), 0 };
+			id_hash_t tex_info_hash = hash_string_with("_i", material->shader->shader.meta->resources[i].name_hash);
+			vec4      info = { (float)physical_tex->width, (float)physical_tex->height, (float)(uint32_t)log2(physical_tex->width), 0 };
 			material_set_param_id(material, tex_info_hash, material_param_vector4, &info);
 		}
 	}

--- a/StereoKitC/asset_types/sprite.cpp
+++ b/StereoKitC/asset_types/sprite.cpp
@@ -1,6 +1,5 @@
 #include "sprite.h"
 #include "assets.h"
-#include "../libraries/ferr_hash.h"
 #include "../systems/sprite_drawer.h"
 #include "../sk_math.h"
 #include "../sk_memory.h"
@@ -110,7 +109,7 @@ sprite_t sprite_create(tex_t image, sprite_type_ type, const char *atlas_id) {
 		material_set_texture(result->material, "diffuse", image);
 	} else {
 		// Find the atlas for this id
-		uint64_t     map_id = hash_fnv64_string(atlas_id);
+		id_hash_t    map_id = hash_string(atlas_id);
 		spritemap_t *map    = nullptr;
 		int32_t      index  = -1;
 		for (int32_t i = 0; i < sprite_map_count; i++) {

--- a/StereoKitC/asset_types/texture.cpp
+++ b/StereoKitC/asset_types/texture.cpp
@@ -4,8 +4,8 @@
 // Copyright (c) 2024 Qualcomm Technologies, Inc.
 
 #include "../stereokit.h"
+#include "../_stereokit.h"
 #include "../platforms/platform.h"
-#include "../libraries/ferr_hash.h"
 #include "../libraries/qoi.h"
 #include "../libraries/stref.h"
 #include "../sk_math.h"
@@ -471,9 +471,9 @@ tex_t tex_create_color128(color128 *data, int32_t width, int32_t height, bool32_
 
 tex_t _tex_create_file_arr(tex_type_ type, const char **files, int32_t file_count, bool32_t srgb_data, int32_t priority) {
 	// Hash the names of all of the files together
-	uint64_t hash = HASH_FNV64_START;
+	id_hash_t hash = default_hash_root;
 	for (int32_t i = 0; i < file_count; i++) {
-		hash = hash_fnv64_string(files[i], hash);
+		hash = hash_string_with(files[i], hash);
 	}
 	char file_id[64];
 	snprintf(file_id, sizeof(file_id), "sk/tex/array/%" PRIu64, hash);
@@ -516,7 +516,7 @@ tex_t tex_create_file_arr(const char **files, int32_t file_count, bool32_t srgb_
 
 tex_t tex_create_cubemap_file(const char *cubemap_file, bool32_t srgb_data, int32_t priority) {
 	char cubemap_id[64];
-	snprintf(cubemap_id, sizeof(cubemap_id), "sk/tex/cubemap/%" PRIu64, hash_fnv64_string(cubemap_file));
+	snprintf(cubemap_id, sizeof(cubemap_id), "sk/tex/cubemap/%" PRIu64, hash_string(cubemap_file));
 
 	tex_t result = tex_find(cubemap_id);
 	if (result != nullptr) {
@@ -1200,9 +1200,9 @@ tex_format_ tex_get_tex_format(int64_t native_fmt) {
 
 ///////////////////////////////////////////
 
-uint64_t tex_meta_hash(tex_t texture) {
-	uint64_t result = hash_fnv64_data(&texture->width,  sizeof(texture->width));
-	result          = hash_fnv64_data(&texture->height, sizeof(texture->height), result);
+id_hash_t tex_meta_hash(tex_t texture) {
+	id_hash_t result = hash_int     (texture->width);
+	result           = hash_int_with(texture->height, result);
 	// May want to consider texture format or some other items as well, but
 	// this is plenty for now.
 	return result;

--- a/StereoKitC/stereokit.cpp
+++ b/StereoKitC/stereokit.cpp
@@ -13,6 +13,7 @@
 #include "systems/_stereokit_systems.h"
 #include "libraries/sokol_time.h"
 #include "libraries/ferr_thread.h"
+#include "libraries/ferr_hash.h"
 #include "utils/random.h"
 #include "platforms/platform.h"
 
@@ -513,5 +514,12 @@ void time_set_time(double total_seconds, double frame_elapsed_seconds) {
 	local.timevf_us      = (float)local.timev_us;
 	local.timevf         = (float)local.timev;
 }
+
+///////////////////////////////////////////
+
+id_hash_t hash_string     (const char* str_utf8)                 { return hash_fnv64_string(str_utf8); }
+id_hash_t hash_string_with(const char* str_utf8, id_hash_t root) { return hash_fnv64_string(str_utf8, root); }
+id_hash_t hash_int        (int32_t value)                        { return hash_fnv64_data  (&value, sizeof(int32_t), HASH_FNV64_START); }
+id_hash_t hash_int_with   (int32_t value,        id_hash_t root) { return hash_fnv64_data  (&value, sizeof(int32_t), root); }
 
 } // namespace sk

--- a/StereoKitC/stereokit.h
+++ b/StereoKitC/stereokit.h
@@ -57,7 +57,8 @@ inline enumType  operator~ (const enumType& a)              { return static_cast
 namespace sk {
 #endif
 
-typedef int32_t bool32_t;
+typedef int32_t  bool32_t;
+typedef uint64_t id_hash_t;
 
 typedef struct vec2 {
 	float x;
@@ -542,6 +543,13 @@ SK_API double        time_step             (void);
 SK_API void          time_scale            (double scale);
 SK_API void          time_set_time         (double total_seconds, double frame_elapsed_seconds sk_default(0));
 SK_API uint64_t      time_frame            (void);
+
+///////////////////////////////////////////
+
+SK_API id_hash_t     hash_string           (const char* str_utf8);
+SK_API id_hash_t     hash_string_with      (const char* str_utf8, id_hash_t root);
+SK_API id_hash_t     hash_int              (int32_t value);
+SK_API id_hash_t     hash_int_with         (int32_t value,        id_hash_t root);
 
 ///////////////////////////////////////////
 
@@ -1288,7 +1296,7 @@ SK_API void              material_set_uint3       (material_t material, const ch
 SK_API void              material_set_uint4       (material_t material, const char *name, uint32_t value1, uint32_t value2, uint32_t value3, uint32_t value4);
 SK_API void              material_set_matrix      (material_t material, const char *name, matrix   value);
 SK_API bool32_t          material_set_texture     (material_t material, const char *name, tex_t    value);
-SK_API bool32_t          material_set_texture_id  (material_t material, uint64_t    id,   tex_t    value);
+SK_API bool32_t          material_set_texture_id  (material_t material, id_hash_t   id,   tex_t    value);
 SK_API float             material_get_float       (material_t material, const char *name);
 SK_API vec2              material_get_vector2     (material_t material, const char *name);
 SK_API vec3              material_get_vector3     (material_t material, const char *name);
@@ -1301,9 +1309,9 @@ SK_API matrix            material_get_matrix      (material_t material, const ch
 SK_API tex_t             material_get_texture     (material_t material, const char *name);
 SK_API bool32_t          material_has_param       (material_t material, const char *name, material_param_ type);
 SK_API void              material_set_param       (material_t material, const char *name, material_param_ type, const void *value);
-SK_API void              material_set_param_id    (material_t material, uint64_t    id,   material_param_ type, const void *value);
+SK_API void              material_set_param_id    (material_t material, id_hash_t   id,   material_param_ type, const void *value);
 SK_API bool32_t          material_get_param       (material_t material, const char *name, material_param_ type, void *out_value);
-SK_API bool32_t          material_get_param_id    (material_t material, uint64_t    id,   material_param_ type, void *out_value);
+SK_API bool32_t          material_get_param_id    (material_t material, id_hash_t   id,   material_param_ type, void *out_value);
 SK_API void              material_get_param_info  (material_t material, int32_t index, char **out_name, material_param_ *out_type);
 SK_API int32_t           material_get_param_count (material_t material);
 SK_API void              material_set_shader      (material_t material, shader_t shader);

--- a/StereoKitC/stereokit_ui.h
+++ b/StereoKitC/stereokit_ui.h
@@ -154,8 +154,6 @@ typedef struct ui_slider_data_t {
 	int32_t       interactor;
 } ui_slider_data_t;
 
-typedef uint64_t id_hash_t;
-
 SK_API void     ui_quadrant_size_verts  (vert_t *ref_vertices, int32_t vertex_count, float overflow_percent);
 SK_API void     ui_quadrant_size_mesh   (mesh_t ref_mesh, float overflow_percent);
 SK_API mesh_t   ui_gen_quadrant_mesh    (ui_corner_ rounded_corners, float corner_radius, uint32_t corner_resolution, bool32_t delete_flat_sides, bool32_t quadrantify, const ui_lathe_pt_t* lathe_pts, int32_t lathe_pt_count);
@@ -204,8 +202,8 @@ SK_API id_hash_t ui_push_id              (const char*     id);
 SK_API id_hash_t ui_push_id_16           (const char16_t* id);
 SK_API id_hash_t ui_push_idi             (int32_t id);
 SK_API void      ui_pop_id               (void);
-SK_API id_hash_t ui_stack_hash           (const char*     string);
-SK_API id_hash_t ui_stack_hash_16        (const char16_t* string);
+SK_API id_hash_t ui_stack_hash           (const char*     string_utf8);
+SK_API id_hash_t ui_stack_hash_16        (const char16_t* string_utf16);
 
 SK_API void     ui_layout_area     (vec3 start, vec2 dimensions, bool32_t add_margin sk_default(true));
 SK_API vec2     ui_layout_remaining(void);

--- a/StereoKitC/tools/file_picker.cpp
+++ b/StereoKitC/tools/file_picker.cpp
@@ -24,8 +24,6 @@
 
 #elif defined(SK_OS_WINDOWS_UWP)
 
-	#include "../libraries/ferr_hash.h"
-
 	#ifndef WIN32_LEAN_AND_MEAN
 	#define WIN32_LEAN_AND_MEAN
 	#endif
@@ -68,7 +66,7 @@ enum fp_sort_by_ {
 #if defined(SK_OS_WINDOWS_UWP)
 struct fp_file_cache_t {
 public:
-	uint64_t    name_hash;
+	id_hash_t   name_hash;
 	StorageFile file = nullptr;
 };
 std::vector<fp_file_cache_t> fp_file_cache;
@@ -76,7 +74,7 @@ std::vector<fp_file_cache_t> fp_file_cache;
 
 char                         fp_filename [1024];
 wchar_t                      fp_wfilename[1024];
-char                         fp_buffer[1023];
+char                         fp_buffer   [1023];
 bool                         fp_call                  = false;
 void                        *fp_call_data             = nullptr;
 bool                         fp_call_status           = false;
@@ -302,7 +300,7 @@ void file_picker_uwp_picked(IAsyncOperation<StorageFile> result, AsyncStatus sta
 
 		fp_file_cache_t item;
 		item.file      = file;
-		item.name_hash = hash_fnv64_string(fp_filename);
+		item.name_hash = hash_string(fp_filename);
 		fp_file_cache.push_back(item);
 		fp_call        = true;
 		fp_call_status = true;
@@ -629,7 +627,7 @@ void file_picker_shutdown() {
 
 bool file_picker_cache_read(const char *filename, void **out_data, size_t *out_size) {
 #if defined(SK_OS_WINDOWS_UWP)
-	uint64_t hash = hash_fnv64_string(filename);
+	id_hash_t hash = hash_string(filename);
 	for (size_t i = 0; i < fp_file_cache.size(); i++) {
 		if (fp_file_cache[i].name_hash == hash) {
 			IRandomAccessStreamWithContentType stream = fp_file_cache[i].file.OpenReadAsync().get();
@@ -657,7 +655,7 @@ bool file_picker_cache_read(const char *filename, void **out_data, size_t *out_s
 
 bool file_picker_cache_save(const char *filename, void *data, size_t size) {
 #if defined(SK_OS_WINDOWS_UWP)
-	uint64_t hash = hash_fnv64_string(filename);
+	id_hash_t hash = hash_string(filename);
 	for (size_t i = 0; i < fp_file_cache.size(); i++) {
 		if (fp_file_cache[i].name_hash == hash) {
 			winrt::array_view<uint8_t const> view{ (uint8_t *)data, (uint8_t *)data + size };

--- a/StereoKitC/tools/virtual_keyboard.cpp
+++ b/StereoKitC/tools/virtual_keyboard.cpp
@@ -11,7 +11,6 @@
 #include "../libraries/array.h"
 #include "../libraries/unicode.h"
 #include "../libraries/stref.h"
-#include "../libraries/ferr_hash.h"
 #include "../platforms/platform.h"
 
 namespace sk {
@@ -157,11 +156,11 @@ void virtualkeyboard_shutdown() {
 
 ///////////////////////////////////////////
 
-uint64_t virtualkeyboard_hash(const keylayout_key_t* key) {
+id_hash_t virtualkeyboard_hash(const keylayout_key_t* key) {
 	return key->is_sprite
-		? (uint64_t)key->display_sprite
+		? (id_hash_t)key->display_sprite
 		: (key->display_text != nullptr
-			? hash_fnv64_string(key->display_text)
+			? hash_string(key->display_text)
 			: 0);
 }
 

--- a/StereoKitC/ui/ui_core.cpp
+++ b/StereoKitC/ui/ui_core.cpp
@@ -8,8 +8,8 @@
 #include "ui_layout.h"
 #include "ui_theming.h"
 
+#include "../_stereokit.h"
 #include "../libraries/array.h"
-#include "../libraries/ferr_hash.h"
 #include "../systems/input.h"
 #include "../hands/input_hand.h"
 #include "../sk_math.h"
@@ -58,7 +58,7 @@ void ui_core_init() {
 	skui_preserve_keyboard_ids_read  = &skui_preserve_keyboard_ids[0];
 	skui_preserve_keyboard_ids_write = &skui_preserve_keyboard_ids[1];
 
-	skui_id_stack.add({ HASH_FNV64_START });
+	skui_id_stack.add({ default_hash_root });
 
 	skui_hand_interactors[0] = interactor_create(interactor_type_point, interactor_event_poke,  interactor_activate_position);
 	skui_hand_interactors[1] = interactor_create(interactor_type_point, interactor_event_pinch, interactor_activate_state);
@@ -990,7 +990,7 @@ button_state_ ui_last_element_focused() {
 
 ///////////////////////////////////////////
 
-id_hash_t hash_fnv64_string_16(const char16_t* string, id_hash_t start_hash = HASH_FNV64_START) {
+id_hash_t hash_fnv64_string_16(const char16_t* string, id_hash_t start_hash = default_hash_root) {
 	id_hash_t hash = start_hash;
 	while (*string != '\0') {
 		hash = (hash ^ ((*string & 0xFF00) >> 2)) * 1099511628211;
@@ -1004,8 +1004,8 @@ id_hash_t hash_fnv64_string_16(const char16_t* string, id_hash_t start_hash = HA
 
 id_hash_t ui_stack_hash(const char *string) {
 	return skui_id_stack.count > 0 
-		? hash_fnv64_string(string, skui_id_stack.last())
-		: hash_fnv64_string(string);
+		? hash_string_with(string, skui_id_stack.last())
+		: hash_string     (string);
 }
 
 ///////////////////////////////////////////
@@ -1020,8 +1020,8 @@ id_hash_t ui_stack_hash_16(const char16_t *string) {
 
 id_hash_t ui_stack_hashi(int32_t id) {
 	return skui_id_stack.count > 0 
-		? hash_fnv64_data(&id, sizeof(int32_t), skui_id_stack.last())
-		: hash_fnv64_data(&id, sizeof(int32_t));
+		? hash_int_with(id, skui_id_stack.last())
+		: hash_int     (id);
 }
 
 ///////////////////////////////////////////

--- a/StereoKitC/xr_backends/openxr.cpp
+++ b/StereoKitC/xr_backends/openxr.cpp
@@ -20,7 +20,6 @@
 #include "../log.h"
 #include "../device.h"
 #include "../libraries/stref.h"
-#include "../libraries/ferr_hash.h"
 #include "../systems/render.h"
 #include "../systems/audio.h"
 #include "../systems/input.h"
@@ -86,7 +85,7 @@ bool                 xr_system_success    = false;
 
 array_t<const char*> xr_exts_user         = {};
 array_t<const char*> xr_exts_exclude      = {};
-array_t<uint64_t>    xr_exts_loaded       = {};
+array_t<id_hash_t>   xr_exts_loaded       = {};
 bool32_t             xr_minimum_exts      = false;
 
 bool                 xr_has_bounds        = false;
@@ -225,7 +224,7 @@ bool openxr_create_system() {
 	openxr_list_layers(&layers_available, &layers_request);
 
 	for (int32_t i = 0; i < exts_request.count; i++)
-		xr_exts_loaded.add(hash_fnv64_string(exts_request[i]));
+		xr_exts_loaded.add(hash_string(exts_request[i]));
 
 	XrInstanceCreateInfo create_info = { XR_TYPE_INSTANCE_CREATE_INFO };
 	create_info.enabledExtensionCount = (uint32_t)exts_request.count;
@@ -386,7 +385,7 @@ bool openxr_init() {
 
 	// We would use backend_openxr_ext_enabled, but openxr isn't full ready
 	// yet, so it throws errors into the logs.
-	if (xr_exts_loaded.index_of(hash_fnv64_string(XR_GFX_EXTENSION)) < 0) {
+	if (xr_exts_loaded.index_of(hash_string(XR_GFX_EXTENSION)) < 0) {
 		log_infof("Couldn't load required extension [%s]", XR_GFX_EXTENSION);
 		openxr_cleanup();
 		return false;
@@ -1414,7 +1413,7 @@ bool32_t backend_openxr_ext_enabled(const char *extension_name) {
 		log_err("backend_openxr_ functions only work when OpenXR is the backend!");
 		return false;
 	}
-	uint64_t hash = hash_fnv64_string(extension_name);
+	id_hash_t hash = hash_string(extension_name);
 	return xr_exts_loaded.index_of(hash) >= 0;
 }
 


### PR DESCRIPTION
This adds some of SK's data hashing code to the public API! In the C interface, ids also appear in some of the material APIs, so this allows usage of those functions. Any id hashes (public interface and internally) that were using a bare `uint64_t` are now using an `id_hash_t` to be explicit about what they represent.

`Hash.String` / `hash_string` / `hash_string_with`
`Hash.Int` / `hash_int` / `hash_int_with`