### PR TITLE
Pointers now come directly from interactors

### DIFF
--- a/StereoKitC/systems/input.cpp
+++ b/StereoKitC/systems/input.cpp
@@ -354,31 +354,6 @@ pointer_t *input_get_pointer(int32_t id) {
 
 ///////////////////////////////////////////
 
-int32_t input_pointer_count(input_source_ filter) {
-	int32_t result = 0;
-	for (int32_t i = 0; i < local.pointers.count; i++) {
-		if (local.pointers[i].source & filter)
-			result += 1;
-	}
-	return result;
-}
-
-///////////////////////////////////////////
-
-pointer_t input_pointer(int32_t index, input_source_ filter) {
-	int32_t curr = 0;
-	for (int32_t i = 0; i < local.pointers.count; i++) {
-		if (local.pointers[i].source & filter) {
-			if (curr == index)
-				return local.pointers[i];
-			curr += 1;
-		}
-	}
-	return {};
-}
-
-///////////////////////////////////////////
-
 void input_subscribe(input_source_ source, button_state_ input_event, void (*input_event_callback)(input_source_ source, button_state_ input_event, const pointer_t &in_pointer)) {
 	local.listeners.add({ source, input_event, input_event_callback });
 }

--- a/StereoKitC/ui/interactor_modes.cpp
+++ b/StereoKitC/ui/interactor_modes.cpp
@@ -490,4 +490,69 @@ button_state_ ui_last_element_hand_focused(handed_ hand) {
 	return button_state_inactive;
 }
 
+///////////////////////////////////////////
+
+pointer_t input_pointer(int32_t index, input_source_ filter) {
+	switch (local.input_mode) {
+	case interact_mode_controllers: {
+		int32_t start = 0;
+		if      (filter & input_source_hand      ) start = 0;
+		else if (filter & input_source_hand_left ) start = 0;
+		else if (filter & input_source_hand_right) start = 1;
+		int32_t idx = index + start;
+		if (idx > 1) return {};
+
+		interactor_id actor_id = local.controllers.far[idx];
+		pointer_t result   = {};
+		result.orientation = interactor_get_motion (actor_id).orientation;
+		result.state       = interactor_get        (actor_id)->pinch_state;
+		result.tracked     = interactor_get_tracked(actor_id);
+		result.ray         = { interactor_get(actor_id)->capsule_start_world, result.orientation * vec3_forward };
+		result.source      = idx == 0 ? input_source_hand_left : input_source_hand_right;
+		return result;
+	} break;
+	case interact_mode_hands: {
+		int32_t start = 0;
+		if      (filter & input_source_hand      ) start = 0;
+		else if (filter & input_source_hand_left ) start = 0;
+		else if (filter & input_source_hand_right) start = 1;
+		int32_t idx = index + start;
+		if (idx > 1) return {};
+
+		interactor_id actor_id = local.hands.far[idx];
+		pointer_t result   = {};
+		result.orientation = interactor_get_motion (actor_id).orientation;
+		result.state       = interactor_get        (actor_id)->pinch_state;
+		result.tracked     = interactor_get_tracked(actor_id);
+		result.ray         = { interactor_get(actor_id)->capsule_start_world, result.orientation * vec3_forward };
+		result.source      = idx == 0 ? input_source_hand_left : input_source_hand_right;
+		return result;
+	} break;
+	case interact_mode_mouse: {
+		if (index > 0) return {};
+		interactor_id actor_id = local.mouse.interactor;
+		pointer_t result   = {};
+		result.orientation = interactor_get_motion (actor_id).orientation;
+		result.state       = interactor_get        (actor_id)->pinch_state;
+		result.tracked     = interactor_get_tracked(actor_id);
+		result.ray         = { interactor_get(actor_id)->capsule_start_world, result.orientation * vec3_forward };
+		result.source      = input_source_hand_right;
+		return result;
+	} break;
+	default: return{};
+	}
+}
+
+
+///////////////////////////////////////////
+
+int32_t input_pointer_count(input_source_ filter) {
+	switch (local.input_mode) {
+	case interact_mode_controllers: return 2;
+	case interact_mode_hands:       return 2;
+	case interact_mode_mouse:       return 1;
+	default: return 0;
+	}
+}
+
 }


### PR DESCRIPTION
Pointers will be deprecated and removed in v0.4 in favor of the upcoming interactor APIs. In the meantime, this fix will help improve the current state of pointers and hopefully unblock #1234.

This fix focuses specifically on hand source pointers, so `InputSource.Hand`, `InputSource.HandLeft`, and `InputSource.HandRight` should work as expected. `Gaze` pointers have been removed for now, since `Input.Eyes` should cover the use case for now. `InputSource.CanPress` was also not included in this fix.