### PR TITLE
Fix repo StereoKit.sln build

### DIFF
--- a/Examples/StereoKitCTest/StereoKitCTest.vcxproj
+++ b/Examples/StereoKitCTest/StereoKitCTest.vcxproj
@@ -152,4 +152,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
+  <Target Name="SKCleanShaders" AfterTargets="Clean">
+    <RemoveDir Directories="$(IntDir)shaders" />
+  </Target>
 </Project>

--- a/Examples/StereoKitCTest/StereoKitCTest.vcxproj
+++ b/Examples/StereoKitCTest/StereoKitCTest.vcxproj
@@ -62,7 +62,7 @@
       <SubSystem>Console</SubSystem>
     </Link>
     <PreBuildEvent>
-      <Command>"$(ProjectDir)..\..\tools\skshaderc\win32_x64\skshaderc.exe" -O3 -h -t xgew -i "$(ProjectDir)..\..\tools\include" "$(ProjectDir)Shaders\*.hlsl"</Command>
+      <Command>"$(ProjectDir)..\..\tools\skshaderc\win32_x64\skshaderc.exe" -o $(IntDir)\shaders\ -O3 -e -h -t xgew -i "$(ProjectDir)..\..\tools\include" "$(ProjectDir)Shaders\*.hlsl"</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
@@ -80,7 +80,7 @@
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
     <PreBuildEvent>
-      <Command>"$(ProjectDir)..\..\tools\skshaderc\win32_x64\skshaderc.exe" -o $(IntDir)\shaders  -O3 -h -t xgew -i "$(ProjectDir)..\..\tools\include" "$(ProjectDir)Shaders\*.hlsl"</Command>
+      <Command>"$(ProjectDir)..\..\tools\skshaderc\win32_x64\skshaderc.exe" -o $(IntDir)\shaders\ -O3 -e -h -t xgew -i "$(ProjectDir)..\..\tools\include" "$(ProjectDir)Shaders\*.hlsl"</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
 

--- a/Examples/StereoKitCTest/StereoKitCTest.vcxproj.filters
+++ b/Examples/StereoKitCTest/StereoKitCTest.vcxproj.filters
@@ -60,6 +60,8 @@
     <None Include="Shaders\skt_default_lighting.hlsl">
       <Filter>Shaders</Filter>
     </None>
-    <None Include="Shaders\blit.hlsl" />
+    <None Include="Shaders\blit.hlsl">
+      <Filter>Shaders</Filter>
+    </None>
   </ItemGroup>
 </Project>

--- a/Examples/StereoKitCTest/StereoKitCTest_UWP/StereoKitCTest_UWP.vcxproj
+++ b/Examples/StereoKitCTest/StereoKitCTest_UWP/StereoKitCTest_UWP.vcxproj
@@ -74,37 +74,37 @@
     <OutDir>$(SolutionDir)bin\$(Platform)_$(Configuration)_UWP\$(ProjectName)\</OutDir>
     <IntDir>$(SolutionDir)bin\intermediate\$(Platform)_$(Configuration)\$(ProjectName)\</IntDir>
     <LibraryPath>$(SolutionDir)bin\$(Platform)_$(Configuration)_UWP\StereoKitC_UWP\;$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64);$(NETFXKitsDir)Lib\um\x64</LibraryPath>
-    <IncludePath>$(SolutionDir)StereoKitC;$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
+    <IncludePath>$(SolutionDir)StereoKitC;$(IntDir)\shaders;$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
     <OutDir>$(SolutionDir)bin\$(Platform)_$(Configuration)_UWP\$(ProjectName)\</OutDir>
     <IntDir>$(SolutionDir)bin\intermediate\$(Platform)_$(Configuration)\$(ProjectName)\</IntDir>
     <LibraryPath>$(SolutionDir)bin\$(Platform)_$(Configuration)_UWP\StereoKitC_UWP\;$(VC_LibraryPath_ARM64);$(WindowsSDK_LibraryPath_ARM64);$(NETFXKitsDir)Lib\um\ARM64</LibraryPath>
