### PR TITLE
Remove sounds from UI behaviors, and add UI sound APIs

### DIFF
--- a/Examples/StereoKitTest/Demos/DemoRoundedUI.cs
+++ b/Examples/StereoKitTest/Demos/DemoRoundedUI.cs
@@ -76,6 +76,9 @@ internal class DemoRoundedUI : ITest
 		layout.dimensions.z  = offset;
 		RoundedSprite.Mesh(UI.Settings.rounding).Draw(roundedSprite.material, Matrix.TS(layout.center, layout.dimensions), UI.GetElementColor(UIVisual.Aura, UI.GetAnimFocus(id, focus, state)));
 
+		if (state.IsJustActive())
+			UI.PlaySoundOnOff(UIVisual.Button, id, layout.center);
+
 		return state.IsJustInactive();
 	}
 

--- a/Examples/StereoKitTest/Docs/DocSliderBehavior.cs
+++ b/Examples/StereoKitTest/Docs/DocSliderBehavior.cs
@@ -29,6 +29,9 @@ class DocSliderBehavior : ITest
 		UI.DrawElement(UIVisual.SliderLine, bounds.TLB, new Vec3(bounds.dimensions.x, bounds.dimensions.y, depth*0.1f), slider.focusState.IsActive() ? 0.5f:0);
 		UI.DrawElement(UIVisual.SliderPush, slider.buttonCenter.XY0 + btnSize.XY0/2.0f, btnSize, focus);
 
+		if (slider.activeState.IsJustActive  ()) UI.PlaySoundOn (UIVisual.SliderPush, slider.buttonCenter.XY0);
+		if (slider.activeState.IsJustInactive()) UI.PlaySoundOff(UIVisual.SliderPush, slider.buttonCenter.XY0);
+
 		return prev.x != pt.x || prev.y != pt.y;
 	}
 

--- a/Examples/StereoKitTest/Tests/TestCustomButton.cs
+++ b/Examples/StereoKitTest/Tests/TestCustomButton.cs
@@ -73,6 +73,9 @@ internal class TestCustomButton : ITest
 		Mesh.Cube.Draw(Material.UI, Matrix.TS(layout.center, layout.dimensions), UI.GetElementColor(UIVisual.Button, UI.GetAnimFocus(id, focus, state)));
 		Text.Add(text, Matrix.T(layout.center.x, layout.center.y, -(offset + 0.002f)), UI.TextStyle, Pivot.Center);
 
+		if (state.IsJustActive())
+			UI.PlaySoundOnOff(UIVisual.Button, id, layout.center);
+
 		return state.IsJustInactive();
 	}
 
@@ -88,6 +91,9 @@ internal class TestCustomButton : ITest
 		layout.dimensions.z = offset;
 		UI.DrawElement(UIVisual.Button, layout.TLB, layout.dimensions, UI.GetAnimFocus(id, focus, state));
 		Text.Add(text, Matrix.T(layout.center.x, layout.center.y, -(offset + 0.002f)), UI.TextStyle, Pivot.Center);
+
+		if (state.IsJustActive())
+			UI.PlaySoundOnOff(UIVisual.Button, id, layout.center);
 
 		return state.IsJustInactive();
 	}
@@ -105,6 +111,9 @@ internal class TestCustomButton : ITest
 		UI.DrawElement(CustomUIVisual.Button, layout.TLB, layout.dimensions, UI.GetAnimFocus(id, focus, state));
 		Text.Add(text, Matrix.T(layout.center.x, layout.center.y, -(offset + 0.002f)), UI.TextStyle, Pivot.Center);
 
+		if (state.IsJustActive())
+			UI.PlaySoundOnOff(CustomUIVisual.Nonexistent, id, layout.center);
+
 		return state.IsJustInactive();
 	}
 
@@ -120,6 +129,9 @@ internal class TestCustomButton : ITest
 		layout.dimensions.z = offset;
 		UI.DrawElement(CustomUIVisual.Nonexistent, layout.TLB, layout.dimensions, UI.GetAnimFocus(id, focus, state));
 		Text.Add(text, Matrix.T(layout.center.x, layout.center.y, -(offset + 0.002f)), UI.TextStyle, Pivot.Center);
+
+		if (state.IsJustActive())
+			UI.PlaySoundOnOff(CustomUIVisual.Nonexistent, id, layout.center);
 
 		return state.IsJustInactive();
 	}

