### PR TITLE
Don't cache `SK.System`

### DIFF
--- a/StereoKit/SK.cs
+++ b/StereoKit/SK.cs
@@ -11,7 +11,6 @@ namespace StereoKit
 	/// library!</summary>
 	public static class SK
 	{
-		private static SystemInfo              _system;
 		private static Steppers                _steppers         = new Steppers();
 		private static ConcurrentQueue<Action> _mainThreadInvoke = new ConcurrentQueue<Action>();
 
@@ -35,7 +34,7 @@ namespace StereoKit
 		/// system and its capabilities. There's a lot of different MR devices,
 		/// so it's nice to have code for systems with particular 
 		/// characteristics!</summary>
-		public static SystemInfo System => _system;
+		public static SystemInfo System => NativeAPI.sk_system_info();
 
 		/// <summary>Human-readable version name embedded in the StereoKitC
 		/// DLL.</summary>
@@ -158,8 +157,7 @@ namespace StereoKit
 			Settings = NativeAPI.sk_get_settings();
 
 			// Do a few things on success
-			if (result) { 
-				_system = NativeAPI.sk_system_info();
+			if (result) {
 				Default.Initialize();
 
 				// Ensure any steppers already in the queue get initialized


### PR DESCRIPTION
Some data in the `SystemInfo` struct now updates at runtime, so caching at start no longer works. This plus the addition of the `Device` system broke `displayWidth`/`Height` (#1209). This should now be resolved.

`SystemInfo` may be deprecated eventually in favor of `Device`, but `Device` doesn't currently surface the display size. It needs some additional thought related to multiple displays, surfaces, etc for a more future-proof display size.