### PR TITLE
Add UISettings.hseparatorScale and update C# usage and tests

### DIFF
--- a/Examples/StereoKitTest/Demos/DemoUISettings.cs
+++ b/Examples/StereoKitTest/Demos/DemoUISettings.cs
@@ -40,8 +40,8 @@ class DemoUISettings : ITest
 		UI.HSlider("sl_depth",    ref activeSettings.depth,    0, 40 * U.mm, 0);
 		UI.Label("Rounding", size); UI.SameLine();
 		UI.HSlider("sl_rounding", ref activeSettings.rounding, 0, 40 * U.mm, 0);
-		UI.Label("HSeparator", size); UI.SameLine();
-		UI.HSlider("sl_hseparator", ref activeSettings.hseparatorScale, 0, 2.0f, 0.0f);
+		UI.Label("Separator", size); UI.SameLine();
+		UI.HSlider("sl_separator", ref activeSettings.separatorScale, 0, 2.0f, 0.0f);
 		UI.PanelEnd();
 
 		UI.HSeparator();

--- a/Examples/StereoKitTest/Demos/DemoUISettings.cs
+++ b/Examples/StereoKitTest/Demos/DemoUISettings.cs
@@ -40,6 +40,8 @@ class DemoUISettings : ITest
 		UI.HSlider("sl_depth",    ref activeSettings.depth,    0, 40 * U.mm, 0);
 		UI.Label("Rounding", size); UI.SameLine();
 		UI.HSlider("sl_rounding", ref activeSettings.rounding, 0, 40 * U.mm, 0);
+		UI.Label("HSeparator", size); UI.SameLine();
+		UI.HSlider("sl_hseparator", ref activeSettings.hseparatorScale, 0, 2.0f, 0.0f);
 		UI.PanelEnd();
 
 		UI.HSeparator();

--- a/StereoKit/Native/NativeTypes.cs
+++ b/StereoKit/Native/NativeTypes.cs
@@ -243,11 +243,11 @@ namespace StereoKit
 		/// meters.</summary>
 		public float backplateBorder;
 		/// <summary>
-		/// Defines the scale factor for the horizontal separator's thickness.
+		/// Defines the scale factor for the separator's thickness.
 		/// The thickness is calculated by multiplying the height of the text
 		/// by this factor. The default valus is 0.4f.
 		/// </summary>
-		public float hseparatorScale;
+		public float separatorScale;
     }
 
 	/// <summary>This represents a single vertex in a Mesh, all StereoKit

--- a/StereoKit/Native/NativeTypes.cs
+++ b/StereoKit/Native/NativeTypes.cs
@@ -242,7 +242,13 @@ namespace StereoKit
 		/// <summary>How wide is the back-border around the UI elements? In
 		/// meters.</summary>
 		public float backplateBorder;
-	}
+		/// <summary>
+		/// Defines the scale factor for the horizontal separator's thickness.
+		/// The thickness is calculated by multiplying the height of the text
+		/// by this factor. The default valus is 0.4f.
+		/// </summary>
+		public float hseparatorScale;
+    }
 
 	/// <summary>This represents a single vertex in a Mesh, all StereoKit
 	/// Meshes currently use this exact layout!

--- a/StereoKitC/stereokit_ui.h
+++ b/StereoKitC/stereokit_ui.h
@@ -144,7 +144,7 @@ typedef struct ui_settings_t {
 	float rounding;
 	float backplate_depth;
 	float backplate_border;
-	float hseparator_scale;
+	float separator_scale;
 } ui_settings_t;
 
 typedef struct ui_slider_data_t {

--- a/StereoKitC/stereokit_ui.h
+++ b/StereoKitC/stereokit_ui.h
@@ -144,6 +144,7 @@ typedef struct ui_settings_t {
 	float rounding;
 	float backplate_depth;
 	float backplate_border;
+	float hseparator_scale;
 } ui_settings_t;
 
 typedef struct ui_slider_data_t {

--- a/StereoKitC/ui/stereokit_ui.cpp
+++ b/StereoKitC/ui/stereokit_ui.cpp
@@ -138,7 +138,7 @@ void ui_model_at(model_t model, vec3 start, vec3 size, color128 color) {
 void ui_hseparator() {
 	vec3 pos;
 	vec2 size;
-	ui_layout_reserve_sz({ 0, text_style_get_baseline(ui_get_text_style())*0.4f }, false, &pos, &size);
+	ui_layout_reserve_sz({ 0, text_style_get_baseline(ui_get_text_style())*skui_settings.hseparator_scale }, false, &pos, &size);
 
 	ui_draw_element(ui_vis_separator, pos, vec3{ size.x, size.y, size.y / 2.0f }, 0);
 }

--- a/StereoKitC/ui/stereokit_ui.cpp
+++ b/StereoKitC/ui/stereokit_ui.cpp
@@ -138,7 +138,7 @@ void ui_model_at(model_t model, vec3 start, vec3 size, color128 color) {
 void ui_hseparator() {
 	vec3 pos;
 	vec2 size;
-	ui_layout_reserve_sz({ 0, text_style_get_baseline(ui_get_text_style())*skui_settings.hseparator_scale }, false, &pos, &size);
+	ui_layout_reserve_sz({ 0, text_style_get_baseline(ui_get_text_style())*skui_settings.separator_scale }, false, &pos, &size);
 
 	ui_draw_element(ui_vis_separator, pos, vec3{ size.x, size.y, size.y / 2.0f }, 0);
 }

--- a/StereoKitC/ui/ui_theming.cpp
+++ b/StereoKitC/ui/ui_theming.cpp
@@ -521,7 +521,7 @@ void ui_settings(ui_settings_t settings) {
 	if (settings.padding          == 0) settings.padding = 10 * mm2m;
 	if (settings.margin           == 0) settings.margin  = settings.padding;
 	if (settings.rounding         == 0) settings.rounding= 7.5f * mm2m;
-	if (settings.hseparator_scale == 0) settings.hseparator_scale = 0.4f;
+	if (settings.separator_scale == 0) settings.separator_scale = 0.4f;
 
 	bool rebuild_meshes = skui_settings.rounding != settings.rounding;
 	skui_settings = settings;

--- a/StereoKitC/ui/ui_theming.cpp
+++ b/StereoKitC/ui/ui_theming.cpp
@@ -521,6 +521,7 @@ void ui_settings(ui_settings_t settings) {
 	if (settings.padding          == 0) settings.padding = 10 * mm2m;
 	if (settings.margin           == 0) settings.margin  = settings.padding;
 	if (settings.rounding         == 0) settings.rounding= 7.5f * mm2m;
+	if (settings.hseparator_scale == 0) settings.hseparator_scale = 0.4f;
 
 	bool rebuild_meshes = skui_settings.rounding != settings.rounding;
 	skui_settings = settings;


### PR DESCRIPTION
Add a hseparator_scale setting to control the thickness of horizontal separators in the StereoKit UI.

Main Changes:

- Added the hseparator_scale field to ui_settings_t (C) and UISettings (C#).
- Applied hseparator_scale in the ui_hseparator function to dynamically adjust separator thickness.
- Set a default value (0.4f) if no scale is specified which is the historical factor value for the separator thickness.
- Updated the UI panel to include a slider for adjusting hseparator_scale in DemoUISettings.