### PR TITLE
Switch to latest clang/lld

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -184,7 +184,7 @@ jobs:
     - name: Install Prerequisites
       run: |
         sudo apt-get update
-        sudo apt-get install clang-12 lld-12 ninja-build libx11-dev libxfixes-dev libegl-dev libgbm-dev libfontconfig-dev
+        sudo apt-get install clang lld ninja-build libx11-dev libxfixes-dev libegl-dev libgbm-dev libfontconfig-dev
     
     - name: Set Version
       shell: pwsh


### PR DESCRIPTION
Runners are acting slow downloading older versions. `12` was a leftover from when we were using Ubuntu 20.