-    <IncludePath>$(SolutionDir)StereoKitC;$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
+    <IncludePath>$(SolutionDir)StereoKitC;$(IntDir)\shaders;$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
     <OutDir>$(SolutionDir)bin\$(Platform)_$(Configuration)_UWP\$(ProjectName)\</OutDir>
     <IntDir>$(SolutionDir)bin\intermediate\$(Platform)_$(Configuration)\$(ProjectName)\</IntDir>
     <LibraryPath>$(SolutionDir)bin\$(Platform)_$(Configuration)_UWP\StereoKitC_UWP\;$(VC_LibraryPath_ARM);$(WindowsSDK_LibraryPath_ARM);$(NETFXKitsDir)Lib\um\ARM</LibraryPath>
-    <IncludePath>$(SolutionDir)StereoKitC;$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
+    <IncludePath>$(SolutionDir)StereoKitC;$(IntDir)\shaders;$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <OutDir>$(SolutionDir)bin\$(Platform)_$(Configuration)_UWP\$(ProjectName)\</OutDir>
     <IntDir>$(SolutionDir)bin\intermediate\$(Platform)_$(Configuration)\$(ProjectName)\</IntDir>
     <LibraryPath>$(SolutionDir)bin\$(Platform)_$(Configuration)_UWP\StereoKitC_UWP\;$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64);$(NETFXKitsDir)Lib\um\x64</LibraryPath>
-    <IncludePath>$(SolutionDir)StereoKitC;$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
+    <IncludePath>$(SolutionDir)StereoKitC;$(IntDir)\shaders;$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
     <OutDir>$(SolutionDir)bin\$(Platform)_$(Configuration)_UWP\$(ProjectName)\</OutDir>
     <IntDir>$(SolutionDir)bin\intermediate\$(Platform)_$(Configuration)\$(ProjectName)\</IntDir>
     <LibraryPath>$(SolutionDir)bin\$(Platform)_$(Configuration)_UWP\StereoKitC_UWP\;$(VC_LibraryPath_ARM64);$(WindowsSDK_LibraryPath_ARM64);$(NETFXKitsDir)Lib\um\ARM64</LibraryPath>
-    <IncludePath>$(SolutionDir)StereoKitC;$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
+    <IncludePath>$(SolutionDir)StereoKitC;$(IntDir)\shaders;$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
     <OutDir>$(SolutionDir)bin\$(Platform)_$(Configuration)_UWP\$(ProjectName)\</OutDir>
     <IntDir>$(SolutionDir)bin\intermediate\$(Platform)_$(Configuration)\$(ProjectName)\</IntDir>
     <LibraryPath>$(SolutionDir)bin\$(Platform)_$(Configuration)_UWP\StereoKitC_UWP\;$(VC_LibraryPath_ARM);$(WindowsSDK_LibraryPath_ARM);$(NETFXKitsDir)Lib\um\ARM</LibraryPath>
-    <IncludePath>$(SolutionDir)StereoKitC;$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
+    <IncludePath>$(SolutionDir)StereoKitC;$(IntDir)\shaders;$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
@@ -128,6 +128,9 @@
       <AdditionalDependencies Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">StereoKitC.lib;WindowsApp.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalDependencies Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">StereoKitC.lib;WindowsApp.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
+    <PreBuildEvent>
+      <Command>"$(ProjectDir)..\..\..\tools\skshaderc\win32_x64\skshaderc.exe" -o $(IntDir)\shaders\ -O3 -e -h -t xgew -i "$(ProjectDir)..\..\..\tools\include" "$(ProjectDir)..\Shaders\*.hlsl"</Command>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
     <ClCompile>
@@ -138,7 +141,16 @@
       <AdditionalDependencies Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">StereoKitC.lib;WindowsApp.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalDependencies Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">StereoKitC.lib;WindowsApp.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
