### PR TITLE
Remove remaining old pointer code

### DIFF
--- a/StereoKit/Native/NativeEnums.cs
+++ b/StereoKit/Native/NativeEnums.cs
@@ -896,14 +896,19 @@ namespace StereoKit
 		/// <summary>Matches with right hand input sources.</summary>
 		HandRight    = 1 << 2,
 		/// <summary>Matches with Gaze category input sources.</summary>
+		[Obsolete("Use Input.Eyes")]
 		Gaze         = 1 << 4,
 		/// <summary>Matches with the head gaze input source.</summary>
+		[Obsolete("Use Input.Eyes")]
 		GazeHead     = 1 << 5,
 		/// <summary>Matches with the eye gaze input source.</summary>
+		[Obsolete("Use Input.Eyes")]
 		GazeEyes     = 1 << 6,
 		/// <summary>Matches with mouse cursor simulated gaze as an input source.</summary>
+		[Obsolete("Use Input.Eyes")]
 		GazeCursor   = 1 << 7,
 		/// <summary>Matches with any input source that has an activation button!</summary>
+		[Obsolete]
 		CanPress     = 1 << 8,
 	}
 

--- a/StereoKit/Systems/Input.cs
+++ b/StereoKit/Systems/Input.cs
@@ -1,10 +1,9 @@
 ﻿// SPDX-License-Identifier: MIT
 // The authors below grant copyright rights under the MIT license:
-// Copyright (c) 2019-2024 Nick Klingensmith
-// Copyright (c) 2023-2024 Qualcomm Technologies, Inc.
+// Copyright (c) 2019-2025 Nick Klingensmith
+// Copyright (c) 2023-2025 Qualcomm Technologies, Inc.
 
 using System;
-using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Text;
 
@@ -329,17 +328,8 @@ namespace StereoKit
 	/// heads, mice and pointers!</summary>
 	public static class Input
 	{
-		struct EventListener
-		{
-			public InputSource source;
-			public BtnState type;
-			public Action<InputSource, BtnState, Pointer> callback;
-		}
-		static List<EventListener> listeners   = new List<EventListener>();
-		static bool                initialized = false;
-		static InputEventCallback  callback;
-		static Hand[]              hands       = new Hand[2] { new Hand(), new Hand() };
-		static Controller[]        controllers = new Controller[2] { new Controller(), new Controller() };
+		static Hand[]       hands       = new Hand[2] { new Hand(), new Hand() };
+		static Controller[] controllers = new Controller[2] { new Controller(), new Controller() };
 
 		/// <summary>If the device has eye tracking hardware and the app has
 		/// permission to use it, then this is the most recently tracked eye
@@ -654,24 +644,6 @@ namespace StereoKit
 		public static Pointer Pointer(int index, InputSource filter = InputSource.Any)
 			=> NativeAPI.input_pointer(index, filter);
 
-		static void Initialize()
-		{
-			initialized = true;
-			callback    = OnEvent; // This is stored in a persistent variable to force the callback from getting garbage collected!
-			NativeAPI.input_subscribe(InputSource.Any, BtnState.Any, callback);
-		}
-		static void OnEvent(InputSource source, BtnState evt, in Pointer pointer)
-		{
-			for (int i = 0; i < listeners.Count; i++)
-			{
-				if ((listeners[i].source & source) > 0 &&
-					(listeners[i].type   & evt) > 0)
-				{
-					listeners[i].callback(source, evt, pointer);
-				}
-			}
-		}
-
 		/// <summary>You can subscribe to input events from Pointer sources
 		/// here. StereoKit will call your callback and pass along a Pointer
 		/// that matches the position of that pointer at the moment the event
@@ -683,16 +655,9 @@ namespace StereoKit
 		/// is a bit flag.</param>
 		/// <param name="onEvent">The callback to call when the event occurs!
 		/// </param>
+		[Obsolete]
 		public static void Subscribe(InputSource eventSource, BtnState eventTypes, Action<InputSource, BtnState, Pointer> onEvent)
 		{
-			if (!initialized)
-				Initialize();
-
-			EventListener item;
-			item.callback = onEvent;
-			item.source   = eventSource;
-			item.type     = eventTypes;
-			listeners.Add(item);
 		}
 		/// <summary>Unsubscribes a listener from input events.</summary>
 		/// <param name="eventSource">The source this listener was originally
@@ -701,19 +666,9 @@ namespace StereoKit
 		/// registered for.</param>
 		/// <param name="onEvent">The callback this listener originally used.
 		/// </param>
+		[Obsolete]
 		public static void Unsubscribe(InputSource eventSource, BtnState eventTypes, Action<InputSource, BtnState, Pointer> onEvent)
 		{
-			if (!initialized)
-				Initialize();
-
-			for (int i = 0; i < listeners.Count; i++)
-			{
-				if (listeners[i].callback == onEvent && listeners[i].source == eventSource && listeners[i].type == eventTypes)
-				{
-					listeners.RemoveAt(i);
-					i--;
-				}
-			}
 		}
 		/// <summary>This function allows you to artifically insert an input
 		/// event, simulating any device source and event type you want.
@@ -724,12 +679,9 @@ namespace StereoKit
 		/// flag.</param>
 		/// <param name="pointer">The pointer data to pass along with this
 		/// simulated input event.</param>
-		public static void FireEvent  (InputSource eventSource, BtnState eventTypes, Pointer pointer)
+		[Obsolete]
+		public static void FireEvent(InputSource eventSource, BtnState eventTypes, Pointer pointer)
 		{
-			IntPtr arg = Marshal.AllocCoTaskMem(Marshal.SizeOf<Pointer>());
-			Marshal.StructureToPtr(pointer, arg, false);
-			NativeAPI.input_fire_event(eventSource, eventTypes, arg);
-			Marshal.FreeCoTaskMem(arg);
 		}
 	}
 }

