### PR TITLE
Add support for XR_KHR_maintenance1

### DIFF
--- a/StereoKitC/xr_backends/extensions/palm_pose.cpp
+++ b/StereoKitC/xr_backends/extensions/palm_pose.cpp
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: MIT */
 /* The authors below grant copyright rights under the MIT license:
  * Copyright (c) 2025 Nick Klingensmith
- * Copyright (c) 2025 Qualcomm Technologies, Inc.
+ * Copyright (c) 2025-2026 Qualcomm Technologies, Inc.
  */
 
 // This implements XR_EXT_palm_pose and XR_KHR_maintenance1
@@ -32,11 +32,27 @@ void       xr_ext_palm_pose_on_profile(void*, xr_interaction_profile_t* ref_prof
 ///////////////////////////////////////////
 
 void xr_ext_palm_pose_register() {
+	bool has_maint1 = ext_management_ext_available(XR_KHR_MAINTENANCE1_EXTENSION_NAME) && !ext_management_is_excluded(XR_KHR_MAINTENANCE1_EXTENSION_NAME);
+	bool has_palm   = ext_management_ext_available(XR_EXT_PALM_POSE_EXTENSION_NAME)   && !ext_management_is_excluded(XR_EXT_PALM_POSE_EXTENSION_NAME);
+
+	if (!has_maint1 && !has_palm)
+		return;
+
+	bool user_wants_palm   = ext_management_is_user_requested(XR_EXT_PALM_POSE_EXTENSION_NAME);
+	bool user_wants_maint1 = ext_management_is_user_requested(XR_KHR_MAINTENANCE1_EXTENSION_NAME);
+
 	xr_system_t sys = {};
-	sys.request_exts[sys.request_ext_count++] = XR_KHR_MAINTENANCE1_EXTENSION_NAME;
-	sys.request_exts[sys.request_ext_count++] = XR_EXT_PALM_POSE_EXTENSION_NAME;
-	sys.evt_initialize  = { xr_ext_palm_pose_initialize };
-	sys.evt_profile     = { xr_ext_palm_pose_on_profile };
+	// Only force legacy palm_pose if the user specifically requested it and NOT maintenance1
+	if (user_wants_palm && !user_wants_maint1 && has_palm) {
+		sys.request_exts[sys.request_ext_count++] = XR_EXT_PALM_POSE_EXTENSION_NAME;
+	} else if (has_maint1) {
+		sys.request_exts[sys.request_ext_count++] = XR_KHR_MAINTENANCE1_EXTENSION_NAME;
+	} else {
+		sys.request_exts[sys.request_ext_count++] = XR_EXT_PALM_POSE_EXTENSION_NAME;
+	}
+
+	sys.evt_initialize = { xr_ext_palm_pose_initialize };
+	sys.evt_profile    = { xr_ext_palm_pose_on_profile };
 	ext_management_sys_register(sys);
 }
 
@@ -64,7 +80,7 @@ void xr_ext_palm_pose_on_profile(void*, xr_interaction_profile_t* ref_profile) {
 	// This function will only get called if the system was successfully
 	// initialized.
 
-	const char* path = local.khr_maintenance1_available ?  "grip_surface/pose" : "palm_ext/pose";
+	const char* path = local.khr_maintenance1_available ? "grip_surface/pose" : "palm_ext/pose";
 
 	// KHR_maintenance1 and EXT_palm_pose apply to all interaction profiles that use /user/hand/*
 	// paths, so we need to check if the top level path matches.

--- a/StereoKitC/xr_backends/extensions/palm_pose.cpp
+++ b/StereoKitC/xr_backends/extensions/palm_pose.cpp
@@ -4,8 +4,9 @@
  * Copyright (c) 2025 Qualcomm Technologies, Inc.
  */
 
-// This implements XR_EXT_palm_pose
+// This implements XR_EXT_palm_pose and XR_KHR_maintenance1
 // https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#XR_EXT_palm_pose
+// https://registry.khronos.org/OpenXR/specs/1.1/html/xrspec.html#XR_KHR_maintenance1
 
 #include "palm_pose.h"
 #include "ext_management.h"
@@ -15,6 +16,13 @@
 ///////////////////////////////////////////
 
 namespace sk {
+
+///////////////////////////////////////////
+
+typedef struct xr_ext_palm_pose_state_t {
+	bool khr_maintenance1_available;
+} xr_ext_palm_pose_state_t;
+static xr_ext_palm_pose_state_t local = { };
 
 ///////////////////////////////////////////
 
@@ -36,7 +44,8 @@ void xr_ext_palm_pose_register() {
 
 xr_system_ xr_ext_palm_pose_initialize(void*) {
 	// Check if we got at least one of our extensions
-	if (!backend_openxr_ext_enabled(XR_KHR_MAINTENANCE1_EXTENSION_NAME) && !backend_openxr_ext_enabled(XR_EXT_PALM_POSE_EXTENSION_NAME))
+	local.khr_maintenance1_available = backend_openxr_ext_enabled(XR_KHR_MAINTENANCE1_EXTENSION_NAME);
+	if (!local.khr_maintenance1_available && !backend_openxr_ext_enabled(XR_EXT_PALM_POSE_EXTENSION_NAME))
 		return xr_system_fail;
 
 	// Snapdragon Spaces advertises the palm pose extension, but provides bad

--- a/StereoKitC/xr_backends/extensions/palm_pose.cpp
+++ b/StereoKitC/xr_backends/extensions/palm_pose.cpp
@@ -25,6 +25,7 @@ void       xr_ext_palm_pose_on_profile(void*, xr_interaction_profile_t* ref_prof
 
 void xr_ext_palm_pose_register() {
 	xr_system_t sys = {};
+	sys.request_exts[sys.request_ext_count++] = XR_KHR_MAINTENANCE1_EXTENSION_NAME;
 	sys.request_exts[sys.request_ext_count++] = XR_EXT_PALM_POSE_EXTENSION_NAME;
 	sys.evt_initialize  = { xr_ext_palm_pose_initialize };
 	sys.evt_profile     = { xr_ext_palm_pose_on_profile };
@@ -34,8 +35,8 @@ void xr_ext_palm_pose_register() {
 ///////////////////////////////////////////
 
 xr_system_ xr_ext_palm_pose_initialize(void*) {
-	// Check if we got our extension
-	if (!backend_openxr_ext_enabled(XR_EXT_PALM_POSE_EXTENSION_NAME))
+	// Check if we got at least one of our extensions
+	if (!backend_openxr_ext_enabled(XR_KHR_MAINTENANCE1_EXTENSION_NAME) && !backend_openxr_ext_enabled(XR_EXT_PALM_POSE_EXTENSION_NAME))
 		return xr_system_fail;
 
 	// Snapdragon Spaces advertises the palm pose extension, but provides bad
@@ -54,11 +55,12 @@ void xr_ext_palm_pose_on_profile(void*, xr_interaction_profile_t* ref_profile) {
 	// This function will only get called if the system was successfully
 	// initialized.
 
-	// EXT_palm_pose applies to all interaction profiles that use /user/hand/*
-	// paths, so we need to check if the top level path matches.
-	if (string_eq("/user/hand/left",  ref_profile->top_level_path)) ref_profile->binding[ref_profile->binding_ct++] = { xra_type_pose, input_pose_l_palm, "palm_ext/pose" };
-	if (string_eq("/user/hand/right", ref_profile->top_level_path)) ref_profile->binding[ref_profile->binding_ct++] = { xra_type_pose, input_pose_r_palm, "palm_ext/pose" };
+	const char* path = local.khr_maintenance1_available ?  "grip_surface/pose" : "palm_ext/pose";
 
+	// KHR_maintenance1 and EXT_palm_pose apply to all interaction profiles that use /user/hand/*
+	// paths, so we need to check if the top level path matches.
+	if (string_eq("/user/hand/left",  ref_profile->top_level_path)) ref_profile->binding[ref_profile->binding_ct++] = { xra_type_pose, input_pose_l_palm, path };
+	if (string_eq("/user/hand/right", ref_profile->top_level_path)) ref_profile->binding[ref_profile->binding_ct++] = { xra_type_pose, input_pose_r_palm, path };
 }
 
 } // namespace sk

--- a/StereoKitC/xr_backends/openxr_input.cpp
+++ b/StereoKitC/xr_backends/openxr_input.cpp
@@ -293,7 +293,7 @@ xr_system_ oxri_init(void*) {
 	// Suggest all our input profiles
 	local.registration_finished = true;
 	// We can only submit one binding per interaction profile, so here we
-	// combine each uniqu top-level path belonging to the same interaction
+	// combine each unique top-level path belonging to the same interaction
 	// profile.
 
 	// Figure out all the unique interaction profiles


### PR DESCRIPTION
Adds support for `/input/grip_surface/pose` provided by https://registry.khronos.org/OpenXR/specs/1.1/html/xrspec.html#XR_KHR_maintenance1

The relevant pieces of the 1.0 spec:

>When the [XR_KHR_maintenance1](https://registry.khronos.org/OpenXR/specs/1.1/html/xrspec.html#XR_KHR_maintenance1) extension is available and enabled, this interaction profile must also support
> * …/input/grip_surface/pose

> The pose of …/input/palm_ext/pose and …/input/grip_surface/pose must be identical.