--- a/StereoKit/Native/NativeAPI.cs
+++ b/StereoKit/Native/NativeAPI.cs
@@ -763,7 +763,9 @@ namespace StereoKit
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   ui_draw_element_color   (UIVisual element_visual, UIVisual element_color, Vec3 start, Vec3 size, float focus);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern Color  ui_get_element_color    (UIVisual element_visual,                                                float focus);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern float  ui_get_anim_focus       (IdHash id, BtnState focus_state, BtnState activation_state);
-
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   ui_play_sound_on_off    (UIVisual element_visual, IdHash element_id, Vec3 at_local);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   ui_play_sound_on        (UIVisual element_visual, Vec3 at_local);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   ui_play_sound_off       (UIVisual element_visual, Vec3 at_local);
 
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void ui_push_grab_aura        ([MarshalAs(UnmanagedType.Bool)] bool enabled);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void ui_pop_grab_aura         ();

--- a/StereoKit/Systems/UI.cs
+++ b/StereoKit/Systems/UI.cs
@@ -1727,5 +1727,36 @@ namespace StereoKit
 		/// its events.</param>
 		public static void SliderBehavior(Vec3 windowRelativePos, Vec2 size, IdHash id, ref Vec2 value, Vec2 min, Vec2 max, Vec2 buttonSizeVisual, Vec2 buttonSizeInteract, UIConfirm confirmMethod, out UISliderData data)
 			=> NativeAPI.ui_slider_behavior(windowRelativePos, size, id, ref value, min, max, buttonSizeVisual, buttonSizeInteract, confirmMethod, out data);
+
+		/// <summary>This will play the 'on' sound associated with the given
+		/// UIVisual at the local position. It will also play the 'off' sound
+		/// when the given element becomes inactive, at the world location of
+		/// the initial local position!</summary>
+		/// <param name="elementVisual">The UIVisual to pull sound information
+		/// from.</param>
+		/// <param name="elementId">The id of the element that will be tracked
+		/// for playing the 'off' sound.</param>
+		/// <param name="atLocal">The hierarchy local location where the sound
+		/// will play. </param>
+		public static void PlaySoundOnOff(UIVisual elementVisual, IdHash elementId, Vec3 atLocal)
+			=> NativeAPI.ui_play_sound_on_off(elementVisual, elementId, atLocal);
+
+		/// <summary>This will play the 'on' sound associated with the given
+		/// UIVisual at the world position.</summary>
+		/// <param name="elementVisual">The UIVisual to pull sound information
+		/// from.</param>
+		/// <param name="atLocal">The hierarchy local location where the sound
+		/// will play. </param>
+		public static void PlaySoundOn(UIVisual elementVisual, Vec3 atLocal)
+			=> NativeAPI.ui_play_sound_on(elementVisual, atLocal);
+
+		/// <summary>This will play the 'off' sound associated with the given
+		/// UIVisual at the world position.</summary>
+		/// <param name="elementVisual">The UIVisual to pull sound information
+		/// from.</param>
+		/// <param name="atLocal">The hierarchy local location where the sound
+		/// will play. </param>
+		public static void PlaySoundOff(UIVisual elementVisual, Vec3 atLocal)
+			=> NativeAPI.ui_play_sound_off(elementVisual, atLocal);
 	}
 }

