### PR TITLE
Fixes for EGL headless

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -209,13 +209,12 @@ jobs:
       env:
         NDK: ${{ steps.setup-ndk.outputs.ndk-path }}
 
-    - name: Install Arm64 Prerequisites
-      run: |
-        sudo cp ./tools/docker/arm-cross-compile-sources-focal.list /etc/apt/sources.list.d/
-        sudo sed -i "s/deb mirror/deb [arch=amd64] mirror/g" /etc/apt/sources.list
-        sudo dpkg --add-architecture arm64
-        sudo apt-get update
-        sudo apt-get install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu lld:arm64 libx11-dev:arm64 libxfixes-dev:arm64 libegl-dev:arm64 libgbm-dev:arm64 libfontconfig-dev:arm64
+    - name: Install Cross-Compile Support for ARM64
+      uses: cyberjunk/gha-ubuntu-cross@v5
+      with:
+        arch: arm64
+    - name: Install cross-compilation tools
+      run: sudo apt-get install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu lld:arm64 libx11-dev:arm64 libxfixes-dev:arm64 libegl-dev:arm64 libgbm-dev:arm64 libfontconfig-dev:arm64
 
     - name: Build Linux Arm64
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,8 +219,8 @@ add_compile_definitions(BASISD_SUPPORT_BC7_MODE5=0)
 
 #### sk_gpu - https://github.com/StereoKit/sk_gpu ####
 CPMAddPackage( # We're scraping the comment after the NAME for some other scripts
-  NAME sk_gpu # 2025.4.28
-  URL https://github.com/StereoKit/sk_gpu/releases/download/v2025.4.28/sk_gpu.v2025.4.28.zip
+  NAME sk_gpu # 2025.4.30
+  URL https://github.com/StereoKit/sk_gpu/releases/download/v2025.4.30/sk_gpu.v2025.4.30.zip
 )
 # For building directly with in-progress sk_gpu changes, point this to your
 # local sk_gpu clone, and use it instead of CPM.


### PR DESCRIPTION
Pulling an sk_gpu update for @technobaboo's headless EGL fixes (https://github.com/StereoKit/sk_gpu/pull/26).
Also includes some GitHub Actions fixes for ARM64 cross-compiling after the recent deprecation of Ubuntu 20.04.