+    <PreBuildEvent>
+      <Command>"$(ProjectDir)..\..\..\tools\skshaderc\win32_x64\skshaderc.exe" -o $(IntDir)\shaders\ -O3 -e -h -t xgew -i "$(ProjectDir)..\..\..\tools\include" "$(ProjectDir)..\Shaders\*.hlsl"</Command>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
+
+  <Target Name="SKCheckSKShaderC" BeforeTargets="PreBuild">
+    <!--Make sure the shader compiler is available to us-->
+    <Exec Command="cd $(ProjectDir)..\..\..\ &amp; powershell.exe -ExecutionPolicy Bypass -NoProfile -NonInteractive -File &quot;tools\Update-Dependencies.ps1&quot; -arch x64 -config Debug -plat UWP -onlyDep sk_gpu" />
+  </Target>
+
   <ItemGroup>
     <AppxManifest Include="Package.appxmanifest">
       <SubType>Designer</SubType>
@@ -180,5 +192,8 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.221121.5\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.221121.5\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.221121.5\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.221121.5\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+  </Target>
+  <Target Name="SKCleanShaders" AfterTargets="Clean">
+    <RemoveDir Directories="$(IntDir)shaders" />
   </Target>
 </Project>

--- a/Examples/StereoKitTest/StereoKitTest.csproj
+++ b/Examples/StereoKitTest/StereoKitTest.csproj
@@ -46,7 +46,7 @@
 		<None Include="Guides\GuideGettingStarted.cs" />
 	</ItemGroup>
 
-	<!-- Include the Stereokit project manually. This is similar to including the
+	<!-- Include the StereoKit project manually. This is similar to including the
 	     StereoKit NuGet, but different because C# cannot consume a NuGet package
 	     directly. -->
 	<Import Project="$(ProjectDir)..\..\StereoKit\BuildStereoKitSDK.targets" />

--- a/Examples/StereoKitTest/StereoKitTest_NetAndroid/StereoKitTest_NetAndroid.csproj
+++ b/Examples/StereoKitTest/StereoKitTest_NetAndroid/StereoKitTest_NetAndroid.csproj
@@ -28,7 +28,7 @@
 		<NoWarn>XA4211;XA1006;XA4301;CS1587</NoWarn>
 	</PropertyGroup>
 
-	<!-- Include the Stereokit project manually. This is similar to including the
+	<!-- Include the StereoKit project manually. This is similar to including the
 	     StereoKit NuGet, but different because C# cannot consume a NuGet package
 	     directly. -->
 	<Import Project="$(ProjectDir)..\..\..\StereoKit\BuildStereoKitSDK.targets" />

--- a/Examples/StereoKitTest/StereoKitTest_NetUWP/StereoKitTest_NetUWP.csproj
+++ b/Examples/StereoKitTest/StereoKitTest_NetUWP/StereoKitTest_NetUWP.csproj
@@ -28,7 +28,7 @@
 		<EnableXamlCompilerTargetsForUwpApps>false</EnableXamlCompilerTargetsForUwpApps>
 	</PropertyGroup>
 
-	<!-- Include the Stereokit project manually. This is similar to including the
+	<!-- Include the StereoKit project manually. This is similar to including the
 	     StereoKit NuGet, but different because C# cannot consume a NuGet package
 	     directly. -->
 	<Import Project="$(ProjectDir)..\..\..\StereoKit\BuildStereoKitSDK.targets" />

--- a/Examples/StereoKitTest/StereoKitTest_UWP/StereoKitTest_UWP.csproj
+++ b/Examples/StereoKitTest/StereoKitTest_UWP/StereoKitTest_UWP.csproj
@@ -56,7 +56,7 @@
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
   </PropertyGroup>
   
-  <!-- Include the Stereokit project manually. This is similar to including the
+  <!-- Include the StereoKit project manually. This is similar to including the
 	     StereoKit NuGet, but different because C# cannot consume a NuGet package
 	     directly. -->
 	<Import Project="$(ProjectDir)..\..\..\StereoKit\BuildStereoKitSDK.targets" />

