### PR TITLE
Fix multiview double draw

### DIFF
--- a/StereoKitC/systems/render.cpp
+++ b/StereoKitC/systems/render.cpp
@@ -762,6 +762,16 @@ void render_add_model(model_t model, const matrix &transform, color128 color_lin
 void render_draw_queue(render_list_t list, const matrix *views, const matrix *projections, int32_t eye_offset, int32_t view_count, int32_t inst_multiplier, render_layer_ filter) {
 	skg_event_begin("Render List Setup");
 
+	// A temporary fix for multiview trying to render to mono rendertargets
+	if (view_count == 1) {
+		memset(&local.global_buffer.view      [1], 0, sizeof(local.global_buffer.view      [1]));
+		memset(&local.global_buffer.proj      [1], 0, sizeof(local.global_buffer.proj      [1]));
+		memset(&local.global_buffer.proj_inv  [1], 0, sizeof(local.global_buffer.proj_inv  [1]));
+		memset(&local.global_buffer.viewproj  [1], 0, sizeof(local.global_buffer.viewproj  [1]));
+		memset(&local.global_buffer.camera_pos[1], 0, sizeof(local.global_buffer.camera_pos[1]));
+		memset(&local.global_buffer.camera_dir[1], 0, sizeof(local.global_buffer.camera_dir[1]));
+	}
+
 	// Copy camera information into the global buffer
 	for (int32_t i = 0; i < view_count; i++) {
 		XMMATRIX view_f, projection_f;


### PR DESCRIPTION
Multiview will try to draw twice regardless of whether or not it's drawing to a multiview surface. This results in weird behavior (doubled object visuals) when drawing to rendertargets with only a single surface!

Ideally, finding a way to turn off multiview for mono targets would be best, but realistically, it looks like shader variations may be necessary to support this scenario in GLES. That's not a small project, so this is a temporary fix that should eliminate most of the symptoms!

This fix clears the memory for the second view data when drawing a single pass, so anything trying to use it will get drawn to an invalid point. So, no visible doubled geometry! We may still be paying some cost for extra vertex transforms in this case though.