### PR TITLE
Auto-determine external textures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,8 +228,8 @@ add_compile_definitions(BASISD_SUPPORT_BC7_MODE5=0)
 #### sk_gpu - https://github.com/StereoKit/sk_gpu ####
 if (NOT SK_LOCAL_SK_GPU)
   CPMAddPackage( # We're scraping the comment after the NAME for some other scripts
-    NAME sk_gpu # 2025.6.27
-    URL https://github.com/StereoKit/sk_gpu/releases/download/v2025.6.27/sk_gpu.v2025.6.27.zip
+    NAME sk_gpu # 2025.7.11
+    URL https://github.com/StereoKit/sk_gpu/releases/download/v2025.7.11/sk_gpu.v2025.7.11.zip
   )
 else()
   # For building directly with in-progress sk_gpu changes, point this to your


### PR DESCRIPTION
This updates to a version of sk_gpu that for GL, will check textures to see if they're external, and if so, use the external texture target for them. See https://github.com/StereoKit/sk_gpu/commit/a3f6af1cbf016cdfe1e3f8a007be235662578fb2

External textures seemed to work previously, but may have experienced issues in more complex scenes, or when multiple external textures were present? ( See #1219 ) This change was tested with this project: https://github.com/maluoi/SKARCore, which previously worked, and continued to work, but has a simple scene with only one external texture. I don't have easy access to a good test case for this scenario, so I am uncertain if this particular fix is properly effective.