### PR TITLE
Add Controller Model EXT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,9 +185,9 @@ include("cmake/CPM.cmake")
 #### OpenXR - https://www.khronos.org/openxr/ ####
 if (SK_BUILD_OPENXR_LOADER)
   CPMAddPackage( # We're scraping the comment after the NAME for some other scripts
-    NAME openxr_loader # 1.1.47
+    NAME openxr_loader # 1.1.49
     GITHUB_REPOSITORY KhronosGroup/OpenXR-SDK
-    GIT_TAG release-1.1.47
+    GIT_TAG release-1.1.49
     GIT_SHALLOW 1
     OPTIONS
     "BUILD_WITH_SYSTEM_JSONCPP OFF"
@@ -426,6 +426,10 @@ set(SK_SRC_XR_EXTS
   StereoKitC/xr_backends/extensions/composition_depth.cpp
   StereoKitC/xr_backends/extensions/debug_utils.h
   StereoKitC/xr_backends/extensions/debug_utils.cpp
+  StereoKitC/xr_backends/extensions/ext_interaction_render_model.h
+  StereoKitC/xr_backends/extensions/ext_interaction_render_model.cpp
+  StereoKitC/xr_backends/extensions/ext_render_model.h
+  StereoKitC/xr_backends/extensions/ext_render_model.cpp
   StereoKitC/xr_backends/extensions/eye_interaction.h
   StereoKitC/xr_backends/extensions/eye_interaction.cpp
   StereoKitC/xr_backends/extensions/fb_colorspace.h

--- a/StereoKitC/StereoKitC.vcxproj
+++ b/StereoKitC/StereoKitC.vcxproj
@@ -198,7 +198,9 @@ xcopy "$(ProjectDir)stereokit_ui.h" "$(ProjectDir)..\bin\distribute\include\" /d
     <ClCompile Include="xr_backends\extensions\android_thread.cpp" />
     <ClCompile Include="xr_backends\extensions\composition_depth.cpp" />
     <ClCompile Include="xr_backends\extensions\debug_utils.cpp" />
+    <ClCompile Include="xr_backends\extensions\ext_interaction_render_model.cpp" />
     <ClCompile Include="xr_backends\extensions\ext_management.cpp" />
+    <ClCompile Include="xr_backends\extensions\ext_render_model.cpp" />
     <ClCompile Include="xr_backends\extensions\eye_interaction.cpp" />
     <ClCompile Include="xr_backends\extensions\fb_colorspace.cpp" />
     <ClCompile Include="xr_backends\extensions\graphics.cpp" />
@@ -313,7 +315,9 @@ xcopy "$(ProjectDir)stereokit_ui.h" "$(ProjectDir)..\bin\distribute\include\" /d
     <ClInclude Include="xr_backends\extensions\android_thread.h" />
     <ClInclude Include="xr_backends\extensions\composition_depth.h" />
     <ClInclude Include="xr_backends\extensions\debug_utils.h" />
+    <ClInclude Include="xr_backends\extensions\ext_interaction_render_model.h" />
     <ClInclude Include="xr_backends\extensions\ext_management.h" />
+    <ClInclude Include="xr_backends\extensions\ext_render_model.h" />
     <ClInclude Include="xr_backends\extensions\eye_interaction.h" />
     <ClInclude Include="xr_backends\extensions\fb_colorspace.h" />
     <ClInclude Include="xr_backends\extensions\graphics.h" />

--- a/StereoKitC/StereoKitC.vcxproj.filters
+++ b/StereoKitC/StereoKitC.vcxproj.filters
@@ -321,6 +321,12 @@
     <ClCompile Include="ui\interactor_modes.cpp">
       <Filter>ui</Filter>
     </ClCompile>
+    <ClCompile Include="xr_backends\extensions\ext_render_model.cpp">
+      <Filter>xr_backends\extensions</Filter>
+    </ClCompile>
+    <ClCompile Include="xr_backends\extensions\ext_interaction_render_model.cpp">
+      <Filter>xr_backends\extensions</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="stereokit.h" />
@@ -668,6 +674,12 @@
     </ClInclude>
     <ClInclude Include="ui\interactor_modes.h">
       <Filter>ui</Filter>
+    </ClInclude>
+    <ClInclude Include="xr_backends\extensions\ext_render_model.h">
+      <Filter>xr_backends\extensions</Filter>
+    </ClInclude>
+    <ClInclude Include="xr_backends\extensions\ext_interaction_render_model.h">
+      <Filter>xr_backends\extensions</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/StereoKitC/systems/input_render.cpp
+++ b/StereoKitC/systems/input_render.cpp
@@ -11,6 +11,7 @@
 #include "../libraries/array.h"
 #include "../xr_backends/openxr.h"
 #include "../xr_backends/extensions/hand_mesh.h"
+#include "../xr_backends/extensions/ext_interaction_render_model.h"
 #include "../systems/defaults.h"
 
 namespace sk {
@@ -132,8 +133,12 @@ void input_render_step_late() {
 			}
 		} else if (source == hand_source_simulated) {
 			const controller_t* control = input_controller((handed_)i);
-			if ((control->tracked & button_state_active) != 0 && local.controller_model[i] != nullptr) {
-				render_add_model(local.controller_model[i], matrix_trs(control->pose.position, control->pose.orientation));
+			if (!input_controller_is_hand((handed_)i) && (control->tracked & button_state_active) != 0) {
+				if (xr_ext_interaction_render_model_available()) {
+					xr_ext_interaction_render_model_draw_controller((handed_)i);
+				} else if (local.controller_model[i] != nullptr) {
+					render_add_model(local.controller_model[i], matrix_trs(control->pose.position, control->pose.orientation));
+				}
 			}
 		} else if (source == hand_source_overridden) {
 			const hand_t* hand = input_hand((handed_)i);
@@ -144,6 +149,8 @@ void input_render_step_late() {
 			}
 		}
 	}
+
+	xr_ext_interaction_render_model_draw_others();
 }
 
 ///////////////////////////////////////////

--- a/StereoKitC/systems/input_render.cpp
+++ b/StereoKitC/systems/input_render.cpp
@@ -196,14 +196,11 @@ void input_controller_model_set(handed_ hand, model_t model) {
 ///////////////////////////////////////////
 
 model_t input_controller_model_get(handed_ hand) {
-	model_t result = nullptr;
-	if (local.controller_model[hand] == nullptr) {
-		if (xr_ext_interaction_render_model_available()) result = xr_ext_interaction_render_model_get(hand);
-		else                                             result = hand == handed_left ? sk_default_controller_l : sk_default_controller_r;
-	}
-
-	if (result != nullptr)
-		model_addref(result);
+	model_t result = local.controller_model[hand];
+	if (result == nullptr && xr_ext_interaction_render_model_available()) result = xr_ext_interaction_render_model_get(hand);
+	if (result == nullptr)                                                result = hand == handed_left ? sk_default_controller_l : sk_default_controller_r;
+	
+	model_addref(result);
 	return result;
 }
 

--- a/StereoKitC/xr_backends/extensions/_registration.cpp
+++ b/StereoKitC/xr_backends/extensions/_registration.cpp
@@ -12,6 +12,8 @@
 
 #include "composition_depth.h"
 #include "debug_utils.h"
+#include "ext_interaction_render_model.h"
+#include "ext_render_model.h"
 #include "eye_interaction.h"
 #include "fb_colorspace.h"
 #include "graphics.h"
@@ -63,6 +65,8 @@ bool ext_registration() {
 	xr_ext_oculus_audio_register();
 	xr_ext_msft_bridge_register();
 	xr_ext_msft_anchor_interop_register();
+	xr_ext_interaction_render_model_register();
+	xr_ext_render_model_register();
 
 	// Input extensions all must go before the oxri/input system
 	xr_ext_palm_pose_register                    ();

--- a/StereoKitC/xr_backends/extensions/ext_interaction_render_model.cpp
+++ b/StereoKitC/xr_backends/extensions/ext_interaction_render_model.cpp
@@ -106,6 +106,14 @@ void xr_ext_interaction_render_model_draw_controller(handed_ hand) {
 
 ///////////////////////////////////////////
 
+model_t xr_ext_interaction_render_model_get(handed_ hand) {
+	return local.controller_idx[hand] >= 0
+		? local.models[local.controller_idx[hand]].model
+		: nullptr;
+}
+
+///////////////////////////////////////////
+
 bool xr_ext_interaction_render_model_available() {
 	return local.available;
 }

--- a/StereoKitC/xr_backends/extensions/ext_interaction_render_model.cpp
+++ b/StereoKitC/xr_backends/extensions/ext_interaction_render_model.cpp
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: MIT
+// The authors below grant copyright rights under the MIT license:
+// Copyright (c) 2025 Nick Klingensmith
+// Copyright (c) 2025 Qualcomm Technologies, Inc.
+
+// This implements XR_EXT_interaction_render_model
+// https://registry.khronos.org/OpenXR/specs/1.1/html/xrspec.html#XR_EXT_interaction_render_model
+
+#include "ext_interaction_render_model.h"
+#include "ext_render_model.h"
+#include "ext_management.h"
+
+ ///////////////////////////////////////////
+
+#define XR_EXT_FUNCTIONS( X ) \
+	X(xrEnumerateInteractionRenderModelIdsEXT) \
+	X(xrEnumerateRenderModelSubactionPathsEXT) \
+	X(xrGetRenderModelPoseTopLevelUserPathEXT)
+OPENXR_DEFINE_FN_STATIC(XR_EXT_FUNCTIONS);
+
+///////////////////////////////////////////
+
+namespace sk {
+
+///////////////////////////////////////////
+
+typedef struct xr_ext_interaction_render_model_t {
+	bool               available;
+	xr_render_model_t* models;
+	int32_t            model_count;
+} xr_ext_interaction_render_model_t;
+static xr_ext_interaction_render_model_t local = { };
+
+///////////////////////////////////////////
+
+xr_system_ xr_ext_interaction_render_model_initialize(void*);
+void       xr_ext_interaction_render_model_shutdown  (void*);
+void       xr_ext_interaction_render_model_step_begin(void*);
+void       xr_ext_interaction_render_model_poll      (void*, XrEventDataBuffer* event);
+
+///////////////////////////////////////////
+
+void xr_ext_interaction_render_model_register() {
+	xr_system_t sys = {};
+	sys.request_exts[sys.request_ext_count++] = XR_EXT_INTERACTION_RENDER_MODEL_EXTENSION_NAME;
+	sys.evt_initialize = { xr_ext_interaction_render_model_initialize };
+	sys.evt_shutdown   = { xr_ext_interaction_render_model_shutdown   };
+	sys.evt_poll       = { (void (*)(void*, void*))xr_ext_interaction_render_model_poll };
+	sys.evt_step_begin = { xr_ext_interaction_render_model_step_begin };
+	ext_management_sys_register(sys);
+}
+
+///////////////////////////////////////////
+
+xr_system_ xr_ext_interaction_render_model_initialize(void*) {
+	if (!backend_openxr_ext_enabled(XR_EXT_INTERACTION_RENDER_MODEL_EXTENSION_NAME))
+		return xr_system_fail;
+
+	OPENXR_LOAD_FN_RETURN(XR_EXT_FUNCTIONS, xr_system_fail);
+
+	local.available = true;
+
+	// This ext gets added a bit late, and misses some early polling?
+	XrEventDataInteractionRenderModelsChangedEXT evt = { XR_TYPE_EVENT_DATA_INTERACTION_RENDER_MODELS_CHANGED_EXT };
+	xr_ext_interaction_render_model_poll(nullptr, (XrEventDataBuffer*)&evt);
+
+	return xr_system_succeed;
+}
+
+///////////////////////////////////////////
+
+void xr_ext_interaction_render_model_shutdown(void*) {
+	OPENXR_CLEAR_FN(XR_EXT_FUNCTIONS);
+}
+
+///////////////////////////////////////////
+
+void xr_ext_interaction_render_model_step_begin(void*) {
+	for (int32_t i = 0; i < local.model_count; i++) {
+		xr_render_model_t* model = &local.models[i];
+		xr_ext_render_model_update(model);
+
+		XrSpaceLocation loc = { XR_TYPE_SPACE_LOCATION };
+		if (XR_FAILED(xrLocateSpace(model->space, xr_app_space, xr_time, &loc)))
+			continue;
+		if ((loc.locationFlags & XR_SPACE_LOCATION_POSITION_VALID_BIT   ) != 0 &&
+			(loc.locationFlags & XR_SPACE_LOCATION_ORIENTATION_VALID_BIT) != 0) {
+			XrVector3f    p = loc.pose.position;
+			XrQuaternionf r = loc.pose.orientation;
+			model_draw(model->model, matrix_trs({ p.x, p.y, p.z }, {r.x, r.y, r.z, r.w}));
+		}
+	}
+}
+
+///////////////////////////////////////////
+
+void xr_ext_interaction_render_model_poll(void*, XrEventDataBuffer* event) {
+	if (event->type != XR_TYPE_EVENT_DATA_INTERACTION_PROFILE_CHANGED &&
+		event->type != XR_TYPE_EVENT_DATA_INTERACTION_RENDER_MODELS_CHANGED_EXT) // Should be this event, but it's not firing?
+		return;
+
+	// Enumerate the render model IDs
+	uint32_t                                    count    = 0;
+	XrInteractionRenderModelIdsEnumerateInfoEXT get_info = { XR_TYPE_INTERACTION_RENDER_MODEL_IDS_ENUMERATE_INFO_EXT };
+	xrEnumerateInteractionRenderModelIdsEXT(xr_session, &get_info, 0, &count, NULL);
+	XrRenderModelIdEXT* model_ids = sk_malloc_t(XrRenderModelIdEXT, count);
+	XrResult r = xrEnumerateInteractionRenderModelIdsEXT(xr_session, &get_info, count, &count, model_ids);
+	if (XR_FAILED(r)) log_warnf("%s: [%s]", "xrEnumerateInteractionRenderModelIdsEXT", openxr_string(r));
+
+	// Get the new models
+	int32_t            new_count = count;
+	xr_render_model_t* new_list  = sk_malloc_t(xr_render_model_t, count);
+	for (int32_t i = 0; i < count; i++) {
+		new_list[i] = xr_ext_render_model_get(model_ids[i]);
+	}
+
+	// Release our previous list of models (this comes second so we don't
+	// release models that are re-used in the new list).
+	for (int32_t i = 0; i < local.model_count; i++) {
+		xr_ext_render_model_destroy(&local.models[i]);
+	}
+	sk_free(local.models);
+
+	// Swap over to the new list
+	local.models      = new_list;
+	local.model_count = new_count;
+
+	log_infof("Found %d render models", local.model_count);
+
+	sk_free(model_ids);
+}
+
+} // namespace sk

--- a/StereoKitC/xr_backends/extensions/ext_interaction_render_model.h
+++ b/StereoKitC/xr_backends/extensions/ext_interaction_render_model.h
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+// The authors below grant copyright rights under the MIT license:
+// Copyright (c) 2025 Nick Klingensmith
+// Copyright (c) 2025 Qualcomm Technologies, Inc.
+
+#pragma once
+
+#include "../../stereokit.h"
+
+namespace sk {
+
+void xr_ext_interaction_render_model_register();
+
+}

--- a/StereoKitC/xr_backends/extensions/ext_interaction_render_model.h
+++ b/StereoKitC/xr_backends/extensions/ext_interaction_render_model.h
@@ -9,9 +9,10 @@
 
 namespace sk {
 
-void xr_ext_interaction_render_model_register();
-void xr_ext_interaction_render_model_draw_controller(handed_ hand);
-void xr_ext_interaction_render_model_draw_others    ();
-bool xr_ext_interaction_render_model_available      ();
+void    xr_ext_interaction_render_model_register();
+void    xr_ext_interaction_render_model_draw_controller(handed_ hand);
+model_t xr_ext_interaction_render_model_get            (handed_ hand);
+void    xr_ext_interaction_render_model_draw_others    ();
+bool    xr_ext_interaction_render_model_available      ();
 
 }

--- a/StereoKitC/xr_backends/extensions/ext_interaction_render_model.h
+++ b/StereoKitC/xr_backends/extensions/ext_interaction_render_model.h
@@ -10,5 +10,8 @@
 namespace sk {
 
 void xr_ext_interaction_render_model_register();
+void xr_ext_interaction_render_model_draw_controller(handed_ hand);
+void xr_ext_interaction_render_model_draw_others    ();
+bool xr_ext_interaction_render_model_available      ();
 
 }

--- a/StereoKitC/xr_backends/extensions/ext_render_model.cpp
+++ b/StereoKitC/xr_backends/extensions/ext_render_model.cpp
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: MIT
+// The authors below grant copyright rights under the MIT license:
+// Copyright (c) 2025 Nick Klingensmith
+// Copyright (c) 2025 Qualcomm Technologies, Inc.
+
+// This implements XR_EXT_render_model
+// https://registry.khronos.org/OpenXR/specs/1.1/html/xrspec.html#XR_EXT_render_model
+
+#include "ext_render_model.h"
+#include "ext_management.h"
+
+#include <inttypes.h>
+#include <stdio.h>
+
+ ///////////////////////////////////////////
+
+#define XR_EXT_FUNCTIONS( X )             \
+	X(xrCreateRenderModelAssetEXT)        \
+	X(xrCreateRenderModelEXT)             \
+	X(xrCreateRenderModelSpaceEXT)        \
+	X(xrDestroyRenderModelAssetEXT)       \
+	X(xrDestroyRenderModelEXT)            \
+	X(xrGetRenderModelAssetDataEXT)       \
+	X(xrGetRenderModelAssetPropertiesEXT) \
+	X(xrGetRenderModelPropertiesEXT)      \
+	X(xrGetRenderModelStateEXT)
+OPENXR_DEFINE_FN_STATIC(XR_EXT_FUNCTIONS);
+
+///////////////////////////////////////////
+
+namespace sk {
+
+///////////////////////////////////////////
+
+typedef struct xr_ext_render_model_state_t {
+	bool available;
+} xr_ext_render_model_state_t;
+static xr_ext_render_model_state_t local = { };
+
+///////////////////////////////////////////
+
+xr_system_ xr_ext_render_model_initialize(void*);
+void       xr_ext_render_model_shutdown  (void*);
+
+///////////////////////////////////////////
+
+void xr_ext_render_model_register() {
+	xr_system_t sys = {};
+	sys.request_exts[sys.request_ext_count++] = XR_EXT_RENDER_MODEL_EXTENSION_NAME;
+	sys.request_exts[sys.request_ext_count++] = XR_EXT_UUID_EXTENSION_NAME;
+	sys.evt_initialize = { xr_ext_render_model_initialize };
+	sys.evt_shutdown   = { xr_ext_render_model_shutdown };
+	ext_management_sys_register(sys);
+}
+
+///////////////////////////////////////////
+
+xr_system_ xr_ext_render_model_initialize(void*) {
+	if (!backend_openxr_ext_enabled(XR_EXT_RENDER_MODEL_EXTENSION_NAME))
+		return xr_system_fail;
+
+	OPENXR_LOAD_FN_RETURN(XR_EXT_FUNCTIONS, xr_system_fail);
+
+	local.available = true;
+
+	return xr_system_succeed;
+}
+
+///////////////////////////////////////////
+
+void xr_ext_render_model_shutdown(void*) {
+	OPENXR_CLEAR_FN(XR_EXT_FUNCTIONS);
+}
+
+///////////////////////////////////////////
+
+xr_render_model_t xr_ext_render_model_get(XrRenderModelIdEXT id) {
+	if (!local.available) return {};
+
+	const char* gltf_exts[] = {
+		"KHR_texture_basisu",
+		"KHR_materials_unlit",
+		"KHR_texture_transform",
+		"EXT_meshopt_compression",
+	};
+
+	xr_render_model_t result = {};
+	result.id = id;
+
+	XrRenderModelCreateInfoEXT model_info = { XR_TYPE_RENDER_MODEL_CREATE_INFO_EXT };
+	model_info.renderModelId      = id;
+	model_info.gltfExtensionCount = sizeof(gltf_exts) / sizeof(gltf_exts[0]);
+	model_info.gltfExtensions     = gltf_exts;
+	XrResult r = xrCreateRenderModelEXT(xr_session, &model_info, &result.render_model);
+	if (XR_FAILED(r)) log_warnf("%s: [%s]", "xrCreateRenderModelEXT", openxr_string(r));
+
+	XrRenderModelSpaceCreateInfoEXT   space_info       = { XR_TYPE_RENDER_MODEL_SPACE_CREATE_INFO_EXT };
+	space_info.renderModel = result.render_model;
+	r = xrCreateRenderModelSpaceEXT(xr_session, &space_info, &result.space);
+	if (XR_FAILED(r)) log_warnf("%s: [%s]", "xrCreateRenderModelSpaceEXT", openxr_string(r));
+
+	XrRenderModelPropertiesGetInfoEXT props_info       = { XR_TYPE_RENDER_MODEL_PROPERTIES_GET_INFO_EXT };
+	XrRenderModelPropertiesEXT        props            = { XR_TYPE_RENDER_MODEL_PROPERTIES_EXT          };
+	r = xrGetRenderModelPropertiesEXT(result.render_model, &props_info, &props);
+	if (XR_FAILED(r)) log_warnf("%s: [%s]","xrGetRenderModelPropertiesEXT", openxr_string(r));
+
+	XrRenderModelAssetEXT            asset;
+	XrRenderModelAssetCreateInfoEXT  asset_info = { XR_TYPE_RENDER_MODEL_ASSET_CREATE_INFO_EXT };
+	asset_info.cacheId = props.cacheId;
+	r = xrCreateRenderModelAssetEXT(xr_session, &asset_info, &asset);
+	if (XR_FAILED(r)) log_warnf("xrCreateRenderModelAssetEXT: [%s]", openxr_string(r));
+
+	char name[128];
+	XrUuidEXT uuid = props.cacheId;
+	snprintf(name, sizeof(name), "sk/xr_model/%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x.glb",
+		uuid.data[0 ], uuid.data[1 ], uuid.data[2 ], uuid.data[3 ],
+		uuid.data[4 ], uuid.data[5 ], uuid.data[6 ], uuid.data[7 ],
+		uuid.data[8 ], uuid.data[9 ], uuid.data[10], uuid.data[11],
+		uuid.data[12], uuid.data[13], uuid.data[14], uuid.data[15]);
+	result.model = model_find(name);
+
+	if (result.model == nullptr) {
+		XrRenderModelAssetDataGetInfoEXT data_info = { XR_TYPE_RENDER_MODEL_ASSET_DATA_GET_INFO_EXT };
+		XrRenderModelAssetDataEXT        data      = { XR_TYPE_RENDER_MODEL_ASSET_DATA_EXT };
+		xrGetRenderModelAssetDataEXT(asset, &data_info, &data);
+		data.bufferCapacityInput = data.bufferCountOutput;
+		data.buffer              = sk_malloc_t(uint8_t, data.bufferCountOutput);
+		r = xrGetRenderModelAssetDataEXT(asset, &data_info, &data);
+		if (XR_FAILED(r)) log_warnf("%s: [%s]", "xrGetRenderModelAssetDataEXT", openxr_string(r));
+
+		result.model = model_create_mem(name, data.buffer, data.bufferCountOutput);
+		model_set_id(result.model, name);
+
+		sk_free(data.buffer);
+	}
+	result.model = model_copy(result.model);
+
+	XrRenderModelAssetPropertiesGetInfoEXT asset_props_info = { XR_TYPE_RENDER_MODEL_ASSET_PROPERTIES_GET_INFO_EXT };
+	XrRenderModelAssetPropertiesEXT        asset_props      = { XR_TYPE_RENDER_MODEL_ASSET_PROPERTIES_EXT };
+	XrRenderModelAssetNodePropertiesEXT*   node_props       = sk_malloc_t(XrRenderModelAssetNodePropertiesEXT, props.animatableNodeCount);
+	asset_props.nodePropertyCount = props.animatableNodeCount;
+	asset_props.nodeProperties    = node_props;
+	r = xrGetRenderModelAssetPropertiesEXT(asset, &asset_props_info, &asset_props);
+	if (XR_FAILED(r)) log_warnf("%s: [%s]", "xrGetRenderModelAssetPropertiesEXT", openxr_string(r));
+	result.anim_nodes      = sk_malloc_t(model_node_id, asset_props.nodePropertyCount);
+	result.anim_node_count = asset_props.nodePropertyCount;
+	for (int32_t i = 0; i < asset_props.nodePropertyCount; i++) {
+		result.anim_nodes[i] = model_node_find(result.model, asset_props.nodeProperties[i].uniqueName);
+		matrix m = model_node_get_transform_local(result.model, result.anim_nodes[i]);
+		vec3   p = matrix_extract_translation(m);
+	}
+
+	result.state_query.nodeStateCount = asset_props.nodePropertyCount;
+	result.state_query.nodeStates     = sk_malloc_t(XrRenderModelNodeStateEXT, asset_props.nodePropertyCount);
+
+	sk_free(node_props);
+
+	xrDestroyRenderModelAssetEXT(asset);
+
+	return result;
+}
+
+///////////////////////////////////////////
+
+void xr_ext_render_model_update(xr_render_model_t* ref_model) {
+	XrRenderModelStateGetInfoEXT info  = { XR_TYPE_RENDER_MODEL_STATE_GET_INFO_EXT };
+	info.displayTime = xr_time;
+	XrResult r = xrGetRenderModelStateEXT(ref_model->render_model, &info, &ref_model->state_query);
+	if (XR_FAILED(r)) log_warnf("%s: [%s]", "xrGetRenderModelStateEXT", openxr_string(r));
+
+	for (int32_t i = 0; i < ref_model->state_query.nodeStateCount; i++) {
+		model_node_id node = ref_model->anim_nodes[i];
+
+		XrVector3f    p = ref_model->state_query.nodeStates[i].nodePose.position;
+		XrQuaternionf r = ref_model->state_query.nodeStates[i].nodePose.orientation;
+		model_node_set_transform_local(ref_model->model, node, matrix_trs({ p.x, p.y, p.z }, {r.x, r.y, r.z, r.w}));
+		model_node_set_visible        (ref_model->model, node, ref_model->state_query.nodeStates[i].isVisible);
+	}
+}
+
+///////////////////////////////////////////
+
+void xr_ext_render_model_destroy(xr_render_model_t* ref_model) {
+	model_release (ref_model->model);
+	xrDestroySpace(ref_model->space);
+	sk_free(ref_model->anim_nodes);
+	sk_free(ref_model->state_query.nodeStates);
+	*ref_model = {};
+}
+
+} // namespace sk

--- a/StereoKitC/xr_backends/extensions/ext_render_model.h
+++ b/StereoKitC/xr_backends/extensions/ext_render_model.h
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+// The authors below grant copyright rights under the MIT license:
+// Copyright (c) 2025 Nick Klingensmith
+// Copyright (c) 2025 Qualcomm Technologies, Inc.
+
+#pragma once
+
+#include "../../stereokit.h"
+#include <openxr/openxr.h>
+
+namespace sk {
+
+typedef struct xr_render_model_t {
+	XrRenderModelIdEXT id;
+	XrRenderModelEXT   render_model;
+	model_t            model;
+	XrSpace            space;
+	model_node_id*     anim_nodes;
+	int32_t            anim_node_count;
+	XrRenderModelStateEXT state_query;
+};
+
+void              xr_ext_render_model_register();
+xr_render_model_t xr_ext_render_model_get     (XrRenderModelIdEXT id);
+void              xr_ext_render_model_update  (xr_render_model_t* ref_model);
+void              xr_ext_render_model_destroy (xr_render_model_t* ref_model);
+
+}


### PR DESCRIPTION
This adds support for `XR_EXT_interaction_render_model` and `XR_EXT_render_model`, which allow for the runtime to provide the application with animated models for the user's controllers!

When these extensions are present, StereoKit will now use these controllers in place of StereoKit's default/placeholder controller model. `Input.ControllerModelGet`/`Set` should continue to work as expected with this feature.