--- a/StereoKitC/StereoKitC.vcxproj
+++ b/StereoKitC/StereoKitC.vcxproj
@@ -111,7 +111,7 @@ xcopy "$(ProjectDir)stereokit_ui.h" "$(ProjectDir)..\bin\distribute\include\" /d
     <PreBuildEvent>
       <SKShaderDebugFlag Condition="'$(Configuration)' == 'Debug'">-d</SKShaderDebugFlag>
       <Command>powershell.exe -ExecutionPolicy Bypass -NoProfile -NonInteractive -File "$([MSBuild]::NormalizePath('$(ProjectDir)..\tools\Update-Dependencies.ps1'))" -arch $(PlatformTarget) -config $(Configuration) -plat Win32
-"$([MSBuild]::NormalizePath('$(ProjectDir)..\tools\skshaderc\win32_x64\skshaderc.exe'))" -O3 $(SKShaderDebugFlag) -e -h -z -t x -i "$([MSBuild]::NormalizePath('$(ProjectDir)..\tools\include'))" -o "$([MSBuild]::NormalizePath('$(IntermediateOutputPath)shaders\'))" "$(ProjectDir)shaders_builtin\*.hlsl"</Command>
+"$([MSBuild]::NormalizePath('$(ProjectDir)..\tools\skshaderc\win32_x64\skshaderc.exe'))" -O3 $(SKShaderDebugFlag) -e -h -z -t x -i "$([MSBuild]::NormalizePath('$(ProjectDir)..\tools\include'))" -o $([MSBuild]::NormalizePath('$(IntermediateOutputPath)shaders\')) "$(ProjectDir)shaders_builtin\*.hlsl"</Command>
       <Message>Checking project dependencies and compiling shaders.</Message>
     </PreBuildEvent>
   </ItemDefinitionGroup>

--- a/StereoKitC/StereoKitC.vcxproj
+++ b/StereoKitC/StereoKitC.vcxproj
@@ -111,7 +111,7 @@ xcopy "$(ProjectDir)stereokit_ui.h" "$(ProjectDir)..\bin\distribute\include\" /d
     <PreBuildEvent>
       <SKShaderDebugFlag Condition="'$(Configuration)' == 'Debug'">-d</SKShaderDebugFlag>
       <Command>powershell.exe -ExecutionPolicy Bypass -NoProfile -NonInteractive -File "$([MSBuild]::NormalizePath('$(ProjectDir)..\tools\Update-Dependencies.ps1'))" -arch $(PlatformTarget) -config $(Configuration) -plat Win32
-"$([MSBuild]::NormalizePath('$(ProjectDir)..\tools\skshaderc\win32_x64\skshaderc.exe'))" -O3 $(SKShaderDebugFlag) -h -z -t x -i "$([MSBuild]::NormalizePath('$(ProjectDir)..\tools\include'))" -o "$([MSBuild]::NormalizePath('$(IntermediateOutputPath)shaders'))" "$(ProjectDir)shaders_builtin\*.hlsl"</Command>
+"$([MSBuild]::NormalizePath('$(ProjectDir)..\tools\skshaderc\win32_x64\skshaderc.exe'))" -O3 $(SKShaderDebugFlag) -e -h -z -t x -i "$([MSBuild]::NormalizePath('$(ProjectDir)..\tools\include'))" -o "$([MSBuild]::NormalizePath('$(IntermediateOutputPath)shaders\'))" "$(ProjectDir)shaders_builtin\*.hlsl"</Command>
       <Message>Checking project dependencies and compiling shaders.</Message>
     </PreBuildEvent>
   </ItemDefinitionGroup>

--- a/StereoKitC/StereoKitC_UWP/StereoKitC_UWP.vcxproj
+++ b/StereoKitC/StereoKitC_UWP/StereoKitC_UWP.vcxproj
@@ -79,7 +79,7 @@
   <PropertyGroup>
     <OutDir>$(ProjectDir)..\..\bin\$(Platform)_$(Configuration)_UWP\$(ProjectName)\</OutDir>
     <IntDir>$(ProjectDir)..\..\bin\intermediate\$(Platform)_$(Configuration)\$(ProjectName)\</IntDir>
-    <IncludePath>$(ProjectDir)..\lib\include\meshoptimizer;$(ProjectDir)..\lib\include;$(IntDir)shaders;$(IncludePath)</IncludePath>
+    <IncludePath>$(ProjectDir)..\lib\include\basisu;$(ProjectDir)..\lib\include\meshoptimizer;$(ProjectDir)..\lib\include;$(IntDir)shaders;$(ProjectDir)..\lib\include\sk_gpu;$(IncludePath)</IncludePath>
     <LibraryPath>$(ProjectDir)..\lib\bin\$(LibrariesArchitecture)_UWP\$(Configuration);$(ProjectDir)..\lib\bin\$(LibrariesArchitecture)\$(Configuration);$(ProjectDir)..\lib\bin\$(LibrariesArchitecture);$(LibraryPath)</LibraryPath>
     <TargetName>StereoKitC</TargetName>
   </PropertyGroup>
@@ -107,7 +107,7 @@
     </ClCompile>
     <Link>
       <AdditionalOptions>/ignore:4099 %(AdditionalOptions)</AdditionalOptions>
-      <AdditionalDependencies>openxr_loader.lib;WindowsApp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>meshoptimizer.lib;openxr_loader.lib;WindowsApp.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
@@ -118,7 +118,7 @@
     </ClCompile>
     <Link>
       <AdditionalOptions>/ignore:4099 %(AdditionalOptions)</AdditionalOptions>
-      <AdditionalDependencies>openxr_loader.lib;WindowsApp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>meshoptimizer.lib;openxr_loader.lib;WindowsApp.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup>
@@ -131,7 +131,7 @@ xcopy "$(TargetDir)*.pdb" "$(ProjectDir)..\..\bin\distribute\bin\UWP\$(Platform)
     <PreBuildEvent>
       <SKShaderDebugFlag Condition="'$(Configuration)' == 'Debug'">-d</SKShaderDebugFlag>
       <Command>powershell.exe -ExecutionPolicy Bypass -NoProfile -NonInteractive -File "$(ProjectDir)..\..\tools\Update-Dependencies.ps1" -arch $(PlatformTarget) -config $(Configuration) -plat UWP
-"$(ProjectDir)..\..\tools\skshaderc\win32_x64\skshaderc.exe" -O3 $(SKShaderDebugFlag) -e -h -z -t x -i "$(ProjectDir)..\..\tools\include" -o $(IntermediateOutputPath)shaders\ "$(ProjectDir)..\..\StereoKitC\shaders_builtin\*.hlsl"</Command>
+"$(ProjectDir)..\..\tools\skshaderc\win32_x64\skshaderc.exe" -O3 $(SKShaderDebugFlag) -e -h -z -t x -i "$(ProjectDir)..\..\tools\include" -o $(IntermediateOutputPath)shaders\ "$(ProjectDir)..\shaders_builtin\*.hlsl"</Command>
       <Message>Checking project dependencies and compiling shaders.</Message>
     </PreBuildEvent>
   </ItemDefinitionGroup>
@@ -141,6 +141,8 @@ xcopy "$(TargetDir)*.pdb" "$(ProjectDir)..\..\bin\distribute\bin\UWP\$(Platform)
   <Target Name="AddWildCardItems" AfterTargets="BuildGenerateSources">
     <ItemGroup>
       <ClCompile Include="@(_WildCardClCompile)" />
+      <ClCompile Include="..\lib\include\basisu\basisu_transcoder.cpp" />
+      <ClCompile Include="..\lib\include\zstd\zstd.c" />
     </ItemGroup>
   </Target>
   <ItemGroup>

--- a/StereoKitC/StereoKitC_UWP/StereoKitC_UWP.vcxproj
+++ b/StereoKitC/StereoKitC_UWP/StereoKitC_UWP.vcxproj
@@ -131,7 +131,7 @@ xcopy "$(TargetDir)*.pdb" "$(ProjectDir)..\..\bin\distribute\bin\UWP\$(Platform)
     <PreBuildEvent>
       <SKShaderDebugFlag Condition="'$(Configuration)' == 'Debug'">-d</SKShaderDebugFlag>
       <Command>powershell.exe -ExecutionPolicy Bypass -NoProfile -NonInteractive -File "$(ProjectDir)..\..\tools\Update-Dependencies.ps1" -arch $(PlatformTarget) -config $(Configuration) -plat UWP
-"$(ProjectDir)..\..\tools\skshaderc\win32_x64\skshaderc.exe" -O3 $(SKShaderDebugFlag) -h -z -t x -i "$(ProjectDir)..\..\tools\include" -o "$(IntermediateOutputPath)shaders" "$(ProjectDir)..\..\StereoKitC\shaders_builtin\*.hlsl"</Command>
+"$(ProjectDir)..\..\tools\skshaderc\win32_x64\skshaderc.exe" -O3 $(SKShaderDebugFlag) -e -h -z -t x -i "$(ProjectDir)..\..\tools\include" -o "$(IntermediateOutputPath)shaders\" "$(ProjectDir)..\..\StereoKitC\shaders_builtin\*.hlsl"</Command>
       <Message>Checking project dependencies and compiling shaders.</Message>
     </PreBuildEvent>
   </ItemDefinitionGroup>

--- a/StereoKitC/StereoKitC_UWP/StereoKitC_UWP.vcxproj
+++ b/StereoKitC/StereoKitC_UWP/StereoKitC_UWP.vcxproj
@@ -131,7 +131,7 @@ xcopy "$(TargetDir)*.pdb" "$(ProjectDir)..\..\bin\distribute\bin\UWP\$(Platform)
     <PreBuildEvent>
       <SKShaderDebugFlag Condition="'$(Configuration)' == 'Debug'">-d</SKShaderDebugFlag>
       <Command>powershell.exe -ExecutionPolicy Bypass -NoProfile -NonInteractive -File "$(ProjectDir)..\..\tools\Update-Dependencies.ps1" -arch $(PlatformTarget) -config $(Configuration) -plat UWP
-"$(ProjectDir)..\..\tools\skshaderc\win32_x64\skshaderc.exe" -O3 $(SKShaderDebugFlag) -e -h -z -t x -i "$(ProjectDir)..\..\tools\include" -o "$(IntermediateOutputPath)shaders\" "$(ProjectDir)..\..\StereoKitC\shaders_builtin\*.hlsl"</Command>
+"$(ProjectDir)..\..\tools\skshaderc\win32_x64\skshaderc.exe" -O3 $(SKShaderDebugFlag) -e -h -z -t x -i "$(ProjectDir)..\..\tools\include" -o $(IntermediateOutputPath)shaders\ "$(ProjectDir)..\..\StereoKitC\shaders_builtin\*.hlsl"</Command>
       <Message>Checking project dependencies and compiling shaders.</Message>
     </PreBuildEvent>
   </ItemDefinitionGroup>

--- a/StereoKitC/shaders_builtin/shader_builtin.h
+++ b/StereoKitC/shaders_builtin/shader_builtin.h
@@ -9,7 +9,6 @@
 #include "shader_builtin_unlit_clip.hlsl.h"
 #include "shader_builtin_lightmap.hlsl.h"
 #include "shader_builtin_equirect.hlsl.h"
-#include "shader_builtin_blit.hlsl.h"
 #include "shader_builtin_font.hlsl.h"
 #include "shader_builtin_lines.hlsl.h"
 #include "shader_builtin_ui.hlsl.h"


### PR DESCRIPTION
* Adds some missing `-e` flags for skshaderc.exe, which was leading to shader header files missing `.hlsl` from their name
* Adds a missing shader output folder param
* Adds some trailing slashes to shader output folder params (see https://github.com/StereoKit/sk_gpu/pull/29 for more info)
* Removes some quotes from the shader output folder param, since skshaderc.exe doesn't seem to handle that well when there's a trailing slash
* Includes some missing dependencies and include paths for StereoKitC_UWP.vcxproj
* Removes a duplicate line from shader_builtin.h

I didn't test the Android builds, but everything else should be working!
