### PR TITLE
WIP: Parse glTF extensions

### DIFF
--- a/StereoKitC/asset_types/model_gltf.cpp
+++ b/StereoKitC/asset_types/model_gltf.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // The authors below grant copyright rights under the MIT license:
 // Copyright (c) 2019-2024 Nick Klingensmith
-// Copyright (c) 2024 Qualcomm Technologies, Inc.
+// Copyright (c) 2024-2025 Qualcomm Technologies, Inc.
 
 #define _CRT_SECURE_NO_WARNINGS 1
 

--- a/StereoKitC/libraries/cgltf.cpp
+++ b/StereoKitC/libraries/cgltf.cpp
@@ -1,3 +1,8 @@
+/* SPDX-License-Identifier: MIT */
+/* The authors below grant copyright rights under the MIT license:
+ * Copyright (c) 2025 Qualcomm Technologies, Inc.
+ */
+
 #include "../sk_memory.h"
 
 #ifdef _MSC_VER


### PR DESCRIPTION
This test implements the `KHR_node_visibility` extension and sets the visibility of each node.

Open questions/tasks:

1. Should extension data be saved in each node's `info` dictionary? Since the extensions list is a dictionary of dictionaries, we may need to squash the two keys to fit into `info` (something like `{ "KHR_node_visibility: visibility": "true" }`)
2. I'm sure there's a better way to iterate through a `dictionary_t` than what I'm doing here 😅

> [!IMPORTANT]  
> `KHR_node_visibility` is **not** yet a merged and ratified glTF extension. See https://github.com/KhronosGroup/glTF/pull/2410 for more info