--- a/StereoKitC/stereokit_ui.h
+++ b/StereoKitC/stereokit_ui.h
@@ -182,6 +182,9 @@ SK_API void     ui_draw_element         (ui_vis_ element_visual,                
 SK_API void     ui_draw_element_color   (ui_vis_ element_visual, ui_vis_ element_color, vec3 start, vec3 size, float focus);
 SK_API color128 ui_get_element_color    (ui_vis_ element_visual,                                               float focus);
 SK_API float    ui_get_anim_focus       (id_hash_t id, button_state_ focus_state, button_state_ activation_state);
+SK_API void     ui_play_sound_on_off    (ui_vis_ element_visual, id_hash_t element_id, vec3 at_local);
+SK_API void     ui_play_sound_on        (ui_vis_ element_visual, vec3 at_local);
+SK_API void     ui_play_sound_off       (ui_vis_ element_visual, vec3 at_local);
 
 SK_API void     ui_push_grab_aura        (bool32_t enabled);
 SK_API void     ui_pop_grab_aura         ();

--- a/StereoKitC/ui/stereokit_ui.cpp
+++ b/StereoKitC/ui/stereokit_ui.cpp
@@ -290,6 +290,9 @@ bool32_t ui_button_img_at_g(const C* text, sprite_t image, ui_btn_layout_ image_
 	ui_draw_element(ui_vis_button, window_relative_pos, vec3{ size.x,size.y,finger_offset }, fmaxf(min_activation, ui_get_anim_focus(id, focus, state)));
 	_ui_button_img_surface(text, image, image_layout, align_center, window_relative_pos, size, finger_offset, image_tint);
 
+	if (state & button_state_just_active)
+		ui_play_sound_on_off(ui_vis_button, id, window_relative_pos - vec3{ size.x/2.f, size.y/2.f, 0 });
+
 	return state & button_state_just_inactive;
 }
 
@@ -359,6 +362,9 @@ bool32_t ui_toggle_img_at_g(const C* text, bool32_t& pressed, sprite_t toggle_of
 	ui_draw_element(ui_vis_toggle, window_relative_pos, vec3{ size.x,size.y,finger_offset }, fmaxf(min_activation, ui_get_anim_focus(id, focus, state)));
 	_ui_button_img_surface(text, pressed?toggle_on:toggle_off, image_layout, align_center, window_relative_pos, size, finger_offset, color128{1,1,1,1});
 
+	if (state & button_state_just_active)
+		ui_play_sound_on_off(ui_vis_button, id, window_relative_pos - vec3{ size.x/2.f, size.y/2.f, 0 });
+
 	return state & button_state_just_inactive;
 }
 bool32_t ui_toggle_img_at   (const char*     text, bool32_t& pressed, sprite_t toggle_off, sprite_t toggle_on, ui_btn_layout_ image_layout, vec3 window_relative_pos, vec2 size) { return ui_toggle_img_at_g<char    >(text, pressed, toggle_off, toggle_on, image_layout, window_relative_pos, size); }
@@ -424,6 +430,9 @@ bool32_t ui_button_round_at_g(const C *text, sprite_t image, vec3 window_relativ
 	float sprite_scale = fmaxf(1, sprite_get_aspect(image));
 	float sprite_size  = (diameter * 0.7f) / sprite_scale;
 	sprite_draw(image, matrix_ts(window_relative_pos + vec3{ -diameter/2, -diameter/2, -(finger_offset + 2*mm2m) }, vec3{ sprite_size, sprite_size, 1 }), pivot_center);
+
+	if (state & button_state_just_active)
+		ui_play_sound_on_off(ui_vis_button, id, window_relative_pos - vec3{ diameter/2.f, diameter/2.f, 0 });
 
 	return state & button_state_just_inactive;
 }
@@ -622,6 +631,9 @@ bool32_t ui_input_at_g(const C* id, C* buffer, int32_t buffer_size, vec3 window_
 
 	ui_text_in(draw_text, pivot_top_left, align_center_left, text_fit_clip, window_relative_pos - vec3{ skui_settings.padding, 0, text_depth }, text_bounds, vec2_zero);
 
+	if (state & button_state_just_active)
+		ui_play_sound_on_off(ui_vis_button, id_hash, window_relative_pos - vec3{ size.x/2.f, size.y/2.f, 0 });
+
 	return result;
 }
 
@@ -754,13 +766,13 @@ bool32_t ui_slider_at_g(ui_dir_ bar_direction, const C *id_text, float &value, f
 		vis_focus);
 	
 	if (slider.active_state & button_state_just_active)
-		ui_play_sound_on_off(ui_vis_slider_pinch, id, hierarchy_to_world_point({ slider.button_center.x, slider.button_center.y,0 }));
+		ui_play_sound_on_off(ui_vis_slider_pinch, id, { slider.button_center.x, slider.button_center.y, window_relative_pos.z });
 
 	// Play tick sound as the value updates
 	if (slider.active_state & button_state_active && old_value != value) {
 		if (step != 0) {
 			// Play on every change if there's a user specified step value
-			ui_play_sound_on(ui_vis_slider_line, hierarchy_to_world_point({ slider.button_center.x, slider.button_center.y, window_relative_pos.z }));
+			ui_play_sound_on(ui_vis_slider_line, { slider.button_center.x, slider.button_center.y, window_relative_pos.z });
 		} else {
 			// If no user specified step, then we'll do a set number of
 			// clicks across the whole bar.
@@ -771,7 +783,7 @@ bool32_t ui_slider_at_g(ui_dir_ bar_direction, const C *id_text, float &value, f
 			int32_t new_quantize = (int32_t)(percent     * click_steps + 0.5f);
 
 			if (old_quantize != new_quantize) {
-				ui_play_sound_on(ui_vis_slider_line, hierarchy_to_world_point({ slider.button_center.x, slider.button_center.y, window_relative_pos.z }));
+				ui_play_sound_on(ui_vis_slider_line, { slider.button_center.x, slider.button_center.y, window_relative_pos.z });
 			}
 		}
 	}

--- a/StereoKitC/ui/ui_core.cpp
+++ b/StereoKitC/ui/ui_core.cpp
@@ -112,9 +112,6 @@ void ui_button_behavior_depth(vec3 window_relative_pos, vec2 size, id_hash_t id,
 		}
 		out_focus_state = button_make_state(actor->focused_prev_prev == id, actor->focused_prev == id);
 	}
-	
-	if (out_button_state & button_state_just_active)
-		ui_play_sound_on_off(ui_vis_button, id, hierarchy_to_world_point(ui_layout_last().center));
 
 	if (out_opt_hand)
 		*out_opt_hand = interactor;
@@ -251,7 +248,7 @@ bool32_t _ui_handle_begin(id_hash_t id, pose_t &handle_pose, bounds_t handle_bou
 	float color_blend = 0;
 	if (ui_id_focused(id)) color_blend = 1;
 	if (ui_id_active_state(id) & button_state_just_active)
-		ui_play_sound_on_off(ui_vis_handle, id, hierarchy_to_world_point(handle_pose.position));
+		ui_play_sound_on_off(ui_vis_handle, id, handle_bounds.center);
 
 	if (draw) {
 		ui_draw_element(ui_vis_handle,

--- a/StereoKitC/ui/ui_theming.cpp
+++ b/StereoKitC/ui/ui_theming.cpp
@@ -469,33 +469,33 @@ void ui_draw_element(ui_vis_ element_visual, vec3 start, vec3 size, float focus)
 
 ///////////////////////////////////////////
 
-void ui_play_sound_on_off(ui_vis_ element_visual, id_hash_t element_id, vec3 at) {
-	sound_t snd_on  = ui_get_sound_on(element_visual);
+void ui_play_sound_on_off(ui_vis_ element_visual, id_hash_t element_id, vec3 at_local) {
+	sound_t snd_on  = ui_get_sound_on (element_visual);
 	sound_t snd_off = ui_get_sound_off(element_visual);
 
 	if (snd_off) sound_addref(snd_off);
 	sound_release(skui_active_sound_off);
 
 	skui_active_sound_off        = snd_off;
-	skui_active_sound_pos        = at;
+	skui_active_sound_pos        = hierarchy_to_world_point(at_local);
 	skui_active_sound_element_id = element_id;
 
 	if (snd_on)
-		skui_active_sound_inst = sound_play(snd_on, at, 1);
+		skui_active_sound_inst = sound_play(snd_on, skui_active_sound_pos, 1);
 }
 
 ///////////////////////////////////////////
 
-void ui_play_sound_on(ui_vis_ element_visual, vec3 at) {
+void ui_play_sound_on(ui_vis_ element_visual, vec3 at_local) {
 	sound_t snd = ui_get_sound_on(element_visual);
-	if (snd) sound_play(snd, at, 1);
+	if (snd) sound_play(snd, hierarchy_to_world_point(at_local), 1);
 }
 
 ///////////////////////////////////////////
 
-void ui_play_sound_off(ui_vis_ element_visual, vec3 at) {
+void ui_play_sound_off(ui_vis_ element_visual, vec3 at_local) {
 	sound_t snd = ui_get_sound_off(element_visual);
-	if (snd) sound_play(snd, at, 1);
+	if (snd) sound_play(snd, hierarchy_to_world_point(at_local), 1);
 }
 
 ///////////////////////////////////////////

--- a/StereoKitC/ui/ui_theming.h
+++ b/StereoKitC/ui/ui_theming.h
@@ -20,9 +20,6 @@ void     ui_theming_update   ();
 void     ui_theming_shutdown ();
 
 vec2     ui_get_mesh_minsize (ui_vis_ element_visual);
-void     ui_play_sound_on_off(ui_vis_ element_visual, id_hash_t element_id, vec3 at);
-void     ui_play_sound_on    (ui_vis_ element_visual, vec3 at);
-void     ui_play_sound_off   (ui_vis_ element_visual, vec3 at);
 void     ui_draw_cube        (vec3 start, vec3 size, ui_color_ color, float focus);
 
 void     ui_anim_start        (id_hash_t id, int32_t channel);


### PR DESCRIPTION
`UI.ButtonBehavior` automatically added noises, despite being just the button's _behavior_. This was somewhat of a legacy thing, so it is now removed. You now must manually make noises when defining custom buttons. To facilitate this, UI sound functions were promoted to the public API:

- `UI.PlaySoundOnOff`
- `UI.PlaySoundOn`
- `UI.PlaySoundOff`