### PR TITLE
Fix a few warnings and add a missing struct type for render models

### DIFF
--- a/StereoKitC/xr_backends/extensions/ext_interaction_render_model.cpp
+++ b/StereoKitC/xr_backends/extensions/ext_interaction_render_model.cpp
@@ -27,8 +27,8 @@ namespace sk {
 typedef struct xr_ext_interaction_render_model_t {
 	bool               available;
 	xr_render_model_t* models;
-	int32_t            model_count;
-	int32_t            controller_idx[handed_max];
+	uint32_t           model_count;
+	uint32_t           controller_idx[handed_max];
 } xr_ext_interaction_render_model_t;
 static xr_ext_interaction_render_model_t local = { };
 
@@ -89,7 +89,7 @@ void _xr_ext_interaction_render_model_draw(xr_render_model_t *model) {
 ///////////////////////////////////////////
 
 void xr_ext_interaction_render_model_draw_others() {
-	for (int32_t i = 0; i < local.model_count; i++) {
+	for (uint32_t i = 0; i < local.model_count; i++) {
 		if (i == local.controller_idx[0] ||
 			i == local.controller_idx[1])
 			continue;
@@ -134,16 +134,16 @@ void xr_ext_interaction_render_model_poll(void*, XrEventDataBuffer* event) {
 	if (XR_FAILED(r)) log_warnf("%s: [%s]", "xrEnumerateInteractionRenderModelIdsEXT", openxr_string(r));
 
 	// Get the new models
-	int32_t            new_count = count;
+	uint32_t           new_count = count;
 	xr_render_model_t* new_list  = sk_malloc_t(xr_render_model_t, count);
-	for (int32_t i = 0; i < count; i++) {
+	for (uint32_t i = 0; i < count; i++) {
 		new_list[i] = xr_ext_render_model_get(model_ids[i]);
 	}
 	sk_free(model_ids);
 
 	// Release our previous list of models (this comes second so we don't
 	// release models that are re-used in the new list).
-	for (int32_t i = 0; i < local.model_count; i++) {
+	for (uint32_t i = 0; i < local.model_count; i++) {
 		xr_ext_render_model_destroy(&local.models[i]);
 	}
 	sk_free(local.models);
@@ -158,14 +158,14 @@ void xr_ext_interaction_render_model_poll(void*, XrEventDataBuffer* event) {
 	xrStringToPath(xr_instance, "/user/hand/right", &hand_path[handed_right]);
 	local.controller_idx[0] = -1;
 	local.controller_idx[1] = -1;
-	for (int32_t i = 0; i < local.model_count; i++) {
+	for (uint32_t i = 0; i < local.model_count; i++) {
 		XrInteractionRenderModelSubactionPathInfoEXT info = { XR_TYPE_INTERACTION_RENDER_MODEL_SUBACTION_PATH_INFO_EXT };
 		uint32_t path_count = 0;
 		xrEnumerateRenderModelSubactionPathsEXT(new_list[i].render_model, &info, 0,          &path_count, nullptr);
 		XrPath* paths = sk_malloc_t(XrPath, path_count);
 		xrEnumerateRenderModelSubactionPathsEXT(new_list[i].render_model, &info, path_count, &path_count, paths);
 
-		for (int32_t p = 0; p < path_count; p++) {
+		for (uint32_t p = 0; p < path_count; p++) {
 			if      (paths[p] == hand_path[handed_left ]) local.controller_idx[handed_left ] = i;
 			else if (paths[p] == hand_path[handed_right]) local.controller_idx[handed_right] = i;
 		}

--- a/StereoKitC/xr_backends/extensions/ext_render_model.cpp
+++ b/StereoKitC/xr_backends/extensions/ext_render_model.cpp
@@ -144,7 +144,7 @@ xr_render_model_t xr_ext_render_model_get(XrRenderModelIdEXT id) {
 	if (XR_FAILED(r)) log_warnf("%s: [%s]", "xrGetRenderModelAssetPropertiesEXT", openxr_string(r));
 	result.anim_nodes      = sk_malloc_t(model_node_id, asset_props.nodePropertyCount);
 	result.anim_node_count = asset_props.nodePropertyCount;
-	for (int32_t i = 0; i < asset_props.nodePropertyCount; i++) {
+	for (uint32_t i = 0; i < asset_props.nodePropertyCount; i++) {
 		result.anim_nodes[i] = model_node_find(result.model, asset_props.nodeProperties[i].uniqueName);
 		matrix m = model_node_get_transform_local(result.model, result.anim_nodes[i]);
 		vec3   p = matrix_extract_translation(m);
@@ -168,7 +168,7 @@ void xr_ext_render_model_update(xr_render_model_t* ref_model) {
 	XrResult r = xrGetRenderModelStateEXT(ref_model->render_model, &info, &ref_model->state_query);
 	if (XR_FAILED(r)) log_warnf("%s: [%s]", "xrGetRenderModelStateEXT", openxr_string(r));
 
-	for (int32_t i = 0; i < ref_model->state_query.nodeStateCount; i++) {
+	for (uint32_t i = 0; i < ref_model->state_query.nodeStateCount; i++) {
 		model_node_id node = ref_model->anim_nodes[i];
 
 		XrVector3f    p = ref_model->state_query.nodeStates[i].nodePose.position;

--- a/StereoKitC/xr_backends/extensions/ext_render_model.cpp
+++ b/StereoKitC/xr_backends/extensions/ext_render_model.cpp
@@ -150,6 +150,7 @@ xr_render_model_t xr_ext_render_model_get(XrRenderModelIdEXT id) {
 		vec3   p = matrix_extract_translation(m);
 	}
 
+	result.state_query                = { XR_TYPE_RENDER_MODEL_STATE_EXT };
 	result.state_query.nodeStateCount = asset_props.nodePropertyCount;
 	result.state_query.nodeStates     = sk_malloc_t(XrRenderModelNodeStateEXT, asset_props.nodePropertyCount);
 

--- a/StereoKitC/xr_backends/extensions/ext_render_model.h
+++ b/StereoKitC/xr_backends/extensions/ext_render_model.h
@@ -11,13 +11,13 @@
 namespace sk {
 
 typedef struct xr_render_model_t {
-	XrRenderModelIdEXT id;
-	XrRenderModelEXT   render_model;
-	model_t            model;
-	XrSpace            space;
-	model_node_id*     anim_nodes;
-	int32_t            anim_node_count;
-	XrRenderModelStateEXT state_query;
+	XrRenderModelIdEXT    id;
+	XrRenderModelEXT      render_model;
+	model_t               model;
+	XrSpace               space;
+	model_node_id*        anim_nodes;
+	int32_t               anim_node_count;
+	XrRenderModelStateEXT state_query = { XR_TYPE_RENDER_MODEL_STATE_EXT };
 } xr_render_model_t;
 
 void              xr_ext_render_model_register();

--- a/StereoKitC/xr_backends/extensions/ext_render_model.h
+++ b/StereoKitC/xr_backends/extensions/ext_render_model.h
@@ -17,7 +17,7 @@ typedef struct xr_render_model_t {
 	XrSpace               space;
 	model_node_id*        anim_nodes;
 	int32_t               anim_node_count;
-	XrRenderModelStateEXT state_query = { XR_TYPE_RENDER_MODEL_STATE_EXT };
+	XrRenderModelStateEXT state_query;
 } xr_render_model_t;
 
 void              xr_ext_render_model_register();

--- a/StereoKitC/xr_backends/extensions/ext_render_model.h
+++ b/StereoKitC/xr_backends/extensions/ext_render_model.h
@@ -18,7 +18,7 @@ typedef struct xr_render_model_t {
 	model_node_id*     anim_nodes;
 	int32_t            anim_node_count;
 	XrRenderModelStateEXT state_query;
-};
+} xr_render_model_t;
 
 void              xr_ext_render_model_register();
 xr_render_model_t xr_ext_render_model_get     (XrRenderModelIdEXT id);


### PR DESCRIPTION
* Fix warning C4018: '<': signed/unsigned mismatch
* Fix warning C4091: 'typedef ': ignored on left of 'sk::xr_render_model_t' when no variable is declared
* FIx missing struct type