--- a/StereoKitC/hands/hand_mouse.cpp
+++ b/StereoKitC/hands/hand_mouse.cpp
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: MIT */
 /* The authors below grant copyright rights under the MIT license:
- * Copyright (c) 2019-2024 Nick Klingensmith
- * Copyright (c) 2024 Qualcomm Technologies, Inc.
+ * Copyright (c) 2019-2025 Nick Klingensmith
+ * Copyright (c) 2024-2025 Qualcomm Technologies, Inc.
  */
 
 #include "../stereokit.h"
@@ -14,7 +14,6 @@ namespace sk {
 
 ///////////////////////////////////////////
 
-int     mouse_pointer_id;
 float   mouse_hand_scroll  = 0;
 handed_ mouse_active_hand  = handed_right;
 int     mouse_active_state = 0;
@@ -28,8 +27,6 @@ bool hand_mouse_available() {
 ///////////////////////////////////////////
 
 void hand_mouse_init() {
-	mouse_pointer_id = input_hand_pointer_id[handed_right];
-
 	input_hand_sim(handed_left,  true, vec3_zero, quat_identity, false);
 	input_hand_sim(handed_right, true, vec3_zero, quat_identity, false);
 }
@@ -41,22 +38,12 @@ void hand_mouse_shutdown() {
 
 ///////////////////////////////////////////
 
-bool hand_mouse_update_position() {
-	ray_t ray = {};
-	const mouse_t *mouse = input_mouse();
+bool hand_mouse_pose(float scroll_distance, pose_t *out_pose) {
+	const mouse_t* mouse = input_mouse();
+	ray_t          ray   = {};
 	if (mouse->available && ray_from_mouse(mouse->pos, ray)) {
-		quat pointer_rot = quat_lookat(vec3_zero, ray.dir);
-
-		vec3 hand_pos     = ray.pos + ray.dir * (0.6f + mouse_hand_scroll * 0.00025f);
-		quat hand_rot     = (mouse_active_hand == handed_right
-			? quat_from_angles(40, 30, 90)
-			: quat_from_angles(40,-30,-90)) * pointer_rot;
-
-		pointer_t *pointer_cursor = input_get_pointer(mouse_pointer_id);
-		pointer_cursor->ray.dir     = ray.dir;
-		pointer_cursor->ray.pos     = hand_pos;
-		pointer_cursor->orientation = pointer_rot;
-
+		out_pose->orientation = quat_lookat(vec3_zero, ray.dir);
+		out_pose->position    = ray.pos + ray.dir * (0.6f + scroll_distance * 0.00025f);
 		return true;
 	}
 	return false;
@@ -77,10 +64,7 @@ void hand_mouse_update_frame() {
 
 	if (mouse_active_hand == handed_max) return;
 
-	mouse_pointer_id = input_hand_pointer_id[mouse_active_hand];
-
-	pointer_t *pointer_cursor = input_get_pointer(mouse_pointer_id);
-	hand_t    *hand           = input_hand_ref   (mouse_active_hand);
+	hand_t *hand = input_hand_ref(mouse_active_hand);
 	bool l_pressed     = false;
 	bool r_pressed     = false;
 	bool was_tracked   = hand->tracked_state & button_state_active;
@@ -89,42 +73,38 @@ void hand_mouse_update_frame() {
 
 	mouse_hand_scroll = mouse_hand_scroll + (input_mouse()->scroll - mouse_hand_scroll) * fminf(1, time_stepf_unscaled()*8);
 
-	bool hand_tracked = hand_mouse_update_position();
+	pose_t hand_pose    = pose_identity;
+	bool   hand_tracked = hand_mouse_pose(mouse_hand_scroll, &hand_pose);
 	if (hand_tracked) {
 		l_pressed = input_key(key_mouse_left ) & button_state_active;
 		r_pressed = simulator_is_simulating_movement() ? false : input_key(key_mouse_right) & button_state_active;
 	}
-	pointer_cursor->tracked = button_make_state(was_tracked, hand_tracked);
-	pointer_cursor->state   = input_key(key_mouse_left);
+	button_state_ tracked = button_make_state(was_tracked, hand_tracked);
 
 	quat hand_rot = (mouse_active_hand == handed_right
 		? quat_from_angles(40, 30, 90)
-		: quat_from_angles(40,-30,-90)) * pointer_cursor->orientation;
-	input_hand_sim(mouse_active_hand, true, pointer_cursor->ray.pos, hand_rot, hand_tracked);
-
-	input_source_ src = input_source_hand | input_source_hand_right;
-	if (was_tracked   != hand_tracked) input_fire_event( src, hand_tracked  ? button_state_just_active : button_state_just_inactive, *pointer_cursor);
-	if (was_l_pressed != l_pressed   ) input_fire_event( src, l_pressed     ? button_state_just_active : button_state_just_inactive, *pointer_cursor);
-	if (was_r_pressed != r_pressed   ) input_fire_event( src, r_pressed     ? button_state_just_active : button_state_just_inactive, *pointer_cursor);
+		: quat_from_angles(40,-30,-90)) * hand_pose.orientation;
+	input_hand_sim(mouse_active_hand, true, hand_pose.position, hand_rot, hand_tracked);
 
 	hand->pinch_state      = input_key(key_mouse_left );
 	hand->grip_state       = input_key(key_mouse_right);
 	hand->pinch_activation = (input_key(key_mouse_left ) & button_state_active) > 0;
 	hand->grip_activation  = (input_key(key_mouse_right) & button_state_active) > 0;
 
-	hand->aim       = { pointer_cursor->ray.pos, pointer_cursor->orientation };
-	hand->aim_ready = pointer_cursor->tracked;
+	hand->aim       = hand_pose;
+	hand->aim_ready = tracked;
 }
 
 ///////////////////////////////////////////
 
 void hand_mouse_update_poses() {
-	hand_mouse_update_position();
-	pointer_t *pointer_cursor = input_get_pointer(mouse_pointer_id);
-	quat       hand_rot       = (mouse_active_hand == handed_right
-		? quat_from_angles(40, 30, 90)
-		: quat_from_angles(40,-30,-90)) * pointer_cursor->orientation;
-	input_hand_sim_poses(mouse_active_hand, true, pointer_cursor->ray.pos, hand_rot);
+	pose_t hand_pose = pose_identity;
+	if (hand_mouse_pose(mouse_hand_scroll, &hand_pose)) {
+		quat hand_rot = (mouse_active_hand == handed_right
+			? quat_from_angles(40,  30,  90)
+			: quat_from_angles(40, -30, -90)) * hand_pose.orientation;
+		input_hand_sim_poses(mouse_active_hand, true, hand_pose.position, hand_rot);
+	}
 }
 
 }

--- a/StereoKitC/hands/hand_oxr_controller.cpp
+++ b/StereoKitC/hands/hand_oxr_controller.cpp
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: MIT */
 /* The authors below grant copyright rights under the MIT license:
- * Copyright (c) 2019-2024 Nick Klingensmith
- * Copyright (c) 2024 Qualcomm Technologies, Inc.
+ * Copyright (c) 2019-2025 Nick Klingensmith
+ * Copyright (c) 2024-2025 Qualcomm Technologies, Inc.
  */
 
 #include "../platforms/platform.h"
@@ -43,14 +43,9 @@ void hand_oxrc_update_pose(bool animate) {
 	for (uint32_t hand_id = 0; hand_id < handed_max; hand_id++) {
 		const controller_t *controller = input_controller ((handed_)hand_id);
 		hand_t             *hand       = input_hand_ref   ((handed_)hand_id);
-		pointer_t          *pointer    = input_get_pointer(input_hand_pointer_id[hand_id]);
 		// Update the hand point pose
-		pointer->tracked = controller->tracked;
 		if ((controller->tracked & button_state_active) > 0) {
-			hand->aim            = controller->aim;
-			pointer->ray.pos     = hand->aim.position;
-			pointer->ray.dir     = hand->aim.orientation * vec3_forward;
-			pointer->orientation = hand->aim.orientation;
+			hand->aim = controller->aim;
 		}
 
 		// Simulate the hand based on the state of the controller
@@ -71,9 +66,8 @@ void hand_oxrc_update_frame() {
 
 	// Now we'll get the current states of our actions, and store them for later use
 	for (uint32_t hand_id = 0; hand_id < handed_max; hand_id++) {
-		const controller_t *controller = input_controller ((handed_)hand_id);
-		hand_t             *hand       = input_hand_ref((handed_)hand_id);
-		pointer_t          *pointer    = input_get_pointer(input_hand_pointer_id[hand_id]);
+		const controller_t *controller = input_controller((handed_)hand_id);
+		hand_t             *hand       = input_hand_ref  ((handed_)hand_id);
 		bool                tracked    = controller->tracked & button_state_active;
 
 		hand->pinch_state      = button_make_state((hand->pinch_state & button_state_active) > 0, controller->trigger >= 0.5f);
@@ -81,29 +75,6 @@ void hand_oxrc_update_frame() {
 		hand->pinch_activation = fminf(1,controller->trigger/0.5f);
 		hand->grip_activation  = fminf(1,controller->grip   /0.5f);
 		hand->aim_ready        = controller->tracked;
-
-		// Get event poses, and fire our own events for them
-		pointer->state = button_make_state(pointer->state & button_state_active, controller->trigger > 0.5f);
-
-		if (hand->pinch_state & button_state_changed && tracked) {
-			pointer_t event_pointer = *pointer;
-			event_pointer.ray.pos     = controller->aim.position;
-			event_pointer.ray.dir     = controller->aim.orientation * vec3_forward;
-			event_pointer.orientation = controller->aim.orientation;
-
-			input_fire_event(event_pointer.source, hand->pinch_state & ~button_state_active, event_pointer);
-		}
-		if (hand->grip_state & button_state_changed && tracked) {
-			pointer_t event_pointer = *pointer;
-			event_pointer.ray.pos     = controller->aim.position;
-			event_pointer.ray.dir     = controller->aim.orientation * vec3_forward;
-			event_pointer.orientation = controller->aim.orientation;
-
-			input_fire_event(event_pointer.source, hand->grip_state & ~button_state_active, event_pointer);
-		}
-		if (hand->tracked_state & button_state_changed) {
-			input_fire_event(pointer->source, pointer->tracked & ~button_state_active, *pointer);
-		}
 	}
 }
 

--- a/StereoKitC/hands/input_hand.cpp
+++ b/StereoKitC/hands/input_hand.cpp
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: MIT */
 /* The authors below grant copyright rights under the MIT license:
- * Copyright (c) 2019-2024 Nick Klingensmith
- * Copyright (c) 2023-2024 Qualcomm Technologies, Inc.
+ * Copyright (c) 2019-2025 Nick Klingensmith
+ * Copyright (c) 2023-2025 Qualcomm Technologies, Inc.
  */
 
 #include "../stereokit.h"
@@ -55,7 +55,6 @@ array_t<hand_system_t> hand_sources;
 int32_t                hand_system = -1;
 hand_state_t           hand_state[2] = {};
 float                  hand_size_update = 0;
-int32_t                input_hand_pointer_id[handed_max] = {-1, -1};
 array_t<hand_sim_t>    hand_sim_poses   = {};
 hand_sim_id_t          hand_sim_next_id = 1;
 bool32_t               hand_finger_glow_visible = true;
@@ -174,8 +173,6 @@ void input_hand_init() {
 	sys.update_poses    = []() {};
 	input_hand_system_register(sys);
 
-	input_hand_pointer_id[handed_left ] = input_add_pointer(input_source_hand | input_source_hand_left  | input_source_can_press);
-	input_hand_pointer_id[handed_right] = input_add_pointer(input_source_hand | input_source_hand_right | input_source_can_press);
 	hand_finger_glow_visible = true;
 
 	float blend = 1;
@@ -328,11 +325,6 @@ void input_hand_state_update(handed_ handedness) {
 			hand.pinch_pt = matrix_transform_pt(from_relative, hand_state[handedness].pinch_pt_relative);
 		}
 	}
-
-	pointer_t* pointer = input_get_pointer(input_hand_pointer_id[handedness]);
-	pointer->state = button_make_state(
-		(pointer->state & button_state_active) != 0,
-		((pointer->tracked & button_state_active) != 0) && ((hand.pinch_state & button_state_active) != 0));
 }
 
 ///////////////////////////////////////////

--- a/StereoKitC/hands/input_hand.h
+++ b/StereoKitC/hands/input_hand.h
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: MIT */
 /* The authors below grant copyright rights under the MIT license:
- * Copyright (c) 2019-2024 Nick Klingensmith
- * Copyright (c) 2024 Qualcomm Technologies, Inc.
+ * Copyright (c) 2019-2025 Nick Klingensmith
+ * Copyright (c) 2024-2025 Qualcomm Technologies, Inc.
  */
 
 #pragma once
@@ -53,8 +53,6 @@ typedef struct hand_system_t {
 	void       (*update_frame)   ();
 	void       (*update_poses)   ();
 } hand_system_t;
-
-extern int32_t input_hand_pointer_id[handed_max];
 
 void input_hand_init    ();
 void input_hand_shutdown();

--- a/StereoKitC/stereokit.h
+++ b/StereoKitC/stereokit.h
@@ -2279,9 +2279,9 @@ SK_API hand_sim_id_t         input_hand_sim_pose_add         (const pose_t* in_a
 SK_API void                  input_hand_sim_pose_remove      (hand_sim_id_t id);
 SK_API void                  input_hand_sim_pose_clear       (void);
 
-SK_API void                  input_subscribe                 (input_source_ source, button_state_ input_event, void (*input_event_callback)(input_source_ source, button_state_ input_event, const sk_ref(pointer_t) in_pointer));
-SK_API void                  input_unsubscribe               (input_source_ source, button_state_ input_event, void (*input_event_callback)(input_source_ source, button_state_ input_event, const sk_ref(pointer_t) in_pointer));
-SK_API void                  input_fire_event                (input_source_ source, button_state_ input_event, const sk_ref(pointer_t) pointer);
+SK_API SK_DEPRECATED void    input_subscribe                 (input_source_ source, button_state_ input_event, void (*input_event_callback)(input_source_ source, button_state_ input_event, const sk_ref(pointer_t) in_pointer));
+SK_API SK_DEPRECATED void    input_unsubscribe               (input_source_ source, button_state_ input_event, void (*input_event_callback)(input_source_ source, button_state_ input_event, const sk_ref(pointer_t) in_pointer));
+SK_API SK_DEPRECATED void    input_fire_event                (input_source_ source, button_state_ input_event, const sk_ref(pointer_t) pointer);
 
 ///////////////////////////////////////////
 

--- a/StereoKitC/systems/input.cpp
+++ b/StereoKitC/systems/input.cpp
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: MIT */
 /* The authors below grant copyright rights under the MIT license:
- * Copyright (c) 2019-2024 Nick Klingensmith
- * Copyright (c) 2024 Qualcomm Technologies, Inc.
+ * Copyright (c) 2019-2025 Nick Klingensmith
+ * Copyright (c) 2024-2025 Qualcomm Technologies, Inc.
  */
 
 #include "../stereokit.h"
@@ -52,8 +52,6 @@ struct evt_xy_t {
 };
 
 struct input_state_t {
-	array_t<input_event_t>listeners;
-	array_t<pointer_t>    pointers;
 	mouse_t               mouse_data;
 	controller_t          controllers[2];
 	bool                  controller_hand[2];
@@ -129,8 +127,6 @@ void input_shutdown() {
 
 	input_render_shutdown();
 	input_keyboard_shutdown();
-	local.pointers .free();
-	local.listeners.free();
 	input_hand_shutdown();
 	local = {};
 }
@@ -342,42 +338,21 @@ void input_step_late() {
 
 ///////////////////////////////////////////
 
-int32_t input_add_pointer(input_source_ source) {
-	return local.pointers.add({ source, button_state_inactive });
-}
-
-///////////////////////////////////////////
-
-pointer_t *input_get_pointer(int32_t id) {
-	return &local.pointers[id];
-}
-
-///////////////////////////////////////////
-
 void input_subscribe(input_source_ source, button_state_ input_event, void (*input_event_callback)(input_source_ source, button_state_ input_event, const pointer_t &in_pointer)) {
-	local.listeners.add({ source, input_event, input_event_callback });
+	log_warnf("Input events are obsolete");
+
 }
 
 ///////////////////////////////////////////
 
 void input_unsubscribe(input_source_ source, button_state_ input_event, void (*input_event_callback)(input_source_ source, button_state_ input_event, const pointer_t &in_pointer)) {
-	for (int32_t i = local.listeners.count-1; i >= 0; i--) {
-		if (local.listeners[i].source         == source      &&
-			local.listeners[i].event          == input_event &&
-			local.listeners[i].event_callback == input_event_callback) {
-			local.listeners.remove(i);
-		}
-	}
+	log_warnf("Input events are obsolete");
 }
 
 ///////////////////////////////////////////
 
 void input_fire_event(input_source_ source, button_state_ input_event, const pointer_t &pointer) {
-	for (int32_t i = 0; i < local.listeners.count; i++) {
-		if (local.listeners[i].source & source && local.listeners[i].event & input_event) {
-			local.listeners[i].event_callback(source, input_event, pointer);
-		}
-	}
+	log_warnf("Input events are obsolete");
 }
 
 ///////////////////////////////////////////

--- a/StereoKitC/systems/input.h
+++ b/StereoKitC/systems/input.h
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: MIT */
 /* The authors below grant copyright rights under the MIT license:
- * Copyright (c) 2019-2024 Nick Klingensmith
- * Copyright (c) 2024 Qualcomm Technologies, Inc.
+ * Copyright (c) 2019-2025 Nick Klingensmith
+ * Copyright (c) 2024-2025 Qualcomm Technologies, Inc.
  */
 
 #pragma once
@@ -81,9 +81,6 @@ vec2          input_xy_get             (input_xy_     xy_type);
 void          input_reset              ();
 
 void          input_set_palm_offset    (handed_ hand, pose_t offset);
-
-int32_t       input_add_pointer(input_source_ source);
-pointer_t    *input_get_pointer(int32_t id);
 
 void body_make_shoulders(vec3 *out_left, vec3 *out_right);
 

--- a/StereoKitC/xr_backends/extensions/hand_tracking.cpp
+++ b/StereoKitC/xr_backends/extensions/hand_tracking.cpp
@@ -343,13 +343,6 @@ void xr_ext_hand_tracking_update_states() {
 		bool is_far       = vec2_distance_sq({inp_hand->aim.position.x, inp_hand->aim.position.z}, {head.position.x, head.position.z}) > (near_dist*near_dist);
 		bool was_ready    = (inp_hand->aim_ready & button_state_active) > 0;
 		inp_hand->aim_ready = button_make_state(was_ready, hand_tracked && ((was_ready && is_pinched) || (is_facing && is_far)));
-
-		// Update the hand pointer
-		pointer_t* pointer = input_get_pointer(input_hand_pointer_id[h]);
-		pointer->ray.pos     = inp_hand->aim.position;
-		pointer->ray.dir     = inp_hand->aim.orientation * vec3_forward;
-		pointer->orientation = inp_hand->aim.orientation;
-		pointer->tracked     = inp_hand->aim_ready;
 	}
 }
 

--- a/StereoKitC/xr_backends/simulator.cpp
+++ b/StereoKitC/xr_backends/simulator.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // The authors below grant copyright rights under the MIT license:
-// Copyright (c) 2019-2024 Nick Klingensmith
-// Copyright (c) 2023-2024 Qualcomm Technologies, Inc.
+// Copyright (c) 2019-2025 Nick Klingensmith
+// Copyright (c) 2023-2025 Qualcomm Technologies, Inc.
 
 #include "simulator.h"
 
@@ -26,7 +26,6 @@ namespace sk {
 
 ///////////////////////////////////////////
 
-int32_t        sim_gaze_pointer;
 vec3           sim_head_rot;
 vec3           sim_head_pos;
 pose_t         sim_bounds_pose;
@@ -60,7 +59,6 @@ bool simulator_init() {
 	sim_head_rot     = { -21, 0.0001f, 0 };
 	sim_head_pos     = { 0, 0.2f, 0.0f };
 	sim_mouse_look   = false;
-	sim_gaze_pointer = input_add_pointer(input_source_gaze | input_source_gaze_head);
 	sim_window       = -1;
 	sim_render_sys   = systems_find("FrameRender");
 
@@ -204,12 +202,6 @@ void simulator_step_begin() {
 			quat_lookat(vec3_zero, matrix_transform_dir(render_get_cam_final_inv(), ray.dir)) }, 
 			track_state_known, track_state_known);
 	}
-
-	pose_t     eyes_world   = input_pose_get_world(input_pose_eyes);
-	pointer_t *pointer_head = input_get_pointer(sim_gaze_pointer);
-	pointer_head->tracked = button_state_active;
-	pointer_head->ray.pos = eyes_world.position;
-	pointer_head->ray.dir = eyes_world.orientation * vec3_forward;
 
 	render_set_sim_origin(world_origin_offset);
 	render_set_sim_head  (pose_t{ sim_head_pos, quat_from_angles(sim_head_rot.x, sim_head_rot.y, sim_head_rot.z) });

--- a/StereoKitC/xr_backends/xr.cpp
+++ b/StereoKitC/xr_backends/xr.cpp
@@ -1,19 +1,12 @@
 // SPDX-License-Identifier: MIT
 // The authors below grant copyright rights under the MIT license:
-// Copyright (c) 2019-2023 Nick Klingensmith
-// Copyright (c) 2023 Qualcomm Technologies, Inc.
+// Copyright (c) 2019-2025 Nick Klingensmith
+// Copyright (c) 2023-2025 Qualcomm Technologies, Inc.
 
 #include "xr.h"
 #include "openxr.h"
-#include "../systems/input.h"
 
 namespace sk {
-
-	
-struct xr_backend_state_t {
-	int32_t eyes_pointer;
-};
-static xr_backend_state_t local = {};
 
 ///////////////////////////////////////////
 
@@ -22,9 +15,6 @@ bool xr_init() {
 #if defined(SK_XR_OPENXR)
 	result = openxr_init();
 #endif
-
-	local.eyes_pointer = input_add_pointer(input_source_gaze | (device_has_eye_gaze() ? input_source_gaze_eyes : input_source_gaze_head));
-
 	return result;
 }
 
@@ -34,27 +24,6 @@ void xr_step_begin() {
 #if defined(SK_XR_OPENXR)
 	openxr_step_begin();
 #endif
-
-	// Update the gaze pointer
-	pointer_t* pointer = input_get_pointer(local.eyes_pointer);
-	if (device_has_eye_gaze()) {
-		pose_t       pose = input_pose_get_world(input_pose_eyes);
-		track_state_ pos_tracked, rot_tracked;
-		input_pose_get_state(input_pose_eyes, &pos_tracked, &rot_tracked);
-
-		pointer->ray.pos     = pose.position;
-		pointer->ray.dir     = pose.orientation * vec3_forward;
-		pointer->orientation = pose.orientation;
-		pointer->tracked     = button_make_state(
-			(pointer->tracked & button_state_active) != 0,
-			pos_tracked != track_state_lost || rot_tracked != track_state_lost);
-	} else {
-		pose_t pose = input_head();
-		pointer->ray.pos     = pose.position;
-		pointer->ray.dir     = pose.orientation * vec3_forward;
-		pointer->orientation = pose.orientation;
-		pointer->tracked     = world_get_tracked();
-	}
 }
 
 ///////////////////////////////////////////
@@ -73,8 +42,6 @@ void xr_shutdown() {
 	openxr_shutdown();
 #else
 #endif
-
-	local = {};
 }
 
 }


### PR DESCRIPTION
The Pointer public API was hooked up directly to interactors in #1235. This PR removes all the remaining unattached pointer code, moves mouse hands away from pointers, and marks obsolete related parts of the Pointer API. Related to #1234