### PR TITLE
ShadowMap demo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,8 +228,8 @@ add_compile_definitions(BASISD_SUPPORT_BC7_MODE5=0)
 #### sk_gpu - https://github.com/StereoKit/sk_gpu ####
 if (NOT SK_LOCAL_SK_GPU)
   CPMAddPackage( # We're scraping the comment after the NAME for some other scripts
-    NAME sk_gpu # 2025.7.18
-    URL https://github.com/StereoKit/sk_gpu/releases/download/v2025.7.18/sk_gpu.v2025.7.18.zip
+    NAME sk_gpu # 2025.7.30
+    URL https://github.com/StereoKit/sk_gpu/releases/download/v2025.7.30/sk_gpu.v2025.7.30.zip
   )
 else()
   # For building directly with in-progress sk_gpu changes, point this to your

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,8 +228,8 @@ add_compile_definitions(BASISD_SUPPORT_BC7_MODE5=0)
 #### sk_gpu - https://github.com/StereoKit/sk_gpu ####
 if (NOT SK_LOCAL_SK_GPU)
   CPMAddPackage( # We're scraping the comment after the NAME for some other scripts
-    NAME sk_gpu # 2025.7.30
-    URL https://github.com/StereoKit/sk_gpu/releases/download/v2025.7.30/sk_gpu.v2025.7.30.zip
+    NAME sk_gpu # 2025.8.7
+    URL https://github.com/StereoKit/sk_gpu/releases/download/v2025.8.7/sk_gpu.v2025.8.7.zip
   )
 else()
   # For building directly with in-progress sk_gpu changes, point this to your

--- a/Examples/Assets/Shaders/basic_shadow.hlsl
+++ b/Examples/Assets/Shaders/basic_shadow.hlsl
@@ -20,11 +20,11 @@ cbuffer shadow_buffer : register(b12) {
 	float3 light_color;
 	float bias_far;
 };
-Texture2D              shadow_map   : register(t12);
+Texture2DArray         shadow_map   : register(t12);
 SamplerComparisonState shadow_map_s : register(s12);
 
-Texture2D              shadow_map_far   : register(t13);
-SamplerComparisonState shadow_map_far_s : register(s13);
+//Texture2D              shadow_map_far   : register(t13);
+//SamplerComparisonState shadow_map_far_s : register(s13);
 
 ///////////////////////////////////////////
 
@@ -84,32 +84,32 @@ psIn vs(vsIn input, sk_vs_input_t sk_in) {
 // Fast
 float shadow_factor_fast(float3 uv) {
 	if (any(uv.xy != saturate(uv.xy))) { // Check if this is the far cascade or the near one
-		return shadow_map_far.SampleCmpLevelZero(shadow_map_far_s, (uv.xy - 0.5) / far_scale + 0.5, uv.z);
+		return shadow_map.SampleCmpLevelZero(shadow_map_s, float3((uv.xy - 0.5) / far_scale + 0.5, 1), uv.z);
 	} else {
-		return shadow_map.SampleCmpLevelZero(shadow_map_s, uv.xy, uv.z);
+		return shadow_map.SampleCmpLevelZero(shadow_map_s, float3(uv.xy, 0), uv.z);
 	}
 }
 
 ///////////////////////////////////////////
 
 // 2x2 PCF filter
-float shadow_factor_pcf2(float3 uv, float scale) {
+/*float shadow_factor_pcf2(float3 uv, float scale) {
 	float shadow_factor = 0.0;
 	float radius        = shadowmap_size * scale;
 
-	float2 sample_offsets[4] = {
-		float2(-0.6,  0.9),
-		float2( 0.9,  0.6),
-		float2( 0.6, -0.9),
-		float2(-0.9, -0.6)
-	};
-	
 	//float2 sample_offsets[4] = {
-	//	float2(-1,  1),
-	//	float2( 1,  1),
-	//	float2( 1, -1),
-	//	float2(-1, -1)
+	//	float2(-0.6,  0.9),
+	//	float2( 0.9,  0.6),
+	//	float2( 0.6, -0.9),
+	//	float2(-0.9, -0.6)
 	//};
+	
+	float2 sample_offsets[4] = {
+		float2(-1,  1),
+		float2( 1,  1),
+		float2( 1, -1),
+		float2(-1, -1)
+	};
 	
 	//float2 sample_offsets[4] = {
 	//	float2(-1,  0),
@@ -132,7 +132,8 @@ float shadow_factor_pcf2(float3 uv, float scale) {
 		}
 	}
 	return shadow_factor / 4.0;
-}
+}*/
+
 ///////////////////////////////////////////
 
 // Basic 3x3 PCF filter
@@ -144,7 +145,7 @@ float shadow_factor_pcf3(float3 uv, float scale) {
 	if (any(uv.xy != saturate(uv.xy))) { // Check if this is the far cascade or the near one
 		// Convert this to the far cascade space
 		uv.xy = (uv.xy - 0.5) / far_scale + 0.5;
-		return shadow_map_far.SampleCmpLevelZero(shadow_map_far_s, uv.xy, uv.z);
+		return shadow_map.SampleCmpLevelZero(shadow_map_s, float3(uv.xy, 1), uv.z);
 		//for (int x = -1; x <= 1; x++) {
 		//	for (int y = -1; y <= 1; y++) {
 		//		float2 offset = float2(x, y) * radius;
@@ -156,7 +157,7 @@ float shadow_factor_pcf3(float3 uv, float scale) {
 		for (int x = -1; x <= 1; x++) {
 			for (int y = -1; y <= 1; y++) {
 				float2 offset = float2(x, y) * radius;
-				shadow_factor += shadow_map.SampleCmpLevelZero(shadow_map_s, uv.xy + offset, uv.z);
+				shadow_factor += shadow_map.SampleCmpLevelZero(shadow_map_s, float3(uv.xy + offset, 0), uv.z);
 			}
 		}
 		return shadow_factor / 9.0;
@@ -165,7 +166,7 @@ float shadow_factor_pcf3(float3 uv, float scale) {
 
 ///////////////////////////////////////////
 
-float shadow_factor_pcf5(float3 uv, float scale) {
+/*float shadow_factor_pcf5(float3 uv, float scale) {
 	float shadow_factor = 0.0;
 	float radius        = shadowmap_size * scale;
 
@@ -201,7 +202,7 @@ float shadow_factor_pcf_rotated_world(float3 world, float3 uv, float scale) {
 		shadow_factor += shadow_map.SampleCmpLevelZero(shadow_map_s, sample_pos, uv.z);
 	}
 	return lerp(0.1, 1, shadow_factor / (float)samples);
-}
+}*/
 
 ///////////////////////////////////////////
 
@@ -333,7 +334,7 @@ float shadow_factor_rotated_early_out(float3 world, float3 uv) {
 
 ///////////////////////////////////////////
 
-float shadow_factor_pcss(float3 uv) {
+/*float shadow_factor_pcss(float3 uv) {
 	float biased_z = uv.z - shadowmap_bias;
 	float avg_blocker_depth = 0.0;
 	int   num_blockers = 0;
@@ -442,7 +443,7 @@ float shadow_factor_pcss2(float3 uv) {
 	//}
 	//
 	//return lerp(0.1, 1.0, shadow_factor / float(pcf_samples));
-}
+}*/
 
 ///////////////////////////////////////////
 

--- a/Examples/Assets/Shaders/basic_shadow.hlsl
+++ b/Examples/Assets/Shaders/basic_shadow.hlsl
@@ -11,20 +11,13 @@ SamplerState diffuse_s : register(s0);
 
 cbuffer shadow_buffer : register(b12) {
 	float4x4 shadowmap_transform;
-	float shadowmap_size;
-	float shadowmap_bias;
-	float shadowmap_bias_slope;
-	float depth_distance;
-	float3 light_direction;
-	float far_scale;
-	float3 light_color;
-	float bias_far;
+	float3   light_direction;
+	float    shadowmap_bias;
+	float3   light_color;
+	float    shadowmap_pixel_size;
 };
-Texture2DArray         shadow_map   : register(t12);
+Texture2D              shadow_map   : register(t12);
 SamplerComparisonState shadow_map_s : register(s12);
-
-//Texture2D              shadow_map_far   : register(t13);
-//SamplerComparisonState shadow_map_far_s : register(s13);
 
 ///////////////////////////////////////////
 
@@ -35,13 +28,13 @@ struct vsIn {
 	float4 col  : COLOR0;
 };
 struct psIn : sk_ps_input_t {
-	float4 pos   : SV_Position;
-	float2 uv    : TEXCOORD0;
-	float3 shadow_uv : TEXCOORD1;
-	float3 world : TEXCOORD2;
+	float4 pos          : SV_Position;
+	float2 uv           : TEXCOORD0;
+	float3 shadow_uv    : TEXCOORD1;
+	float3 world        : TEXCOORD2;
 	float  shadow_ndotl : TEXCOORD3;
-	float4 color : COLOR0;
-	float3 light : COLOR1;
+	float4 color        : COLOR0;
+	float3 ambient      : COLOR1;
 };
 
 ///////////////////////////////////////////
@@ -60,7 +53,7 @@ psIn vs(vsIn input, sk_vs_input_t sk_in) {
 	// Apply bias to the shadow map position directly in world space:
 	// https://c0de517e.blogspot.com/2011/05/shadowmap-bias-notes.html
 	float  slope      = saturate(min(1, sqrt(1 - o.shadow_ndotl * o.shadow_ndotl) / o.shadow_ndotl));
-	float3 bias       = normal * (shadowmap_bias + shadowmap_bias_slope * slope);
+	float3 bias       = normal * (shadowmap_bias * slope);
 	float4 shadow_pos = mul(float4(world.xyz + bias, 1), shadowmap_transform);
 	o.shadow_uv = float3(shadow_pos.xy, shadow_pos.z / shadow_pos.w);
 	// In GL, shadow_pos.z/shadow_pos.w seems to be in the range [-1, 1], so we
@@ -75,400 +68,45 @@ psIn vs(vsIn input, sk_vs_input_t sk_in) {
 	o.world      = world.xyz;
 	o.uv         = (input.uv * tex_trans.zw) + tex_trans.xy;
 	o.color      = color * input.col * sk_inst[id].color;
-	o.light      = sk_lighting(normal);
+	// We darken the ambient light by 0.5, since in the sample this shader is
+	// mixed with other materials that don't have the extra directional light.
+	// For real applications, this would be 1.0, but all Materials would use
+	// the directional light in addition to the ambient light.
+	o.ambient    = sk_lighting(normal) * 0.5;
 	return o;
 }
 
 ///////////////////////////////////////////
 
-// Fast
+// Alternative faster shadow
 float shadow_factor_fast(float3 uv) {
-	if (any(uv.xy != saturate(uv.xy))) { // Check if this is the far cascade or the near one
-		return shadow_map.SampleCmpLevelZero(shadow_map_s, float3((uv.xy - 0.5) / far_scale + 0.5, 1), uv.z);
-	} else {
-		return shadow_map.SampleCmpLevelZero(shadow_map_s, float3(uv.xy, 0), uv.z);
-	}
+	return shadow_map.SampleCmpLevelZero(shadow_map_s, uv.xy, uv.z);
 }
 
 ///////////////////////////////////////////
 
-// 2x2 PCF filter
-/*float shadow_factor_pcf2(float3 uv, float scale) {
-	float shadow_factor = 0.0;
-	float radius        = shadowmap_size * scale;
-
-	//float2 sample_offsets[4] = {
-	//	float2(-0.6,  0.9),
-	//	float2( 0.9,  0.6),
-	//	float2( 0.6, -0.9),
-	//	float2(-0.9, -0.6)
-	//};
-	
-	float2 sample_offsets[4] = {
-		float2(-1,  1),
-		float2( 1,  1),
-		float2( 1, -1),
-		float2(-1, -1)
-	};
-	
-	//float2 sample_offsets[4] = {
-	//	float2(-1,  0),
-	//	float2( 0,  1),
-	//	float2( 1,  0),
-	//	float2( 0, -1)
-	//};
-	
-	// Sample 2x2 grid around the shadow map coordinate
-	if (any(uv.xy != saturate(uv.xy))) { // Check if this is the far cascade or the near one
-		uv.xy = (uv.xy - 0.5) / far_scale + 0.5;
-		for (int i = 0; i < 4; i++) {
-			float2 offset = sample_offsets[i] * radius;
-			shadow_factor += shadow_map_far.SampleCmpLevelZero(shadow_map_far_s, uv.xy + offset, uv.z);
-		}
-	} else {
-		for (int i = 0; i < 4; i++) {
-			float2 offset = sample_offsets[i] * radius;
-			shadow_factor += shadow_map.SampleCmpLevelZero(shadow_map_s, uv.xy + offset, uv.z);
-		}
-	}
-	return shadow_factor / 4.0;
-}*/
-
-///////////////////////////////////////////
-
-// Basic 3x3 PCF filter
+// Basic 3x3 PCF filter, nice smooth edges, if a bit blurred
 float shadow_factor_pcf3(float3 uv, float scale) {
+	float radius        = shadowmap_pixel_size * scale;
 	float shadow_factor = 0.0;
-	float radius        = shadowmap_size * scale;
-	
-	// Sample 3x3 grid around the shadow map coordinate
-	if (any(uv.xy != saturate(uv.xy))) { // Check if this is the far cascade or the near one
-		// Convert this to the far cascade space
-		uv.xy = (uv.xy - 0.5) / far_scale + 0.5;
-		return shadow_map.SampleCmpLevelZero(shadow_map_s, float3(uv.xy, 1), uv.z);
-		//for (int x = -1; x <= 1; x++) {
-		//	for (int y = -1; y <= 1; y++) {
-		//		float2 offset = float2(x, y) * radius;
-		//		shadow_factor += shadow_map_far.SampleCmpLevelZero(shadow_map_far_s, uv.xy + offset, uv.z);
-		//	}
-		//}
-		//return shadow_factor / 9.0;
-	} else {
-		for (int x = -1; x <= 1; x++) {
-			for (int y = -1; y <= 1; y++) {
-				float2 offset = float2(x, y) * radius;
-				shadow_factor += shadow_map.SampleCmpLevelZero(shadow_map_s, float3(uv.xy + offset, 0), uv.z);
-			}
-		}
-		return shadow_factor / 9.0;
-	}
-}
-
-///////////////////////////////////////////
-
-/*float shadow_factor_pcf5(float3 uv, float scale) {
-	float shadow_factor = 0.0;
-	float radius        = shadowmap_size * scale;
-
-	// Sample 5x5 grid around the shadow map coordinate
-	for (int x = -2; x <= 2; x++)
-	{
-		for (int y = -2; y <= 2; y++)
-		{
+	for (int x = -1; x <= 1; x++) {
+		for (int y = -1; y <= 1; y++) {
 			float2 offset = float2(x, y) * radius;
 			shadow_factor += shadow_map.SampleCmpLevelZero(shadow_map_s, uv.xy + offset, uv.z);
 		}
 	}
-	return shadow_factor / 25.0;
+	return shadow_factor / 9.0;
 }
-
-///////////////////////////////////////////
-
-float random(float3 seed, int i) {
-	float4 seed4       = float4(seed, i);
-	float  dot_product = dot(seed4, float4(12.9898, 78.233, 45.164, 94.673));
-	return frac(sin(dot_product) * 43758.5453);
-}
-
-float shadow_factor_pcf_rotated_world(float3 world, float3 uv, float scale) {
-	//world = round(world * 1000) / 1000;
-	const int samples       = 16;
-	float     shadow_factor = 0.0;
-	float     radius        = shadowmap_size * scale * 2;
-	
-	// Now do the rest of the samples
-	for (int i = 0; i < samples; i++) {
-		float2 sample_pos = uv.xy + (float2(random(world, i * 2), random(world, i * 2 + 1)) - 0.5) * radius;
-		shadow_factor += shadow_map.SampleCmpLevelZero(shadow_map_s, sample_pos, uv.z);
-	}
-	return lerp(0.1, 1, shadow_factor / (float)samples);
-}*/
-
-///////////////////////////////////////////
-
-// https://www.shadertoy.com/view/4djSRW
-/*float hash12(float2 p) {
-	float3 p3 = frac(p.xyx * .1031);
-	p3 += dot(p3, p3.yzx + 33.33);
-	return frac((p3.x + p3.y) * p3.z);
-}
-
-float2 sample_offsets[16] = {
-	float2(-0.5, -0.5),
-	float2( 0.5, -0.5),
-	float2(-0.5,  0.5),
-	float2( 0.5,  0.5),
-
-	float2( 0.0, -0.5),
-	float2(-0.5,  0.0),
-	float2( 0.5,  0.0),
-	float2( 0.0,  0.5),
-
-	float2(-0.25, -0.25),
-	float2( 0.25, -0.25),
-	float2(-0.25,  0.25),
-	float2( 0.25,  0.25),
-
-	float2(-0.35,  0.15),
-	float2( 0.35, -0.15),
-	float2(-0.15, -0.35),
-	float2( 0.15,  0.35)
-};
-
-///////////////////////////////////////////
-
-float shadow_factor_rotated(float2 screen, float3 uv) {
-	// This doesn't seem to be producing great results, it can be improved.
-	float2 random_offset = hash12(screen);
-	random_offset = (random_offset - 0.5) * 2.0 * shadowmap_size;
-
-	const int samples = 16;
-	float shadow_factor = 0;
-	for (int i = 0; i < samples; i++) {
-		float2 sample_pos    = uv.xy + sample_offsets[i] * shadowmap_size + random_offset;
-		float  sampled_depth = shadow_map.Sample(shadow_map_s, sample_pos).r;
-		shadow_factor += (sampled_depth + shadowmap_bias < uv.z) ? 0.1 : 1.0;
-	}
-
-	return shadow_factor / (float)samples;
-}
-
-float random(float3 seed, int i) {
-	float4 seed4 = float4(seed, i);
-	float  dot_product = dot(seed4, float4(12.9898, 78.233, 45.164, 94.673));
-	return frac(sin(dot_product) * 43758.5453);
-}
-float3 quantize(float3 value, float levels) {
-	return round(value * levels) / levels;
-}
-float shadow_factor_rotated_world(float3 world, float3 uv) {
-	world = quantize(world, 100);
-	const int samples = 256;
-	const float shadow_penumbra = 16.0;
-	
-	// Check the first 4 points
-	int   occluded = 0;
-	float initial[4];
-	int   i = 0;
-	for (i = 0; i < 4; i++) {
-		float2 sample_pos    = uv.xy + (float2(random(world, i * 2), random(world, i * 2 + 1)) - 0.5) * shadow_penumbra * shadowmap_size;
-		float  sampled_depth = shadow_map.Sample(shadow_map_s, sample_pos).r;
-		if (sampled_depth + shadowmap_bias < uv.z)
-			occluded += 1;
-		initial[i] = sampled_depth;
-	}
-	
-	//if (occluded == 4) return 0;
-	//if (occluded == 0) return 1;
-
-	float2 max_depths = max(float2(initial[0], initial[1]), float2(initial[2], initial[3]));
-	float  max_depth  = max(max_depths.x, max_depths.y);
-	float2 min_depths = min(float2(initial[0], initial[1]), float2(initial[2], initial[3]));
-	float  min_depth  = min(min_depths.x, min_depths.y);
-	
-	float scale = lerp(1.0, shadow_penumbra, saturate(((max_depth - min_depth) * depth_distance) / 10));
-	//scale = 4.0;
-	//return scale / shadow_penumbra;
-	//return scale / 32.0;
-
-	// Now do the rest of the samples
-	for (i = 4; i < samples; i++)
-	{
-		float2 sample_pos    = uv.xy + (float2(random(world, i * 2), random(world, i * 2 + 1)) - 0.5) * scale * shadowmap_size;
-		float  sampled_depth = shadow_map.Sample(shadow_map_s, sample_pos).r;
-		if (sampled_depth + shadowmap_bias < uv.z)
-			occluded += 1;
-	}
-
-	return lerp(1, 0.1, (float) occluded / (float) samples);
-}
-
-float shadow_factor_rotated_early_out(float3 world, float3 uv) {
-	world = quantize(world, 1000);
-	const int samples = 8;
-	const int initial_samples = 8;
-	
-	int   i = 0;
-	int   occluded = 0;
-	//float initial[initial_samples];
-	//for (i = 0; i < initial_samples; i++) {
-	//	float2 sample_pos    = uv.xy + (float2(random(world, i * 2), random(world, i * 2 + 1)) - 0.5) * 2 * shadowmap_size;
-	//	float  sampled_depth = shadow_map.Sample(shadow_map_s, sample_pos).r;
-	//	if (sampled_depth + shadowmap_bias < uv.z)
-	//		occluded += 1;
-	//	initial[i] = sampled_depth;
-	//}
-	//
-	//if (occluded == initial_samples) return 0.1;
-	//if (occluded == 0) return 1;
-	
-	for (i = 0; i < samples; i++) {
-		float2 sample_pos    = uv.xy + (float2(random(world, i * 2), random(world, i * 2 + 1)) - 0.5) * 2 * shadowmap_size;
-		float  sampled_depth = shadow_map.Sample(shadow_map_s, sample_pos).r;
-		if (sampled_depth + shadowmap_bias < uv.z)
-			occluded += 1;
-	}
-
-	return lerp(1, 0.1, (float) occluded / (float) samples);
-}*/
-
-///////////////////////////////////////////
-
-/*float shadow_factor_pcss(float3 uv) {
-	float biased_z = uv.z - shadowmap_bias;
-	float avg_blocker_depth = 0.0;
-	int   num_blockers = 0;
-
-	// Use a small kernel to search for blockers
-	[unroll]
-	for (int x = -1; x <= 1; x++) {
-		for (int y = -1; y <= 1; y++) {
-			float2 sample_offset = float2(x, y) * shadowmap_size;
-			float sampled_depth = shadow_map.SampleCmpLevelZero(shadow_map_s, uv.xy + sample_offset * 5, biased_z);
-
-			if (sampled_depth > 0) { // If there is a blocker
-				avg_blocker_depth += sampled_depth * depth_distance;
-				num_blockers+=1;
-			}
-		}
-	}
-
-	// If no blockers were found, the pixel is fully lit
-	if (num_blockers == 0) return 0.1;
-	if (num_blockers == 9) return 1;
-
-	// Calculate average blocker depth
-	avg_blocker_depth /= (float)num_blockers;
-
-	// Estimate Penumbra Size
-	float light_radius  = 3.0; // Adjust this to match light source size
-	float penumbra_size = (((uv.z * depth_distance) - avg_blocker_depth) / avg_blocker_depth) * light_radius;
-	float shadow_factor = 0.0;
-	for (int x = -2; x <= 2; x++) {
-		for (int y = -2; y <= 2; y++) {
-			float2 offset = float2(x, y) * shadowmap_size * penumbra_size;
-			shadow_factor += shadow_map.SampleCmpLevelZero(shadow_map_s, uv.xy + offset, biased_z);
-		}
-	}
-	return lerp(0.1, 1, shadow_factor / 25.0);
-}
-
-///////////////////////////////////////////
-
-float shadow_factor_pcss2(float3 uv) {
-	const float2 poisson_disk[16] =
-	{
-		float2(-0.94201624, -0.39906216),
-		float2( 0.94558609, -0.76890725),
-		float2(-0.094184101,-0.92938870),
-		float2( 0.34495938,  0.29387760),
-		float2(-0.91588581,  0.45771432),
-		float2(-0.81544232, -0.87912464),
-		float2(-0.38277543,  0.27676845),
-		float2( 0.97484398,  0.75648379),
-		float2( 0.44323325, -0.97511554),
-		float2( 0.53742981, -0.47373420),
-		float2(-0.26496911, -0.41893023),
-		float2( 0.79197514,  0.19090188),
-		float2(-0.24188840,  0.99706507),
-		float2(-0.81409955,  0.91437590),
-		float2( 0.19984126,  0.78641367),
-		float2( 0.14383161, -0.14100790)
-	};
-	
-	float z_meters = uv.z * depth_distance;
-
-	// Step 1: Blocker search - find average depth of blockers
-	const float light_size_uv = 0.01 / 4; // Adjust this to match light source size
-	const float near_plane    = 4; // Near plane distance, adjust as needed
-	// This uses similar triangles to compute what
-	// area of the shadow map we should search
-	float search_radius = light_size_uv * (z_meters - near_plane) / z_meters;
-	float blocker_sum   = 0.0;
-	int   blocker_count = 0;
-
-	// Search in a grid pattern for blockers
-	const int search_samples = 16; // Adjust for quality/performance
-	for (int i = 0; i < search_samples; i++) {
-		// Use a spiral or Poisson disk pattern for better results
-		float2 offset = poisson_disk[i] * search_radius;
-		float  depth  = shadow_map.SampleLevel(diffuse_s, uv.xy + offset, 0).r;
-
-		if (depth < uv.z) {
-			blocker_sum += depth;
-			blocker_count++;
-		}
-	}
-	
-	// No blockers found - fully lit
-	if (blocker_count == 0) return 1.0;
-
-	// Step 2: Estimate penumbra width
-	float avg_blocker_depth = blocker_sum / float(blocker_count);
-	float penumbra_ratio    = (uv.z - avg_blocker_depth) / avg_blocker_depth;
-	
-	//return penumbra_width;
-
-	// Step 3: PCF with variable filter size based on penumbra
-	float filter_radius = light_size_uv * penumbra_ratio * near_plane / uv.z;
-	
-	return shadow_factor_pcf5(uv, (1 / shadowmap_size) * filter_radius);
-	
-	//float shadow_factor = 0.0;
-	//const int pcf_samples = 16; // Adjust for quality
-	//for (int i = 0; i < pcf_samples; i++)
-	//{
-	//	float2 offset = poisson_disk[i] * filter_radius;
-	//	shadow_factor += shadow_map.SampleCmpLevelZero(shadow_map_s, uv.xy + offset, biased_z);
-	//}
-	//
-	//return lerp(0.1, 1.0, shadow_factor / float(pcf_samples));
-}*/
 
 ///////////////////////////////////////////
 
 float4 ps(psIn input) : SV_TARGET {
 	float4 col = diffuse.Sample(diffuse_s, input.uv);
-	col.a = 1;
 	
-	float shadow_factor = input.shadow_ndotl;
-	if (shadow_factor <= 0.0) {
-		shadow_factor = 0.0;
-	} else {
-		//shadow_factor = min(shadow_factor, shadow_factor_fast(input.shadow_uv));
-		//shadow_factor = min(shadow_factor, shadow_factor_pcf2(input.shadow_uv, 1));
-		shadow_factor = min(shadow_factor, shadow_factor_pcf3(input.shadow_uv,1));
-		//shadow_factor = min(shadow_factor, shadow_factor_pcf5(input.shadow_uv, 1));
-		//shadow_factor = min(shadow_factor, shadow_factor_pcf3_opt(input.shadow_uv));
-		//float shadow_factor = shadow_factor_rotated(input.pos.xy, input.shadow_uv);
-		//float shadow_factor = shadow_factor_rotated_world(input.world, input.shadow_uv);
-		//shadow_factor = min(shadow_factor, shadow_factor_rotated_early_out(input.world, input.shadow_uv));
-		//shadow_factor = min(shadow_factor, shadow_factor_pcss2(input.shadow_uv));
-		//shadow_factor = min(shadow_factor, shadow_factor_pcf_rotated_world(input.world, input.shadow_uv, 1.0));
-
-	}
-
-	input.light     += shadow_factor * light_color;
-	input.color.rgb *= input.light;
-	return col * input.color;
+	float light = input.shadow_ndotl > 0
+		? min(input.shadow_ndotl, shadow_factor_pcf3(input.shadow_uv, 1))
+		: 0;
+	
+	col.rgb *= input.ambient + light * light_color;
+	return col;
 }

--- a/Examples/Assets/Shaders/basic_shadow.hlsl
+++ b/Examples/Assets/Shaders/basic_shadow.hlsl
@@ -13,14 +13,18 @@ cbuffer shadow_buffer : register(b12) {
 	float4x4 shadowmap_transform;
 	float shadowmap_size;
 	float shadowmap_bias;
+	float shadowmap_bias_slope;
 	float depth_distance;
-	float dummy1;
 	float3 light_direction;
-	float dummy2;
+	float far_scale;
+	float3 light_color;
+	float bias_far;
 };
-Texture2D    shadow_map   : register(t12);
-//SamplerState shadow_map_s : register(s12);
+Texture2D              shadow_map   : register(t12);
 SamplerComparisonState shadow_map_s : register(s12);
+
+Texture2D              shadow_map_far   : register(t13);
+SamplerComparisonState shadow_map_far_s : register(s13);
 
 ///////////////////////////////////////////
 
@@ -35,7 +39,7 @@ struct psIn : sk_ps_input_t {
 	float2 uv    : TEXCOORD0;
 	float3 shadow_uv : TEXCOORD1;
 	float3 world : TEXCOORD2;
-	float3 normal : TEXCOORD3;
+	float  shadow_ndotl : TEXCOORD3;
 	float4 color : COLOR0;
 	float3 light : COLOR1;
 };
@@ -60,13 +64,20 @@ psIn vs(vsIn input, sk_vs_input_t sk_in) {
 #else
 	o.shadow_uv.xy = o.shadow_uv.xy * float2(0.5f, -0.5f) + 0.5;
 #endif
+	//o.shadow_uv.z -= shadowmap_bias;
 
-	o.normal = normalize(mul(input.norm, (float3x3)sk_inst[id].world));
 
+	float3 normal = normalize(mul(input.norm, (float3x3)sk_inst[id].world));
+	o.shadow_ndotl = dot(normal, light_direction);
+
+	float cos_alpha = saturate(o.shadow_ndotl);
+	float tan_alpha  = min(1, sqrt(1 - cos_alpha * cos_alpha) / cos_alpha);
+	o.shadow_uv.z -= shadowmap_bias +shadowmap_bias_slope * tan_alpha;
+	
 	o.world      = world.xyz;
 	o.uv         = (input.uv * tex_trans.zw) + tex_trans.xy;
 	o.color      = color * input.col * sk_inst[id].color;
-	o.light      = sk_lighting(o.normal);
+	o.light      = sk_lighting(normal);
 	return o;
 }
 
@@ -76,33 +87,132 @@ psIn vs(vsIn input, sk_vs_input_t sk_in) {
 float shadow_factor_fast(float3 uv) {
 	//float shadow_depth = shadow_map.Sample(shadow_map_s, uv.xy).r;
 	//return (shadow_depth + shadowmap_bias < uv.z) ? 0.1 : 1.0;
-	
-	//float shadow_depth = shadow_map.SampleCmpLevelZero(shadow_map_s, uv.xy, uv.z - shadowmap_bias);
 
-	return shadow_map.SampleCmpLevelZero(shadow_map_s, uv.xy, uv.z - shadowmap_bias);
+	if (any(uv.xy != saturate(uv.xy))) { // Check if this is the far cascade or the near one
+		return shadow_map_far.SampleCmpLevelZero(shadow_map_far_s, (uv.xy - 0.5) / far_scale + 0.5, uv.z);
+	} else {
+		return shadow_map.SampleCmpLevelZero(shadow_map_s, uv.xy, uv.z);
+	}
 }
 
 ///////////////////////////////////////////
 
-// Basic 3x3 PCF filter
-/*float shadow_factor_pcf3(float3 uv) {
+// 2x2 PCF filter
+float shadow_factor_pcf2(float3 uv, float scale) {
 	float shadow_factor = 0.0;
+	float radius        = shadowmap_size * scale;
 
-	// Sample 3x3 grid around the shadow map coordinate
-	for (int x = -1; x <= 1; x++) {
-		for (int y = -1; y <= 1; y++) {
-			float2 offset        = float2(x, y) * shadowmap_size;
-			float  sampled_depth = shadow_map.Sample(shadow_map_s, uv.xy + offset).r;
-			shadow_factor += (sampled_depth + shadowmap_bias < uv.z) ? 0.1 : 1.0;
+	float2 sample_offsets[4] = {
+		float2(-0.6,  0.9),
+		float2( 0.9,  0.6),
+		float2( 0.6, -0.9),
+		float2(-0.9, -0.6)
+	};
+	
+	//float2 sample_offsets[4] = {
+	//	float2(-1,  1),
+	//	float2( 1,  1),
+	//	float2( 1, -1),
+	//	float2(-1, -1)
+	//};
+	
+	//float2 sample_offsets[4] = {
+	//	float2(-1,  0),
+	//	float2( 0,  1),
+	//	float2( 1,  0),
+	//	float2( 0, -1)
+	//};
+	
+	// Sample 2x2 grid around the shadow map coordinate
+	if (any(uv.xy != saturate(uv.xy))) { // Check if this is the far cascade or the near one
+		uv.xy = (uv.xy - 0.5) / far_scale + 0.5;
+		for (int i = 0; i < 4; i++) {
+			float2 offset = sample_offsets[i] * radius;
+			shadow_factor += shadow_map_far.SampleCmpLevelZero(shadow_map_far_s, uv.xy + offset, uv.z);
+		}
+	} else {
+		for (int i = 0; i < 4; i++) {
+			float2 offset = sample_offsets[i] * radius;
+			shadow_factor += shadow_map.SampleCmpLevelZero(shadow_map_s, uv.xy + offset, uv.z);
 		}
 	}
-	return shadow_factor / 9.0;
+	return shadow_factor / 4.0;
+}
+///////////////////////////////////////////
+
+// Basic 3x3 PCF filter
+float shadow_factor_pcf3(float3 uv, float scale) {
+	float shadow_factor = 0.0;
+	float radius        = shadowmap_size * scale;
+	
+	// Sample 3x3 grid around the shadow map coordinate
+	if (any(uv.xy != saturate(uv.xy))) { // Check if this is the far cascade or the near one
+		// Convert this to the far cascade space
+		uv.xy = (uv.xy - 0.5) / far_scale + 0.5;
+		uv.z -= bias_far;
+		//return shadow_map_far.SampleCmpLevelZero(shadow_map_far_s, uv.xy, uv.z);
+		for (int x = -1; x <= 1; x++) {
+			for (int y = -1; y <= 1; y++) {
+				float2 offset = float2(x, y) * radius;
+				shadow_factor += shadow_map_far.SampleCmpLevelZero(shadow_map_far_s, uv.xy + offset, uv.z);
+			}
+		}
+		return shadow_factor / 9.0;
+	} else {
+		for (int x = -1; x <= 1; x++) {
+			for (int y = -1; y <= 1; y++) {
+				float2 offset = float2(x, y) * radius;
+				shadow_factor += shadow_map.SampleCmpLevelZero(shadow_map_s, uv.xy + offset, uv.z);
+			}
+		}
+		return shadow_factor / 9.0;
+	}
+}
+
+///////////////////////////////////////////
+
+float shadow_factor_pcf5(float3 uv, float scale) {
+	float shadow_factor = 0.0;
+	float radius        = shadowmap_size * scale;
+
+	// Sample 5x5 grid around the shadow map coordinate
+	for (int x = -2; x <= 2; x++)
+	{
+		for (int y = -2; y <= 2; y++)
+		{
+			float2 offset = float2(x, y) * radius;
+			shadow_factor += shadow_map.SampleCmpLevelZero(shadow_map_s, uv.xy + offset, uv.z);
+		}
+	}
+	return shadow_factor / 25.0;
+}
+
+///////////////////////////////////////////
+
+float random(float3 seed, int i) {
+	float4 seed4       = float4(seed, i);
+	float  dot_product = dot(seed4, float4(12.9898, 78.233, 45.164, 94.673));
+	return frac(sin(dot_product) * 43758.5453);
+}
+
+float shadow_factor_pcf_rotated_world(float3 world, float3 uv, float scale) {
+	//world = round(world * 1000) / 1000;
+	const int samples       = 16;
+	float     shadow_factor = 0.0;
+	float     radius        = shadowmap_size * scale * 2;
+	
+	// Now do the rest of the samples
+	for (int i = 0; i < samples; i++) {
+		float2 sample_pos = uv.xy + (float2(random(world, i * 2), random(world, i * 2 + 1)) - 0.5) * radius;
+		shadow_factor += shadow_map.SampleCmpLevelZero(shadow_map_s, sample_pos, uv.z);
+	}
+	return lerp(0.1, 1, shadow_factor / (float)samples);
 }
 
 ///////////////////////////////////////////
 
 // https://www.shadertoy.com/view/4djSRW
-float hash12(float2 p) {
+/*float hash12(float2 p) {
 	float3 p3 = frac(p.xyx * .1031);
 	p3 += dot(p3, p3.yzx + 33.33);
 	return frac((p3.x + p3.y) * p3.z);
@@ -225,11 +335,12 @@ float shadow_factor_rotated_early_out(float3 world, float3 uv) {
 	}
 
 	return lerp(1, 0.1, (float) occluded / (float) samples);
-}
+}*/
 
 ///////////////////////////////////////////
 
-float shadow_factor_pcss(float2 screen, float3 uv) {
+float shadow_factor_pcss(float3 uv) {
+	float biased_z = uv.z - shadowmap_bias;
 	float avg_blocker_depth = 0.0;
 	int   num_blockers = 0;
 
@@ -238,76 +349,131 @@ float shadow_factor_pcss(float2 screen, float3 uv) {
 	for (int x = -1; x <= 1; x++) {
 		for (int y = -1; y <= 1; y++) {
 			float2 sample_offset = float2(x, y) * shadowmap_size;
-			float  sampled_depth = shadow_map.Sample(shadow_map_s, uv.xy + sample_offset).r;
+			float sampled_depth = shadow_map.SampleCmpLevelZero(shadow_map_s, uv.xy + sample_offset * 5, biased_z);
 
-			if (sampled_depth + shadowmap_bias < uv.z) { // If there is a blocker
-				avg_blocker_depth += sampled_depth;
+			if (sampled_depth > 0) { // If there is a blocker
+				avg_blocker_depth += sampled_depth * depth_distance;
 				num_blockers+=1;
 			}
 		}
 	}
 
 	// If no blockers were found, the pixel is fully lit
-	if (num_blockers == 0) return 0.999;
+	if (num_blockers == 0) return 0.1;
+	if (num_blockers == 9) return 1;
 
 	// Calculate average blocker depth
 	avg_blocker_depth /= (float)num_blockers;
 
 	// Estimate Penumbra Size
 	float light_radius  = 3.0; // Adjust this to match light source size
-	float penumbra_size = ((uv.z - avg_blocker_depth) / avg_blocker_depth) * light_radius;
+	float penumbra_size = (((uv.z * depth_distance) - avg_blocker_depth) / avg_blocker_depth) * light_radius;
 	float shadow_factor = 0.0;
-	for (int x = -1; x <= 1; x++) {
-		for (int y = -1; y <= 1; y++) {
-			float2 offset        = float2(x, y) * shadowmap_size * penumbra_size;
-			float  sampled_depth = shadow_map.Sample(shadow_map_s, uv.xy + offset).r;
-			shadow_factor += (sampled_depth + shadowmap_bias < uv.z) ? 0.1 : 1.0;
+	for (int x = -2; x <= 2; x++) {
+		for (int y = -2; y <= 2; y++) {
+			float2 offset = float2(x, y) * shadowmap_size * penumbra_size;
+			shadow_factor += shadow_map.SampleCmpLevelZero(shadow_map_s, uv.xy + offset, biased_z);
 		}
 	}
-	return shadow_factor / 9.0;
+	return lerp(0.1, 1, shadow_factor / 25.0);
 }
 
 ///////////////////////////////////////////
 
-float shadow_factor_pcf3_opt(float3 uv) {
-	
-	static const float W3[3][3] = {
-		{ 0.5, 1.0, 0.5, },
-		{ 1.0, 1.0, 1.0, },
-		{ 0.5, 1.0, 0.5, }
+float shadow_factor_pcss2(float3 uv) {
+	const float2 poisson_disk[16] =
+	{
+		float2(-0.94201624, -0.39906216),
+		float2( 0.94558609, -0.76890725),
+		float2(-0.094184101,-0.92938870),
+		float2( 0.34495938,  0.29387760),
+		float2(-0.91588581,  0.45771432),
+		float2(-0.81544232, -0.87912464),
+		float2(-0.38277543,  0.27676845),
+		float2( 0.97484398,  0.75648379),
+		float2( 0.44323325, -0.97511554),
+		float2( 0.53742981, -0.47373420),
+		float2(-0.26496911, -0.41893023),
+		float2( 0.79197514,  0.19090188),
+		float2(-0.24188840,  0.99706507),
+		float2(-0.81409955,  0.91437590),
+		float2( 0.19984126,  0.78641367),
+		float2( 0.14383161, -0.14100790)
 	};
 	
-	float shadow_factor = 0.0;
-	for (int x = 0; x < 3; x++) {
-		for (int y = 0; y < 3; y++) {
-			float2 offset  = float2(x-1, y-1) * shadowmap_size;
-			shadow_factor += W3[x][y] * shadow_map.SampleCmpLevelZero(shadow_map_s, uv.xy + offset, uv.z - shadowmap_bias).r;
+	float z_meters = uv.z * depth_distance;
+
+	// Step 1: Blocker search - find average depth of blockers
+	const float light_size_uv = 0.01 / 4; // Adjust this to match light source size
+	const float near_plane    = 4; // Near plane distance, adjust as needed
+	// This uses similar triangles to compute what
+	// area of the shadow map we should search
+	float search_radius = light_size_uv * (z_meters - near_plane) / z_meters;
+	float blocker_sum   = 0.0;
+	int   blocker_count = 0;
+
+	// Search in a grid pattern for blockers
+	const int search_samples = 16; // Adjust for quality/performance
+	for (int i = 0; i < search_samples; i++) {
+		// Use a spiral or Poisson disk pattern for better results
+		float2 offset = poisson_disk[i] * search_radius;
+		float  depth  = shadow_map.SampleLevel(diffuse_s, uv.xy + offset, 0).r;
+
+		if (depth < uv.z) {
+			blocker_sum += depth;
+			blocker_count++;
 		}
 	}
-	return shadow_factor / 7.0;
-}*/
+	
+	// No blockers found - fully lit
+	if (blocker_count == 0) return 1.0;
+
+	// Step 2: Estimate penumbra width
+	float avg_blocker_depth = blocker_sum / float(blocker_count);
+	float penumbra_ratio    = (uv.z - avg_blocker_depth) / avg_blocker_depth;
+	
+	//return penumbra_width;
+
+	// Step 3: PCF with variable filter size based on penumbra
+	float filter_radius = light_size_uv * penumbra_ratio * near_plane / uv.z;
+	
+	return shadow_factor_pcf5(uv, (1 / shadowmap_size) * filter_radius);
+	
+	//float shadow_factor = 0.0;
+	//const int pcf_samples = 16; // Adjust for quality
+	//for (int i = 0; i < pcf_samples; i++)
+	//{
+	//	float2 offset = poisson_disk[i] * filter_radius;
+	//	shadow_factor += shadow_map.SampleCmpLevelZero(shadow_map_s, uv.xy + offset, biased_z);
+	//}
+	//
+	//return lerp(0.1, 1.0, shadow_factor / float(pcf_samples));
+}
 
 ///////////////////////////////////////////
 
 float4 ps(psIn input) : SV_TARGET {
 	float4 col = diffuse.Sample(diffuse_s, input.uv);
+	col.a = 1;
 	
-	float shadow_factor = dot(input.normal, light_direction);
-	//if (shadow_factor < 0.1) {
-	//	shadow_factor = 0.1;
-	//} else {
-
-		shadow_factor = shadow_factor_fast(input.shadow_uv);
+	float shadow_factor = input.shadow_ndotl;
+	if (shadow_factor < 0.0) {
+		shadow_factor = 0.0;
+	} else {
 		//shadow_factor = min(shadow_factor, shadow_factor_fast(input.shadow_uv));
-		//float shadow_factor = shadow_factor_pcf3(input.shadow_uv);
+		//shadow_factor = min(shadow_factor, shadow_factor_pcf2(input.shadow_uv, 1));
+		shadow_factor = min(shadow_factor, shadow_factor_pcf3(input.shadow_uv,1));
+		//shadow_factor = min(shadow_factor, shadow_factor_pcf5(input.shadow_uv, 1));
 		//shadow_factor = min(shadow_factor, shadow_factor_pcf3_opt(input.shadow_uv));
 		//float shadow_factor = shadow_factor_rotated(input.pos.xy, input.shadow_uv);
 		//float shadow_factor = shadow_factor_rotated_world(input.world, input.shadow_uv);
 		//shadow_factor = min(shadow_factor, shadow_factor_rotated_early_out(input.world, input.shadow_uv));
-		//float shadow_factor = shadow_factor_pcss(input.pos.xy, input.shadow_uv);
-	//}
+		//shadow_factor = min(shadow_factor, shadow_factor_pcss2(input.shadow_uv));
+		//shadow_factor = min(shadow_factor, shadow_factor_pcf_rotated_world(input.world, input.shadow_uv, 1.0));
 
-	input.light     *= shadow_factor;
+	}
+
+	input.light     += shadow_factor * light_color;
 	input.color.rgb *= input.light;
 	return col * input.color;
 }

--- a/Examples/Assets/Shaders/basic_shadow.hlsl
+++ b/Examples/Assets/Shaders/basic_shadow.hlsl
@@ -1,0 +1,313 @@
+#include "stereokit.hlsli"
+
+//--color:color = 1,1,1,1
+//--tex_trans   = 0,0,1,1
+//--diffuse     = white
+
+float4       color;
+float4       tex_trans;
+Texture2D    diffuse   : register(t0);
+SamplerState diffuse_s : register(s0);
+
+cbuffer shadow_buffer : register(b12) {
+	float4x4 shadowmap_transform;
+	float shadowmap_size;
+	float shadowmap_bias;
+	float depth_distance;
+	float dummy1;
+	float3 light_direction;
+	float dummy2;
+};
+Texture2D    shadow_map   : register(t12);
+//SamplerState shadow_map_s : register(s12);
+SamplerComparisonState shadow_map_s : register(s12);
+
+///////////////////////////////////////////
+
+struct vsIn {
+	float4 pos  : SV_Position;
+	float3 norm : NORMAL0;
+	float2 uv   : TEXCOORD0;
+	float4 col  : COLOR0;
+};
+struct psIn : sk_ps_input_t {
+	float4 pos   : SV_Position;
+	float2 uv    : TEXCOORD0;
+	float3 shadow_uv : TEXCOORD1;
+	float3 world : TEXCOORD2;
+	float3 normal : TEXCOORD3;
+	float4 color : COLOR0;
+	float3 light : COLOR1;
+};
+
+///////////////////////////////////////////
+
+psIn vs(vsIn input, sk_vs_input_t sk_in) {
+	psIn o;
+	uint view_id = sk_view_init(sk_in, o);
+	uint id      = sk_inst_id  (sk_in);
+
+	float4 world = mul(input.pos, sk_inst[id].world);
+	o.pos        = mul(world,     sk_viewproj[view_id]);
+
+	float4 shadow_pos = mul(float4(world.xyz, 1), shadowmap_transform);
+	o.shadow_uv = float3(shadow_pos.xy, shadow_pos.z / shadow_pos.w);
+	// In GL, shadow_pos.z/shadow_pos.w seems to be in the range [-1, 1], so we
+	// need to adjust it to [0, 1] to match D3D. There's also a flip in the Y
+	// direction, but that's more expected.
+#ifdef SK_OPENGL
+	o.shadow_uv    = o.shadow_uv    * 0.5                 + 0.5;
+#else
+	o.shadow_uv.xy = o.shadow_uv.xy * float2(0.5f, -0.5f) + 0.5;
+#endif
+
+	o.normal = normalize(mul(input.norm, (float3x3)sk_inst[id].world));
+
+	o.world      = world.xyz;
+	o.uv         = (input.uv * tex_trans.zw) + tex_trans.xy;
+	o.color      = color * input.col * sk_inst[id].color;
+	o.light      = sk_lighting(o.normal);
+	return o;
+}
+
+///////////////////////////////////////////
+
+// Fast
+float shadow_factor_fast(float3 uv) {
+	//float shadow_depth = shadow_map.Sample(shadow_map_s, uv.xy).r;
+	//return (shadow_depth + shadowmap_bias < uv.z) ? 0.1 : 1.0;
+	
+	//float shadow_depth = shadow_map.SampleCmpLevelZero(shadow_map_s, uv.xy, uv.z - shadowmap_bias);
+
+	return shadow_map.SampleCmpLevelZero(shadow_map_s, uv.xy, uv.z - shadowmap_bias);
+}
+
+///////////////////////////////////////////
+
+// Basic 3x3 PCF filter
+/*float shadow_factor_pcf3(float3 uv) {
+	float shadow_factor = 0.0;
+
+	// Sample 3x3 grid around the shadow map coordinate
+	for (int x = -1; x <= 1; x++) {
+		for (int y = -1; y <= 1; y++) {
+			float2 offset        = float2(x, y) * shadowmap_size;
+			float  sampled_depth = shadow_map.Sample(shadow_map_s, uv.xy + offset).r;
+			shadow_factor += (sampled_depth + shadowmap_bias < uv.z) ? 0.1 : 1.0;
+		}
+	}
+	return shadow_factor / 9.0;
+}
+
+///////////////////////////////////////////
+
+// https://www.shadertoy.com/view/4djSRW
+float hash12(float2 p) {
+	float3 p3 = frac(p.xyx * .1031);
+	p3 += dot(p3, p3.yzx + 33.33);
+	return frac((p3.x + p3.y) * p3.z);
+}
+
+float2 sample_offsets[16] = {
+	float2(-0.5, -0.5),
+	float2( 0.5, -0.5),
+	float2(-0.5,  0.5),
+	float2( 0.5,  0.5),
+
+	float2( 0.0, -0.5),
+	float2(-0.5,  0.0),
+	float2( 0.5,  0.0),
+	float2( 0.0,  0.5),
+
+	float2(-0.25, -0.25),
+	float2( 0.25, -0.25),
+	float2(-0.25,  0.25),
+	float2( 0.25,  0.25),
+
+	float2(-0.35,  0.15),
+	float2( 0.35, -0.15),
+	float2(-0.15, -0.35),
+	float2( 0.15,  0.35)
+};
+
+///////////////////////////////////////////
+
+float shadow_factor_rotated(float2 screen, float3 uv) {
+	// This doesn't seem to be producing great results, it can be improved.
+	float2 random_offset = hash12(screen);
+	random_offset = (random_offset - 0.5) * 2.0 * shadowmap_size;
+
+	const int samples = 16;
+	float shadow_factor = 0;
+	for (int i = 0; i < samples; i++) {
+		float2 sample_pos    = uv.xy + sample_offsets[i] * shadowmap_size + random_offset;
+		float  sampled_depth = shadow_map.Sample(shadow_map_s, sample_pos).r;
+		shadow_factor += (sampled_depth + shadowmap_bias < uv.z) ? 0.1 : 1.0;
+	}
+
+	return shadow_factor / (float)samples;
+}
+
+float random(float3 seed, int i) {
+	float4 seed4 = float4(seed, i);
+	float  dot_product = dot(seed4, float4(12.9898, 78.233, 45.164, 94.673));
+	return frac(sin(dot_product) * 43758.5453);
+}
+float3 quantize(float3 value, float levels) {
+	return round(value * levels) / levels;
+}
+float shadow_factor_rotated_world(float3 world, float3 uv) {
+	world = quantize(world, 100);
+	const int samples = 256;
+	const float shadow_penumbra = 16.0;
+	
+	// Check the first 4 points
+	int   occluded = 0;
+	float initial[4];
+	int   i = 0;
+	for (i = 0; i < 4; i++) {
+		float2 sample_pos    = uv.xy + (float2(random(world, i * 2), random(world, i * 2 + 1)) - 0.5) * shadow_penumbra * shadowmap_size;
+		float  sampled_depth = shadow_map.Sample(shadow_map_s, sample_pos).r;
+		if (sampled_depth + shadowmap_bias < uv.z)
+			occluded += 1;
+		initial[i] = sampled_depth;
+	}
+	
+	//if (occluded == 4) return 0;
+	//if (occluded == 0) return 1;
+
+	float2 max_depths = max(float2(initial[0], initial[1]), float2(initial[2], initial[3]));
+	float  max_depth  = max(max_depths.x, max_depths.y);
+	float2 min_depths = min(float2(initial[0], initial[1]), float2(initial[2], initial[3]));
+	float  min_depth  = min(min_depths.x, min_depths.y);
+	
+	float scale = lerp(1.0, shadow_penumbra, saturate(((max_depth - min_depth) * depth_distance) / 10));
+	//scale = 4.0;
+	//return scale / shadow_penumbra;
+	//return scale / 32.0;
+
+	// Now do the rest of the samples
+	for (i = 4; i < samples; i++)
+	{
+		float2 sample_pos    = uv.xy + (float2(random(world, i * 2), random(world, i * 2 + 1)) - 0.5) * scale * shadowmap_size;
+		float  sampled_depth = shadow_map.Sample(shadow_map_s, sample_pos).r;
+		if (sampled_depth + shadowmap_bias < uv.z)
+			occluded += 1;
+	}
+
+	return lerp(1, 0.1, (float) occluded / (float) samples);
+}
+
+float shadow_factor_rotated_early_out(float3 world, float3 uv) {
+	world = quantize(world, 1000);
+	const int samples = 8;
+	const int initial_samples = 8;
+	
+	int   i = 0;
+	int   occluded = 0;
+	//float initial[initial_samples];
+	//for (i = 0; i < initial_samples; i++) {
+	//	float2 sample_pos    = uv.xy + (float2(random(world, i * 2), random(world, i * 2 + 1)) - 0.5) * 2 * shadowmap_size;
+	//	float  sampled_depth = shadow_map.Sample(shadow_map_s, sample_pos).r;
+	//	if (sampled_depth + shadowmap_bias < uv.z)
+	//		occluded += 1;
+	//	initial[i] = sampled_depth;
+	//}
+	//
+	//if (occluded == initial_samples) return 0.1;
+	//if (occluded == 0) return 1;
+	
+	for (i = 0; i < samples; i++) {
+		float2 sample_pos    = uv.xy + (float2(random(world, i * 2), random(world, i * 2 + 1)) - 0.5) * 2 * shadowmap_size;
+		float  sampled_depth = shadow_map.Sample(shadow_map_s, sample_pos).r;
+		if (sampled_depth + shadowmap_bias < uv.z)
+			occluded += 1;
+	}
+
+	return lerp(1, 0.1, (float) occluded / (float) samples);
+}
+
+///////////////////////////////////////////
+
+float shadow_factor_pcss(float2 screen, float3 uv) {
+	float avg_blocker_depth = 0.0;
+	int   num_blockers = 0;
+
+	// Use a small kernel to search for blockers
+	[unroll]
+	for (int x = -1; x <= 1; x++) {
+		for (int y = -1; y <= 1; y++) {
+			float2 sample_offset = float2(x, y) * shadowmap_size;
+			float  sampled_depth = shadow_map.Sample(shadow_map_s, uv.xy + sample_offset).r;
+
+			if (sampled_depth + shadowmap_bias < uv.z) { // If there is a blocker
+				avg_blocker_depth += sampled_depth;
+				num_blockers+=1;
+			}
+		}
+	}
+
+	// If no blockers were found, the pixel is fully lit
+	if (num_blockers == 0) return 0.999;
+
+	// Calculate average blocker depth
+	avg_blocker_depth /= (float)num_blockers;
+
+	// Estimate Penumbra Size
+	float light_radius  = 3.0; // Adjust this to match light source size
+	float penumbra_size = ((uv.z - avg_blocker_depth) / avg_blocker_depth) * light_radius;
+	float shadow_factor = 0.0;
+	for (int x = -1; x <= 1; x++) {
+		for (int y = -1; y <= 1; y++) {
+			float2 offset        = float2(x, y) * shadowmap_size * penumbra_size;
+			float  sampled_depth = shadow_map.Sample(shadow_map_s, uv.xy + offset).r;
+			shadow_factor += (sampled_depth + shadowmap_bias < uv.z) ? 0.1 : 1.0;
+		}
+	}
+	return shadow_factor / 9.0;
+}
+
+///////////////////////////////////////////
+
+float shadow_factor_pcf3_opt(float3 uv) {
+	
+	static const float W3[3][3] = {
+		{ 0.5, 1.0, 0.5, },
+		{ 1.0, 1.0, 1.0, },
+		{ 0.5, 1.0, 0.5, }
+	};
+	
+	float shadow_factor = 0.0;
+	for (int x = 0; x < 3; x++) {
+		for (int y = 0; y < 3; y++) {
+			float2 offset  = float2(x-1, y-1) * shadowmap_size;
+			shadow_factor += W3[x][y] * shadow_map.SampleCmpLevelZero(shadow_map_s, uv.xy + offset, uv.z - shadowmap_bias).r;
+		}
+	}
+	return shadow_factor / 7.0;
+}*/
+
+///////////////////////////////////////////
+
+float4 ps(psIn input) : SV_TARGET {
+	float4 col = diffuse.Sample(diffuse_s, input.uv);
+	
+	float shadow_factor = dot(input.normal, light_direction);
+	//if (shadow_factor < 0.1) {
+	//	shadow_factor = 0.1;
+	//} else {
+
+		shadow_factor = shadow_factor_fast(input.shadow_uv);
+		//shadow_factor = min(shadow_factor, shadow_factor_fast(input.shadow_uv));
+		//float shadow_factor = shadow_factor_pcf3(input.shadow_uv);
+		//shadow_factor = min(shadow_factor, shadow_factor_pcf3_opt(input.shadow_uv));
+		//float shadow_factor = shadow_factor_rotated(input.pos.xy, input.shadow_uv);
+		//float shadow_factor = shadow_factor_rotated_world(input.world, input.shadow_uv);
+		//shadow_factor = min(shadow_factor, shadow_factor_rotated_early_out(input.world, input.shadow_uv));
+		//float shadow_factor = shadow_factor_pcss(input.pos.xy, input.shadow_uv);
+	//}
+
+	input.light     *= shadow_factor;
+	input.color.rgb *= input.light;
+	return col * input.color;
+}

--- a/Examples/StereoKitCTest/skt_lighting.cpp
+++ b/Examples/StereoKitCTest/skt_lighting.cpp
@@ -50,12 +50,14 @@ material_buffer_t        light_buffer    = {};
 ///////////////////////////////////////////
 
 void skt_lighting_init() {
-	light_buffer = material_buffer_create(3, sizeof(skt_light_buffer_t));
+	light_buffer = material_buffer_create(sizeof(skt_light_buffer_t));
+	render_global_buffer(3, light_buffer);
 }
 
 ///////////////////////////////////////////
 
 void skt_lighting_shutdown() {
+	render_global_buffer(3, nullptr);
 	material_buffer_release(light_buffer);
 	skt_lighting_clear_lights();
 }

--- a/Examples/StereoKitTest/Demos/DemoShadows.cs
+++ b/Examples/StereoKitTest/Demos/DemoShadows.cs
@@ -10,74 +10,158 @@ class DemoShadows : ITest
 		public Matrix transform;
 		public float texSize;
 		public float bias;
+		public float biasSlope;
 		public float depthDistance;
-		float dummy;
 		public Vec3 lightDirection;
-		float dummy2;
+		public float farScale;
+		public Vec3 lightColor;
+		public float biasFar;
 	}
 
-	Tex[]    shadowMap  = new Tex[2];
-	Material shadowMat  = new Material("Shaders/basic_shadow.hlsl");
+	Tex[] shadowMap    = new Tex[2];
+	Tex[] shadowMapFar = new Tex[2];
 	Model model;
 	MaterialBuffer<ShadowBuffer> shadowBuffer;
 	ShadowBuffer last;
+	Mesh cylinder;
+	Material shadowMat;
+
+	SphericalHarmonics oldLighting;
+	Tex oldTex;
 
 	public void Initialize()
 	{ 
 		shadowBuffer = new MaterialBuffer<ShadowBuffer>(12);
+		const int resolution = 512;
 		for (int i = 0; i < shadowMap.Length; i++) {
-			shadowMap[i] = Tex.RenderTarget(2048, 2048, 1, TexFormat.None, TexFormat.Depth16);
-			shadowMap[i].SampleMode = TexSample.Point;
-			shadowMap[i].Id = "app/shadow/zbuffer/"+i;
+			shadowMap[i] = Tex.RenderTarget(resolution, resolution, 1, TexFormat.None, TexFormat.Depth16);
+			shadowMap[i].SampleMode  = TexSample.Linear;
+			shadowMap[i].SampleComp  = TexSampleComp.Less;
+			shadowMap[i].AddressMode = TexAddress.Clamp;
+			shadowMap[i].Id          = "app/shadow/zbuffer/"+i;
+
+			shadowMapFar[i] = Tex.RenderTarget(resolution, resolution, 1, TexFormat.None, TexFormat.Depth16);
+			shadowMapFar[i].SampleMode  = TexSample.Linear;
+			shadowMapFar[i].SampleComp  = TexSampleComp.Less;
+			shadowMapFar[i].AddressMode = TexAddress.Clamp;
+			shadowMapFar[i].Id          = "app/shadow/zbuffer/far_"+i;
 		}
 
 		model = Model.FromFile("Townscaper.glb", Shader.FromFile("Shaders/basic_shadow.hlsl"));
+		cylinder = Mesh.GenerateCylinder(0.1f, 10, Vec3.Up);
+		shadowMat = new Material("Shaders/basic_shadow.hlsl");
+
+		oldLighting = Renderer.SkyLight;
+		oldTex      = Renderer.SkyTex;
+
+		SphericalHarmonics ambient = new SphericalHarmonics();
+		ambient.Add( Vec3.UnitY, Color.HSV(0.55f, 0.3f,  0.4f).ToLinear());
+		ambient.Add(-Vec3.UnitY, Color.HSV(0.0f,  0.05f, 0.2f).ToLinear());
+		SphericalHarmonics ambientSky = ambient;
+		ambientSky.Brightness(2.5f);
+
+		Renderer.SkyLight = ambient;
+		Renderer.SkyTex   = Tex.GenCubemap(ambientSky);
 	}
 
 	public void Shutdown()
 	{
+		Renderer.SkyLight = oldLighting;
+		Renderer.SkyTex   = oldTex;
 	}
 
 	Pose sunPose = new Pose(V.XYZ(0.2f,0.6f,-1.001f)*20);
+	float angle = 1;
+	float bias      = 4.0f / ushort.MaxValue;
+	float biasSlope = 40.0f / ushort.MaxValue;
 	public void Step()
 	{
+		if (Input.Key(Key.K).IsActive()) angle -= 0.01f;
+		if (Input.Key(Key.L).IsActive()) angle += 0.01f;
+
+
+		if (Input.Key(Key.H).IsJustActive()) { bias += 1.0f / ushort.MaxValue; Log.Info($"Bias: {bias*ushort.MaxValue}"); }
+		if (Input.Key(Key.N).IsJustActive()) { bias -= 1.0f / ushort.MaxValue; Log.Info($"Bias: {bias*ushort.MaxValue}"); }
+
+		if (Input.Key(Key.J).IsJustActive()) { biasSlope += 1.0f / ushort.MaxValue; Log.Info($"Bias Slope: {biasSlope*ushort.MaxValue}"); }
+		if (Input.Key(Key.M).IsJustActive()) { biasSlope -= 1.0f / ushort.MaxValue; Log.Info($"Bias Slope: {biasSlope*ushort.MaxValue}"); }
+
 		UI.Handle("sun", ref sunPose, new Bounds(Vec3.One*0.1f));
 		//sunPose.position = Vec3.AngleXZ(Time.Totalf*90, 1);
 		//Vec3 sunDir    = new Vec3(0, -1, 0);
 		//Vec3 shadowPos = (sunDir.Normalized * -4); // Input.Head.position - (sunDir.Normalized * 4);
-		sunPose.position = V.XYZ((float)Math.Cos(Time.Total*0.25), 1, (float)Math.Sin(Time.Total*0.25)) * 10;
-		Vec3 shadowPos = sunPose.position;
-		Vec3 sunLookAt = new Vec3(0,-1.5f,0);
-		Vec3 sunDir    = (sunLookAt-sunPose.position).Normalized;
+		//sunPose.position = V.XYZ((float)Math.Cos(Time.Total*0.25), 1, (float)Math.Sin(Time.Total*0.25)) * 10;
+		//sunPose.position = V.XYZ((float)Math.Cos(Time.Total*0.25), (float)Math.Sin(Time.Total*0.25), 0) * 10;
+		//sunPose.position = V.XYZ(0, (float)Math.Sin(angle), (float)Math.Cos(angle)) * 10;
+		//Vec3 shadowPos = sunPose.position;
+		//Vec3 sunLookAt = new Vec3(0,-1.5f,0);
+		//Vec3 sunDir    = (sunLookAt-sunPose.position).Normalized;
 
-		float size = 5;
-		Matrix view = Matrix.TR          (shadowPos, Quat.LookDir(sunDir));
-		Matrix proj = Matrix.Orthographic(size, size, 0.01f, 20);
+
+		float size    = 2;
+		float farSize = size * 10;
+
+		Pose head = Input.Head;
+		Vec3 forward    = head.Forward.X0Z.Normalized;
+		Vec3 forwardPos = head.position.X0Z + forward * 0.5f * size;
+
+		// Stabilize the shadow map so we don't get sparkles when moving the camera
+		Vec3 sunDir = -V.XYZ(0, (float)Math.Sin(angle), (float)Math.Cos(angle));
+		sunPose.position    = sunDir * -10;
+		sunPose.orientation = Quat.LookAt(Vec3.Zero, sunDir, Vec3.Up);
+		Vec3 localP      = forwardPos - sunPose.position;
+		Vec2 planeCoords = new Vec2(
+			Vec3.Dot(localP, sunPose.orientation * Vec3.UnitX),
+			Vec3.Dot(localP, sunPose.orientation * Vec3.UnitY) );
+		float texelSize = farSize / shadowMapFar[0].Width;
+		Vec2  texCoords = planeCoords / texelSize;
+		texCoords = new Vec2((float)Math.Round(texCoords.x), (float)Math.Round(texCoords.y));
+		Vec2 quantizedPlaneCoords = texCoords * texelSize;
+		Vec3 quantizedPos = sunPose.position +
+			(sunPose.orientation * Vec3.UnitX) * quantizedPlaneCoords.x +
+			(sunPose.orientation * Vec3.UnitY) * quantizedPlaneCoords.y;
+
+		sunPose.position = quantizedPos;
+		//sunPose.position    = forwardPos - sunDir * 10;
+
+
+		Matrix view = Matrix.TR(sunPose.position, sunPose.orientation);
+		//Matrix view = Matrix.TR          (shadowPos, Quat.LookDir(sunDir));
+		Matrix proj    = Matrix.Orthographic(size,    size,    0.01f, 20);
+		Matrix projFar = Matrix.Orthographic(farSize, farSize, 0.01f, 20);
 
 		int renderTo   = (int)( Time.Frame                                  % (ulong)shadowMap.Length);
 		int renderFrom = (int)((Time.Frame + ((ulong)shadowMap.Length - 1)) % (ulong)shadowMap.Length);
 
+		Color lightColor = Color.HSV(0.16f, 0.1f, 1.0f).ToLinear();
 		ShadowBuffer curr = new ShadowBuffer
 		{
 			transform = (view.Inverse * proj).Transposed,
 			texSize   = 1.0f / shadowMap[renderTo].Width,
-			bias      = 0.0005f,
-			depthDistance = 50.0f - 0.01f,
-			lightDirection = -sunDir
+			bias      = bias,
+			biasSlope = biasSlope,
+			biasFar   = biasSlope,
+			depthDistance = 20.0f - 0.01f,
+			lightDirection = -sunDir,
+			farScale = farSize/size,
+			lightColor = V.XYZ(lightColor.r, lightColor.g, lightColor.b),
 		};
 		shadowBuffer.Set(last);
 		last = curr;
 
-		Renderer.RenderTo(shadowMap[renderTo], view, proj, RenderLayer.All &~ RenderLayer.Vfx);
-		Renderer.SetGlobalTexture(12, shadowMap[renderFrom]);
+		Renderer.RenderTo(shadowMap   [renderTo], view, proj,    RenderLayer.All &~ RenderLayer.Vfx);
+		Renderer.RenderTo(shadowMapFar[renderTo], view, projFar, RenderLayer.All &~ RenderLayer.Vfx);
+		Renderer.SetGlobalTexture(12, shadowMap   [renderFrom]);
+		Renderer.SetGlobalTexture(13, shadowMapFar[renderFrom]);
 
 		//Mesh.Quad  .Draw(shadowMat, Matrix.TRS(new Vec3(0,-2.5f,0),Quat.LookAt(Vec3.Zero, Vec3.UnitY, Vec3.UnitZ),4));
 		//Mesh.Sphere.Draw(shadowMat, Matrix.TS (new Vec3(0,-2,-0.5f), 0.5f));
 		model.Draw(Matrix.S(0.1f));
+		cylinder.Draw(shadowMat, Matrix.T(-0.2f,0,0));
 
-		Mesh.Sphere.Draw(Material.Unlit, Matrix.TS(shadowPos, 0.1f), Color.White, RenderLayer.Vfx);
-		Pose pose = view.Pose;
-		Lines.Add(shadowPos + pose.Right*size*0.5f, shadowPos - pose.Right*size*0.5f, new Color32(255,200,200,255), 0.01f);
-		Lines.Add(shadowPos + pose.Up*size*0.5f, shadowPos - pose.Up*size*0.5f, new Color32(200,255,200,255), 0.01f);
+		Mesh.Sphere.Draw(Material.Unlit, Matrix.TS(sunPose.position, 0.1f), Color.White, RenderLayer.Vfx);
+		Lines.Add(sunPose.position + sunPose.Right*size*0.5f, sunPose.position - sunPose.Right*size*0.5f, new Color32(255,200,200,255), 0.01f);
+		Lines.Add(sunPose.position + sunPose.Up   *size*0.5f, sunPose.position - sunPose.Up   *size*0.5f, new Color32(200,255,200,255), 0.01f);
+		//Lines.Add(sunPose.position, sunPose.position + sunPose.Forward * size * (20.0f - 0.01f), new Color32(200, 255, 200, 255), 0.01f);
 	}
 }

--- a/Examples/StereoKitTest/Demos/DemoShadows.cs
+++ b/Examples/StereoKitTest/Demos/DemoShadows.cs
@@ -1,0 +1,83 @@
+﻿using StereoKit;
+using System;
+using System.Runtime.InteropServices;
+
+class DemoShadows : ITest
+{
+	[StructLayout(LayoutKind.Sequential)]
+	struct ShadowBuffer
+	{
+		public Matrix transform;
+		public float texSize;
+		public float bias;
+		public float depthDistance;
+		float dummy;
+		public Vec3 lightDirection;
+		float dummy2;
+	}
+
+	Tex[]    shadowMap  = new Tex[2];
+	Material shadowMat  = new Material("Shaders/basic_shadow.hlsl");
+	Model model;
+	MaterialBuffer<ShadowBuffer> shadowBuffer;
+	ShadowBuffer last;
+
+	public void Initialize()
+	{ 
+		shadowBuffer = new MaterialBuffer<ShadowBuffer>(12);
+		for (int i = 0; i < shadowMap.Length; i++) {
+			shadowMap[i] = Tex.RenderTarget(2048, 2048, 1, TexFormat.None, TexFormat.Depth16);
+			shadowMap[i].SampleMode = TexSample.Point;
+			shadowMap[i].Id = "app/shadow/zbuffer/"+i;
+		}
+
+		model = Model.FromFile("Townscaper.glb", Shader.FromFile("Shaders/basic_shadow.hlsl"));
+	}
+
+	public void Shutdown()
+	{
+	}
+
+	Pose sunPose = new Pose(V.XYZ(0.2f,0.6f,-1.001f)*20);
+	public void Step()
+	{
+		UI.Handle("sun", ref sunPose, new Bounds(Vec3.One*0.1f));
+		//sunPose.position = Vec3.AngleXZ(Time.Totalf*90, 1);
+		//Vec3 sunDir    = new Vec3(0, -1, 0);
+		//Vec3 shadowPos = (sunDir.Normalized * -4); // Input.Head.position - (sunDir.Normalized * 4);
+		sunPose.position = V.XYZ((float)Math.Cos(Time.Total*0.25), 1, (float)Math.Sin(Time.Total*0.25)) * 10;
+		Vec3 shadowPos = sunPose.position;
+		Vec3 sunLookAt = new Vec3(0,-1.5f,0);
+		Vec3 sunDir    = (sunLookAt-sunPose.position).Normalized;
+
+		float size = 5;
+		Matrix view = Matrix.TR          (shadowPos, Quat.LookDir(sunDir));
+		Matrix proj = Matrix.Orthographic(size, size, 0.01f, 20);
+
+		int renderTo   = (int)( Time.Frame                                  % (ulong)shadowMap.Length);
+		int renderFrom = (int)((Time.Frame + ((ulong)shadowMap.Length - 1)) % (ulong)shadowMap.Length);
+
+		ShadowBuffer curr = new ShadowBuffer
+		{
+			transform = (view.Inverse * proj).Transposed,
+			texSize   = 1.0f / shadowMap[renderTo].Width,
+			bias      = 0.0005f,
+			depthDistance = 50.0f - 0.01f,
+			lightDirection = -sunDir
+		};
+		shadowBuffer.Set(last);
+		last = curr;
+
+		Renderer.RenderTo(shadowMap[renderTo], view, proj, RenderLayer.All &~ RenderLayer.Vfx);
+		Renderer.SetGlobalTexture(12, shadowMap[renderFrom]);
+
+		//Mesh.Quad  .Draw(shadowMat, Matrix.TRS(new Vec3(0,-2.5f,0),Quat.LookAt(Vec3.Zero, Vec3.UnitY, Vec3.UnitZ),4));
+		//Mesh.Sphere.Draw(shadowMat, Matrix.TS (new Vec3(0,-2,-0.5f), 0.5f));
+		model.Draw(Matrix.S(0.1f));
+
+		Mesh.Sphere.Draw(Material.Unlit, Matrix.TS(shadowPos, 0.1f), Color.White, RenderLayer.Vfx);
+		Pose pose = view.Pose;
+		Lines.Add(shadowPos + pose.Right*size*0.5f, shadowPos - pose.Right*size*0.5f, new Color32(255,200,200,255), 0.01f);
+		Lines.Add(shadowPos + pose.Up*size*0.5f, shadowPos - pose.Up*size*0.5f, new Color32(200,255,200,255), 0.01f);
+	}
+}

--- a/Examples/StereoKitTest/Demos/DemoShadows.cs
+++ b/Examples/StereoKitTest/Demos/DemoShadows.cs
@@ -1,37 +1,60 @@
 ﻿using StereoKit;
-using StereoKit.Framework;
 using System;
 using System.Runtime.InteropServices;
 
 class DemoShadows : ITest
 {
-	DynamicShadows shadows;
+	string title       = "Dynamic ShadowMaps";
+	string description = "Using StereoKit's Renderer.RenderTo, SetGlobalTexture, MaterialBuffers, and a bit of ingenuity, you can also add shadow mapping to your app!\n\nThis is a very basic single cascade implementation of shadow mapping to illustrate the idea.";
 
-	Model    model;
-	Mesh     cylinder;
-	Material shadowMat;
+	[StructLayout(LayoutKind.Sequential)]
+	struct ShadowBuffer
+	{
+		public Matrix shadowMapTransform;
+		public Vec3   lightDirection;
+		public float  shadowMapBias;
+		public Vec3   lightColor;
+		public float  shadowMapPixelSize;
+	}
+
+	Tex                          shadowMap;
+	MaterialBuffer<ShadowBuffer> shadowBuffer;
+
+	const float ShadowMapSize       = 2;
+	const int   ShadowMapResolution = 1024;
+	const float ShadowMapNearClip   = 0.01f;
+	const float ShadowMapFarClip    = 20.0f;
+
+	Model model;
+	Pose  modelPose = Matrix.T(0,-0.2f,0) * Demo.contentPose.Pose;
 
 	SphericalHarmonics oldLighting;
 	Tex                oldTex;
 
 	public void Initialize()
 	{
-		shadows = SK.AddStepper(new DynamicShadows(1, Color.HSV(0.16f, 0.1f, 1.0f), 512));
+		shadowBuffer = new MaterialBuffer<ShadowBuffer>(12);
+		shadowMap = new Tex(TexType.Depthtarget, TexFormat.Depth16);
+		shadowMap.SetSize(ShadowMapResolution, ShadowMapResolution);
+		shadowMap.SampleMode  = TexSample.Linear;
+		shadowMap.SampleComp  = TexSampleComp.LessOrEq;
+		shadowMap.AddressMode = TexAddress.Clamp;
+		shadowMap.Id          = "app/shadow/zbuffer";
 
-		model = Model.FromFile("Townscaper.glb", Shader.FromFile("Shaders/basic_shadow.hlsl"));
-		//model = Model.FromFile(@"C:\Data\GLTF\marsh.glb", Shader.FromFile("Shaders/basic_shadow.hlsl"));
-		model.PlayAnim(model.Anims[0], AnimMode.Loop);
-		cylinder = Mesh.GenerateCylinder(0.1f, 10, Vec3.Up);
-		shadowMat = new Material("Shaders/basic_shadow.hlsl");
+		Material shadowMat = new Material("Shaders/basic_shadow.hlsl");
+		shadowMat.DepthTest = DepthTest.LessOrEq;
+		Material floorMat = shadowMat.Copy();
+		floorMat[MatParamName.DiffuseTex] = Tex.FromFile("floor.png");
+		floorMat[MatParamName.TexTransform] = new Vec4(0, 0, 2, 2);
+		model = GenerateModel(floorMat, shadowMat);
 
 		oldLighting = Renderer.SkyLight;
 		oldTex      = Renderer.SkyTex;
 
 		SphericalHarmonics ambient = new SphericalHarmonics();
-		ambient.Add( Vec3.UnitY, Color.HSV(0.55f, 0.3f,  0.4f).ToLinear());
-		ambient.Add(-Vec3.UnitY, Color.HSV(0.0f,  0.01f, 0.15f).ToLinear());
+		ambient.Add( Vec3.UnitY, Color.HSV(0.55f, 0.3f,  0.6f).ToLinear());
+		ambient.Add(-Vec3.UnitY, Color.HSV(0.0f,  0.01f, 0.2f).ToLinear());
 		SphericalHarmonics ambientSky = ambient;
-		ambientSky.Brightness(2.5f);
 
 		Renderer.SkyLight = ambient;
 		Renderer.SkyTex   = Tex.GenCubemap(ambientSky);
@@ -42,184 +65,93 @@ class DemoShadows : ITest
 		Renderer.SkyLight = oldLighting;
 		Renderer.SkyTex   = oldTex;
 	}
-
-	Pose sunPose = new Pose(V.XYZ(0.2f,0.6f,-1.001f)*20);
-	Vec3 sunDir = -Vec3.UnitY;
-	float angleX = 1;
-	float angleY = 1;
-	float bias      = 50.0f  / ushort.MaxValue;
-	float biasSlope = 800.0f / ushort.MaxValue;
 	public void Step()
 	{
-		if (Input.Key(Key.K).IsActive()) angleX  -= 0.01f;
-		if (Input.Key(Key.L).IsActive()) angleX  += 0.01f;
+		// Make a direction for the light
+		const float angleX = Units.deg2rad * 45;
+		const float angleY = Units.deg2rad * 45;
+		float cosX = (float)Math.Cos(angleX);
+		float sinX = (float)Math.Sin(angleX);
+		float cosY = (float)Math.Cos(angleY);
+		float sinY = (float)Math.Sin(angleY);
+		SetupShadowMap(-V.XYZ(cosX * sinY, sinX, cosX * cosY));
 
-		if (Input.Key(Key.I).IsActive()) angleY -= 0.01f;
-		if (Input.Key(Key.O).IsActive()) angleY += 0.01f;
+		UI.Handle("Model", ref modelPose, model.Bounds);
+		model.Draw(modelPose.ToMatrix());
 
-		Controller c = Input.Controller(Handed.Right);
-		//if (c.grip > 0.5f)
-		//{
-		//	sunDir = c.stick.X0Y;
-		//	sunDir.y = -1;
-		//	sunDir = sunDir.Normalized;
-		//}
-		//else
+		Demo.ShowSummary(title, description,
+			new Bounds(V.XY0(0, -0.05f), V.XYZ(.6f, .4f, 0.6f)));
+	}
+
+	void SetupShadowMap(Vec3 lightDir)
+	{
+		// Position the center of the shadow map in front of the user.
+		Pose head = Input.Head;
+		Vec3 forwardPos       = head.position.X0Z + head.Forward.X0Z.Normalized * 0.5f * ShadowMapSize;
+		Quat lightOrientation = Quat.LookAt(Vec3.Zero, lightDir, Vec3.Up);
+		Vec3 lightPos         = QuantizeLightPos( forwardPos + lightDir * -10, lightOrientation, ShadowMapSize/ShadowMapResolution );
+
+		// Create rendering matrices for the shadow map
+		Matrix view = Matrix.TR(lightPos, lightOrientation);
+		Matrix proj = Matrix.Orthographic(ShadowMapSize, ShadowMapSize, ShadowMapNearClip, ShadowMapFarClip);
+
+		// Send information about the shadow map parameters to the renderer,
+		// these are used by the basic_shadow.hlsl shader.
+		shadowBuffer.Set(new ShadowBuffer {
+			shadowMapTransform = (view.Inverse * proj).Transposed,
+			shadowMapBias      = 2 * MathF.Max(((ShadowMapFarClip - ShadowMapNearClip) / ushort.MaxValue), ShadowMapSize / ShadowMapResolution),
+			lightDirection     = -lightDir,
+			lightColor         =  V.XYZ(1,1,1),
+			shadowMapPixelSize = 1.0f / ShadowMapResolution
+		});
+
+		// Render the shadow map, and bind it globally so it can be used from
+		// any shader.
+		Renderer.RenderTo(shadowMap, view, proj, RenderLayer.All &~ RenderLayer.Vfx);
+		Renderer.SetGlobalTexture(12, shadowMap);
+	}
+
+	static Model GenerateModel(Material floorMat, Material material)
+	{
+		
+		const float width  = 0.5f;
+		const float height = 0.5f;
+		Vec3  sizeMin = new Vec3(0.04f, 0.04f, 0.04f);
+		Vec3  sizeMax = new Vec3(.06f, .2f, .06f);
+		float genWidth  = width - sizeMax.x;
+		float genHeight = height - sizeMax.z;
+		Model model = new Model();
+		model.AddNode("Floor", Matrix.S(width, 0.02f, height), Mesh.Cube, floorMat);
+
+		Random r = new Random(1);
+		for (int i = 0; i < 20; i++)
 		{
-			float cosX = (float)Math.Cos(angleX);
-			float sinX = (float)Math.Sin(angleX);
-			float cosY = (float)Math.Cos(angleY);
-			float sinY = (float)Math.Sin(angleY);
-			sunDir = -V.XYZ(
-				cosX * sinY,
-				sinX,
-				cosX * cosY);
+			float x = (r.NextSingle() - 0.5f) * genWidth;
+			float y = (r.NextSingle() - 0.5f) * genHeight;
+			Vec3 size = new Vec3(
+				sizeMin.x + r.NextSingle() * (sizeMax.x - sizeMin.x),
+				sizeMin.y + r.NextSingle() * (sizeMax.y - sizeMin.y),
+				sizeMin.z + r.NextSingle() * (sizeMax.z - sizeMin.z));
+			model.AddNode("Cube"+i, Matrix.TS(x, 0.01f + size.y/2, y, size), Mesh.Cube, material);
 		}
 
-
-		if (Input.Key(Key.H).IsJustActive()) { bias += 10.0f / ushort.MaxValue; Log.Info($"Bias: {bias * ushort.MaxValue}"); }
-		if (Input.Key(Key.N).IsJustActive()) { bias -= 10.0f / ushort.MaxValue; Log.Info($"Bias: {bias*ushort.MaxValue}"); }
-
-		if (Input.Key(Key.J).IsJustActive()) { biasSlope += 10.0f / ushort.MaxValue; Log.Info($"Bias Slope: {biasSlope*ushort.MaxValue}"); }
-		if (Input.Key(Key.M).IsJustActive()) { biasSlope -= 10.0f / ushort.MaxValue; Log.Info($"Bias Slope: {biasSlope*ushort.MaxValue}"); }
-
-		UI.Handle("sun", ref sunPose, new Bounds(Vec3.One*0.1f));
-		//sunPose.position = Vec3.AngleXZ(Time.Totalf*90, 1);
-		//Vec3 sunDir    = new Vec3(0, -1, 0);
-		//Vec3 shadowPos = (sunDir.Normalized * -4); // Input.Head.position - (sunDir.Normalized * 4);
-		//sunPose.position = V.XYZ((float)Math.Cos(Time.Total*0.25), 1, (float)Math.Sin(Time.Total*0.25)) * 10;
-		//sunPose.position = V.XYZ((float)Math.Cos(Time.Total*0.25), (float)Math.Sin(Time.Total*0.25), 0) * 10;
-		//sunPose.position = V.XYZ(0, (float)Math.Sin(angle), (float)Math.Cos(angle)) * 10;
-		//Vec3 shadowPos = sunPose.position;
-		//Vec3 sunLookAt = new Vec3(0,-1.5f,0);
-		//Vec3 sunDir    = (sunLookAt-sunPose.position).Normalized;
-
-		shadows.LightDirection = sunDir;
-
-		//Mesh.Quad  .Draw(shadowMat, Matrix.TRS(new Vec3(0,-2.5f,0),Quat.LookAt(Vec3.Zero, Vec3.UnitY, Vec3.UnitZ),4));
-		//Mesh.Sphere.Draw(shadowMat, Matrix.TS (new Vec3(0,-2,-0.5f), 0.5f));
-		model.Draw(Matrix.S(0.1f));
-		cylinder.Draw(shadowMat, Matrix.T(-0.2f,0,0));
-		//cylinder.Draw(Default.MaterialHand, Matrix.T(-0.2f,0,0));
-
-		Mesh.Sphere.Draw(Material.Unlit, Input.Hand(Handed.Right).palm.ToMatrix(0.01f), Color.White, RenderLayer.Vfx);
-	}
-}
-
-public class DynamicShadows : IStepper
-{
-	[StructLayout(LayoutKind.Sequential)]
-	struct ShadowBuffer
-	{
-		public Matrix transform;
-		public float texSize;
-		public float bias;
-		public float biasSlope;
-		public float depthDistance;
-		public Vec3  lightDirection;
-		public float farScale;
-		public Vec3  lightColor;
-		public float biasFar;
+		return model;
 	}
 
-	Tex[] shadowMap = new Tex[2];
-	MaterialBuffer<ShadowBuffer> shadowBuffer;
-	ShadowBuffer last;
-
-	private Color _lightColor;
-
-	public int   Resolution { get; private set; }
-	public Color LightColor { get => _lightColor.ToGamma(); set => _lightColor = value.ToLinear(); }
-	public float Size;
-
-	public float Bias      = 50.0f  / ushort.MaxValue;
-	public float BiasSlope = 800.0f / ushort.MaxValue;
-
-	public float NearClip          = 0.01f;
-	public float FarClip           = 20;
-	public float CascadeMultiplier = 8;
-	public Vec3  LightDirection;
-
-	public bool Enabled => true;
-
-	public DynamicShadows(float sizeMeters, Color colorGamma, int resolution = 512)
+	static Vec3 QuantizeLightPos(Vec3 pos, Quat lightOrientation, float texelSize)
 	{
-		Size       = sizeMeters;
-		Resolution = resolution;
-		LightColor = colorGamma;
-	}
+		Vec3  right = lightOrientation * Vec3.UnitX;
+		Vec3  up    = lightOrientation * Vec3.UnitY;
+		Plane p     = new Plane(lightOrientation * Vec3.UnitZ, 0);
 
-	public bool Initialize()
-	{
-		shadowBuffer = new MaterialBuffer<ShadowBuffer>(12);
-		for (int i = 0; i < shadowMap.Length; i++) {
-			shadowMap[i] = new Tex(TexType.Depthtarget, TexFormat.Depth16);
-			shadowMap[i].SetSize(Resolution, Resolution, 2);
-			shadowMap[i].SampleMode  = TexSample.Linear;
-			shadowMap[i].SampleComp  = TexSampleComp.Less;
-			shadowMap[i].AddressMode = TexAddress.Clamp;
-			shadowMap[i].Id          = "app/shadow/zbuffer/"+i;
-		}
-		return true;
-	}
-
-	public void Shutdown()
-	{
-	}
-
-	public void Step()
-	{
-		Pose head       = Input.Head;
-		Vec3 forward    = head.Forward.X0Z.Normalized;
-		Vec3 forwardPos = head.position.X0Z + forward * 0.5f * Size;
-		Vec3 lightDir   = LightDirection.Normalized;
-
-		// Stabilize the shadow map so we don't get sparkles when moving the camera
-		Pose sunPose;
-		sunPose.position    = lightDir * -10;
-		sunPose.orientation = Quat.LookAt(Vec3.Zero, lightDir, Vec3.Up);
-		Vec3 localP      = forwardPos - sunPose.position;
-		Vec2 planeCoords = new Vec2(
-			Vec3.Dot(localP, sunPose.orientation * Vec3.UnitX),
-			Vec3.Dot(localP, sunPose.orientation * Vec3.UnitY) );
-		float texelSize = (Size * CascadeMultiplier) / Resolution;
-		Vec2  texCoords = planeCoords / texelSize;
+		Vec3 localP   = p.Closest(pos);
+		Vec3 localOff = pos - localP;
+		Vec2 planeCoords = new Vec2(Vec3.Dot(localP, right), Vec3.Dot(localP, up));
+		Vec2 texCoords   = planeCoords / texelSize;
 		texCoords = new Vec2((float)Math.Round(texCoords.x), (float)Math.Round(texCoords.y));
 		Vec2 quantizedPlaneCoords = texCoords * texelSize;
-		Vec3 quantizedPos = sunPose.position +
-			(sunPose.orientation * Vec3.UnitX) * quantizedPlaneCoords.x +
-			(sunPose.orientation * Vec3.UnitY) * quantizedPlaneCoords.y;
-
-		sunPose.position = quantizedPos;
-
-		Matrix view    = Matrix.TR(sunPose.position, sunPose.orientation);
-		Matrix proj    = Matrix.Orthographic(Size,                   Size,                   NearClip, FarClip);
-		Matrix projFar = Matrix.Orthographic(Size*CascadeMultiplier, Size*CascadeMultiplier, NearClip, FarClip);
-
-		int renderTo   = (int)( Time.Frame                                  % (ulong)shadowMap.Length);
-		int renderFrom = (int)((Time.Frame + ((ulong)shadowMap.Length - 1)) % (ulong)shadowMap.Length);
-
-		ShadowBuffer curr = new ShadowBuffer
-		{
-			transform      = (view.Inverse * proj).Transposed,
-			texSize        = 1.0f / shadowMap[renderTo].Width,
-			bias           = Bias,
-			biasSlope      = BiasSlope,
-			biasFar        = BiasSlope,
-			depthDistance  = FarClip - NearClip,
-			lightDirection = -lightDir,
-			farScale       = CascadeMultiplier,
-			lightColor     = V.XYZ(_lightColor.r, _lightColor.g, _lightColor.b),
-		};
-		shadowBuffer.Set(last);
-		last = curr;
-
-		Renderer.RenderTo(shadowMap[renderTo], 0, view, proj,    RenderLayer.All &~ RenderLayer.Vfx);
-		Renderer.RenderTo(shadowMap[renderTo], 1, view, projFar, RenderLayer.All &~ RenderLayer.Vfx);
-		Renderer.SetGlobalTexture(12, shadowMap[renderFrom]);
-	}
-
-	public void DebugDraw()
-	{
+		return localOff +
+			right * quantizedPlaneCoords.x +
+			up    * quantizedPlaneCoords.y;
 	}
 }

--- a/Examples/StereoKitTest/Demos/DemoShadows.cs
+++ b/Examples/StereoKitTest/Demos/DemoShadows.cs
@@ -33,13 +33,12 @@ class DemoShadows : ITest
 
 	public void Initialize()
 	{
-		shadowBuffer = new MaterialBuffer<ShadowBuffer>(12);
+		shadowBuffer = new MaterialBuffer<ShadowBuffer>();
 		shadowMap = new Tex(TexType.Depthtarget, TexFormat.Depth16);
 		shadowMap.SetSize(ShadowMapResolution, ShadowMapResolution);
 		shadowMap.SampleMode  = TexSample.Linear;
 		shadowMap.SampleComp  = TexSampleComp.LessOrEq;
 		shadowMap.AddressMode = TexAddress.Clamp;
-		shadowMap.Id          = "app/shadow/zbuffer";
 
 		Material shadowMat = new Material("Shaders/basic_shadow.hlsl");
 		shadowMat.DepthTest = DepthTest.LessOrEq;
@@ -58,12 +57,14 @@ class DemoShadows : ITest
 
 		Renderer.SkyLight = ambient;
 		Renderer.SkyTex   = Tex.GenCubemap(ambientSky);
+		Renderer.SetGlobalBuffer(12, shadowBuffer);
 	}
 
 	public void Shutdown()
 	{
 		Renderer.SkyLight = oldLighting;
 		Renderer.SkyTex   = oldTex;
+		Renderer.SetGlobalBuffer(12, null);
 	}
 	public void Step()
 	{

--- a/Examples/StereoKitTest/Tests/TestMaterialBuffer.cs
+++ b/Examples/StereoKitTest/Tests/TestMaterialBuffer.cs
@@ -22,8 +22,9 @@ class TestMaterialBuffer : ITest
 
 		try
 		{ 
-			testBuffer = new MaterialBuffer<MaterialBufferStruct>(13);
+			testBuffer = new MaterialBuffer<MaterialBufferStruct>();
 			testBuffer.Set(data);
+			Renderer.SetGlobalBuffer(13, testBuffer);
 		} 
 		catch (Exception e)
 		{
@@ -38,32 +39,22 @@ class TestMaterialBuffer : ITest
 		Log.Warn("Expected error:");
 		try
 		{
-			// ids for 0-2 should see MaterialBuffer throw an exceptions
-			testBuffer = new MaterialBuffer<MaterialBufferStruct>(2);
+			// ids for 0-2 should see an error message in the log
+			testBuffer = new MaterialBuffer<MaterialBufferStruct>();
+			Renderer.SetGlobalBuffer(2, testBuffer);
 		}
-		catch { return true; }
-		return false;
-	}
-
-	bool MaterialBufferIdOverlap()
-	{
-		Log.Warn("Expected error:");
-		try
-		{
-			// 13 is already used by MaterialBufferTest, so it should throw
-			testBuffer = new MaterialBuffer<MaterialBufferStruct>(13);
-		}
-		catch { return true; }
-		return false;
+		catch { return false; }
+		return true;
 	}
 
 	public void Initialize()
 	{
 		Tests.Test(MaterialBufferTest);
 		Tests.Test(MaterialBufferId);
-		Tests.Test(MaterialBufferIdOverlap);
 	}
 
-	public void Shutdown() { }
+	public void Shutdown() {
+		Renderer.SetGlobalBuffer(13, null);
+	}
 	public void Step() { }
 }

--- a/StereoKit/Assets/Material.cs
+++ b/StereoKit/Assets/Material.cs
@@ -163,6 +163,15 @@ namespace StereoKit
 		public bool DepthWrite {
 			get => NativeAPI.material_get_depth_write(_inst);
 			set => NativeAPI.material_set_depth_write(_inst, value); }
+		/// <summary>Should the near/far depth plane clip (discard) what we're
+		/// drawing? This defaults to true, and should almost always be true!
+		/// However, it can be useful to set this to false for occasions like
+		/// shadow map rendering, where near/far clip planes are really
+		/// critical, and out of clip objects are still useful to have.
+		/// </summary>
+		public bool DepthClip {
+			get => NativeAPI.material_get_depth_clip(_inst);
+			set => NativeAPI.material_set_depth_clip(_inst, value); }
 		/// <summary>This property will force this material to draw earlier
 		/// or later in the draw queue. Positive values make it draw later,
 		/// negative makes it earlier. This is really helpful when doing tricks

--- a/StereoKit/Assets/MaterialBuffer.cs
+++ b/StereoKit/Assets/MaterialBuffer.cs
@@ -49,16 +49,33 @@ namespace StereoKit
 		/// <param name="registerSlot">Valid values are 3-16. This is the 
 		/// register id that this data will be bound to. In HLSL, you'll see
 		/// the slot id for '3' indicated like this `: register(b3)`</param>
+		[Obsolete("Use empty constructor, and call Renderer.SetGlobalBuffer instead! This will be removed in a future version.")]
 		public MaterialBuffer(int registerSlot) {
 			if (!(typeof(T).IsLayoutSequential || typeof(T).IsExplicitLayout))
 				throw new NotSupportedException("MaterialBuffer's data type must have a '[StructLayout(LayoutKind.Sequential)]' attribute for proper copying! Explicit would work too.");
 
 			int size     = Marshal.SizeOf(typeof(T));
 			_localMemory = Marshal.AllocHGlobal(size);
-			_inst        = NativeAPI.material_buffer_create(registerSlot, size);
+			_inst        = NativeAPI.material_buffer_create(size);
 			if (_inst == IntPtr.Zero)
 				throw new ArgumentException("Bad slot id, see log.");
+			else
+				Renderer.SetGlobalBuffer(registerSlot, this);
 		}
+
+		/// <summary>Create a new global MaterialBuffer that can be bound to a
+		/// register slot id via Renderer.SetGlobalBuffer. All shaders will
+		/// have access to the data provided via this instance's `Set`.</summary>
+		public MaterialBuffer()
+		{
+			if (!(typeof(T).IsLayoutSequential || typeof(T).IsExplicitLayout))
+				throw new NotSupportedException("MaterialBuffer's data type must have a '[StructLayout(LayoutKind.Sequential)]' attribute for proper copying! Explicit would work too.");
+
+			int size     = Marshal.SizeOf(typeof(T));
+			_localMemory = Marshal.AllocHGlobal(size);
+			_inst        = NativeAPI.material_buffer_create(size);
+		}
+
 		/// <summary>Release reference to the StereoKit asset.</summary>
 		~MaterialBuffer()
 		{

--- a/StereoKit/Assets/Tex.cs
+++ b/StereoKit/Assets/Tex.cs
@@ -88,6 +88,11 @@ namespace StereoKit
 			get => NativeAPI.tex_get_sample(_inst);
 			set => NativeAPI.tex_set_sample(_inst, value); }
 
+		public TexSampleComp SampleComp {
+			get => NativeAPI.tex_get_sample_comp(_inst);
+			set => NativeAPI.tex_set_sample_comp(_inst, value);
+		}
+
 		/// <summary>When SampleMode is set to Anisotropic, this is the number
 		/// of samples the GPU takes to figure out the correct color. Default
 		/// is 4, and 16 is pretty high.</summary>

--- a/StereoKit/Assets/Tex.cs
+++ b/StereoKit/Assets/Tex.cs
@@ -422,8 +422,15 @@ namespace StereoKit
 		/// are generally best!</param>
 		/// <param name="height">Height in pixels of the texture. Powers of
 		/// two are generally best!</param>
-		public void SetSize(int width, int height)
-			=> NativeAPI.tex_set_colors(_inst, width, height, IntPtr.Zero);
+		/// <param name="arrayCount">How many surfaces are in this texture? A
+		/// normal texture only has 1, but it can be useful to have multiple
+		/// for certain rendering techniques or effects.</param>
+		/// <param name="msaa">Multisample anti-aliasing, this is only
+		/// important for render target type textures! This is the number of
+		/// fragments that are drawn for each pixel to reduce sparkling /
+		/// aliasing artifacts.</param>
+		public void SetSize(int width, int height, int arrayCount = 1, int msaa = 1)
+			=> NativeAPI.tex_set_color_arr(_inst, width, height, IntPtr.Zero, arrayCount, msaa, IntPtr.Zero);
 
 		/// <summary>Only applicable if this texture is a rendertarget!
 		/// This creates and attaches a zbuffer surface to the texture for

--- a/StereoKit/Native/NativeAPI.cs
+++ b/StereoKit/Native/NativeAPI.cs
@@ -201,6 +201,7 @@ namespace StereoKit
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   tex_set_colors          (IntPtr texture, int width, int height, [In] byte[] data);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   tex_set_colors          (IntPtr texture, int width, int height, [In] ushort[] data);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   tex_set_colors          (IntPtr texture, int width, int height, [In] float[] data);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   tex_set_color_arr       (IntPtr texture, int width, int height, IntPtr array_data, int array_count, int multisample, IntPtr out_sh_lighting_info);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   tex_set_mem             (IntPtr texture, [In] byte[] data, UIntPtr data_size, [MarshalAs(UnmanagedType.Bool)] bool srgb_data, [MarshalAs(UnmanagedType.Bool)] bool blocking, int priority);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   tex_set_surface         (IntPtr texture, IntPtr native_surface, TexType type, long native_fmt, int width, int height, int surface_count, int multisample, int framebuffer_multisample, [MarshalAs(UnmanagedType.Bool)] bool owned);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr tex_get_surface         (IntPtr texture);
@@ -474,7 +475,7 @@ namespace StereoKit
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void               render_screenshot     ([In] byte[] file_utf8, int file_quality_100, Pose viewpoint, int width, int height, float field_of_view_degrees);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void               render_screenshot_capture  ([MarshalAs(UnmanagedType.FunctionPtr)] RenderOnScreenshotCallback render_on_screenshot_callback, Pose viewpoint, int width, int height, float fov_degrees, TexFormat tex_format, IntPtr context);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void               render_screenshot_viewpoint([MarshalAs(UnmanagedType.FunctionPtr)] RenderOnScreenshotCallback render_on_screenshot_callback, Matrix camera, Matrix projection, int width, int height, RenderLayer layer_filter, RenderClear clear, Rect viewport, TexFormat tex_format, IntPtr context);
-		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void               render_to             (IntPtr to_rendertarget, in Matrix camera, in Matrix projection, RenderLayer layer_filter, RenderClear clear, Rect viewport);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void               render_to             (IntPtr to_rendertarget, int to_target_index, IntPtr override_material, in Matrix camera, in Matrix projection, RenderLayer layer_filter, RenderClear clear, Rect viewport);
 		//[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void render_get_device  (void **device, void **context);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr             render_get_primary_list();
 

--- a/StereoKit/Native/NativeAPI.cs
+++ b/StereoKit/Native/NativeAPI.cs
@@ -218,6 +218,8 @@ namespace StereoKit
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern int        tex_get_height      (IntPtr texture);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void       tex_set_sample      (IntPtr texture, TexSample sample = TexSample.Linear);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern TexSample  tex_get_sample      (IntPtr texture);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void          tex_set_sample_comp (IntPtr texture, TexSampleComp compare = TexSampleComp.None);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern TexSampleComp tex_get_sample_comp (IntPtr texture);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void       tex_set_address     (IntPtr texture, TexAddress address_mode = TexAddress.Wrap);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern TexAddress tex_get_address     (IntPtr texture);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void       tex_set_anisotropy  (IntPtr texture, int anisotropy_level = 4);

--- a/StereoKit/Native/NativeAPI.cs
+++ b/StereoKit/Native/NativeAPI.cs
@@ -319,9 +319,10 @@ namespace StereoKit
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   material_set_shader      (IntPtr material, IntPtr shader);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr material_get_shader      (IntPtr material);
 
-		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr material_buffer_create  (int slot, int size);
-		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   material_buffer_set_data(IntPtr buffer, IntPtr data);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr material_buffer_create  (int size);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   material_buffer_addref  (IntPtr buffer);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   material_buffer_release (IntPtr buffer);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   material_buffer_set_data(IntPtr buffer, IntPtr data);
 
 		///////////////////////////////////////////
 
@@ -471,6 +472,7 @@ namespace StereoKit
 		[return: MarshalAs(UnmanagedType.Bool)]
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern bool               render_enabled_skytex ();
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void               render_global_texture (int register_slot, IntPtr texture);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void               render_global_buffer  (int register_slot, IntPtr buffer);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void               render_add_mesh       (IntPtr mesh, IntPtr material, in Matrix transform, Color color, RenderLayer layer);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void               render_add_model      (IntPtr model, in Matrix transform, Color color, RenderLayer layer);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void               render_add_model_mat  (IntPtr model, IntPtr material_override, in Matrix transform, Color color, RenderLayer layer);

--- a/StereoKit/Native/NativeAPI.cs
+++ b/StereoKit/Native/NativeAPI.cs
@@ -264,6 +264,7 @@ namespace StereoKit
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   material_set_wireframe   (IntPtr material, [MarshalAs(UnmanagedType.Bool)] bool wireframe);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   material_set_depth_test  (IntPtr material, DepthTest    depth_test_mode);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   material_set_depth_write (IntPtr material, [MarshalAs(UnmanagedType.Bool)] bool write_enabled);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   material_set_depth_clip  (IntPtr material, [MarshalAs(UnmanagedType.Bool)] bool clip_enabled);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   material_set_queue_offset(IntPtr material, int          offset);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   material_set_chain       (IntPtr material, IntPtr       chain_material);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern Transparency material_get_transparency(IntPtr material);
@@ -273,6 +274,8 @@ namespace StereoKit
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern DepthTest    material_get_depth_test  (IntPtr material);
 		[return: MarshalAs(UnmanagedType.Bool)]
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern bool         material_get_depth_write (IntPtr material);
+		[return: MarshalAs(UnmanagedType.Bool)]
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern bool         material_get_depth_clip  (IntPtr material);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern int          material_get_queue_offset(IntPtr material);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr       material_get_chain       (IntPtr material);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   material_set_float       (IntPtr material, string name, float  value);

--- a/StereoKit/Native/NativeEnums.cs
+++ b/StereoKit/Native/NativeEnums.cs
@@ -368,8 +368,14 @@ namespace StereoKit
 		/// that might be passed in as a target to Renderer.Blit, or other
 		/// such situations.</summary>
 		Rendertarget = 1 << 2,
-		/// <summary>This texture contains depth data, not color data!</summary>
+		/// <summary>This texture contains depth data, not color data! It is writeable, but
+		/// not readable. This makes it great for zbuffers, but not shadowmaps or
+		/// other textures that need to be read from later on.</summary>
 		Depth        = 1 << 3,
+		/// <summary>This texture contains depth data, not color data! It is writeable, but
+		/// not readable. This makes it great for zbuffers, but not shadowmaps or
+		/// other textures that need to be read from later on.</summary>
+		Zbuffer      = 1 << 3,
 		/// <summary>This texture will generate mip-maps any time the contents
 		/// change. Mip-maps are a list of textures that are each half the
 		/// size of the one before them! This is used to prevent textures from
@@ -379,6 +385,10 @@ namespace StereoKit
 		/// CPU (not renders)! This ensures the graphics card stores it
 		/// someplace where writes are easy to do quickly.</summary>
 		Dynamic      = 1 << 5,
+		/// <summary>This texture contains depth data, not color data! It is writeable and
+		/// readable. This makes it great for shadowmaps or other textures that need to
+		/// be read from later on.</summary>
+		Depthtarget  = 1 << 6,
 		/// <summary>A standard color image that also generates mip-maps
 		/// automatically.</summary>
 		Image        = ImageNomips | Mips,
@@ -514,6 +524,18 @@ namespace StereoKit
 		/// <summary>This helps reduce texture blurriness when a surface is
 		/// viewed at an extreme angle!</summary>
 		Anisotropic,
+	}
+
+	public enum TexSampleComp {
+		None         = 0,
+		Less,
+		LessOrEq,
+		Greater,
+		GreaterOrEq,
+		Equal,
+		NotEqual,
+		Always,
+		Never,
 	}
 
 	/// <summary>What happens when the shader asks for a texture coordinate

--- a/StereoKit/Systems/Renderer.cs
+++ b/StereoKit/Systems/Renderer.cs
@@ -456,5 +456,33 @@ namespace StereoKit
 		/// <param name="tex">The texture to assign globally. Setting null here
 		/// will clear any texture that is currently bound.</param>
 		public static void SetGlobalTexture(int textureRegister, Tex tex) => NativeAPI.render_global_texture(textureRegister, tex?._inst ?? IntPtr.Zero);
+
+		/// <summary>This attaches a buffer resource globally across all
+		/// shaders. StereoKit uses this to attach the stereokit rendering
+		/// constants. It can be used for things like shadowmaps, wind data,
+		/// etc.</summary>
+		/// <param name="bufferRegister">Valid values are 3-16. This is the 
+		/// register id that this data will be bound to. In HLSL, you'll see
+		/// the slot id for '3' indicated like this `: register(b3)`</param>
+		/// <param name="buffer">The data buffer you would like to bind, or
+		/// null to unbind.</param>
+		public static void SetGlobalBuffer<T>(int bufferRegister, MaterialBuffer<T> buffer) where T:struct
+		{
+			NativeAPI.render_global_buffer(bufferRegister, buffer?._inst ?? IntPtr.Zero);
+		}
+		/// <summary>This attaches a buffer resource globally across all
+		/// shaders. StereoKit uses this to attach the stereokit rendering
+		/// constants. It can be used for things like shadowmaps, wind data,
+		/// etc.</summary>
+		/// <param name="bufferRegister">Valid values are 3-16. This is the 
+		/// register id that this data will be bound to. In HLSL, you'll see
+		/// the slot id for '3' indicated like this `: register(b3)`</param>
+		/// <param name="buffer">The data buffer you would like to bind, or
+		/// null to unbind.</param>
+		public static void SetGlobalBuffer(int bufferRegister, object buffer)
+		{
+			if (buffer != null) throw new ArgumentException("Use a MaterialBuffer type here!");
+			NativeAPI.render_global_buffer(bufferRegister, IntPtr.Zero);
+		}
 	}
 }

--- a/StereoKit/Systems/Renderer.cs
+++ b/StereoKit/Systems/Renderer.cs
@@ -437,7 +437,13 @@ namespace StereoKit
 		/// If the width of this value is zero, then this will render to the
 		/// entire texture.</param>
 		public static void RenderTo(Tex toRendertarget, Matrix camera, Matrix projection, RenderLayer layerFilter = RenderLayer.All, RenderClear clear = RenderClear.All, Rect viewport = default(Rect))
-			=> NativeAPI.render_to(toRendertarget._inst, camera, projection, layerFilter, clear, viewport);
+			=> NativeAPI.render_to(toRendertarget._inst, 0, IntPtr.Zero, camera, projection, layerFilter, clear, viewport);
+
+		/// <inheritdoc cref="RenderTo(Tex, Matrix, Matrix, RenderLayer, RenderClear, Rect)"/>
+		/// <param name="toTargetIndex">Index of the render target's array
+		/// texture we want to draw to.</param>
+		public static void RenderTo(Tex toRendertarget, int toTargetIndex, Matrix camera, Matrix projection, RenderLayer layerFilter = RenderLayer.All, RenderClear clear = RenderClear.All, Rect viewport = default(Rect))
+			=> NativeAPI.render_to(toRendertarget._inst, toTargetIndex, IntPtr.Zero, camera, projection, layerFilter, clear, viewport);
 
 		/// <summary>This attaches a texture resource globally across all
 		/// shaders. StereoKit uses this to attach the sky cubemap for use in

--- a/StereoKitC/asset_types/material.cpp
+++ b/StereoKitC/asset_types/material.cpp
@@ -336,6 +336,14 @@ void material_set_depth_write(material_t material, bool32_t write_enabled) {
 
 ///////////////////////////////////////////
 
+void material_set_depth_clip(material_t material, bool32_t clip_enabled) {
+	material->depth_clip = clip_enabled;
+	skg_pipeline_set_depth_clip(&material->pipeline, clip_enabled);
+	material_update_label(material);
+}
+
+///////////////////////////////////////////
+
 void material_set_queue_offset(material_t material, int32_t offset) {
 	material->queue_offset = offset;
 }
@@ -381,6 +389,12 @@ depth_test_ material_get_depth_test(material_t material) {
 
 bool32_t material_get_depth_write(material_t material) {
 	return material->depth_write;
+}
+
+///////////////////////////////////////////
+
+bool32_t material_get_depth_clip(material_t material) {
+	return material->depth_clip;
 }
 
 ///////////////////////////////////////////

--- a/StereoKitC/asset_types/material.cpp
+++ b/StereoKitC/asset_types/material.cpp
@@ -3,6 +3,7 @@
 #include "texture.h"
 #include "../libraries/stref.h"
 #include "../libraries/array.h"
+#include "../libraries/atomic_util.h"
 #include "../sk_memory.h"
 #include "../systems/defaults.h"
 
@@ -11,7 +12,6 @@
 
 namespace sk {
 
-_material_buffer_t material_buffers[14] = {};
 
 ///////////////////////////////////////////
 
@@ -845,23 +845,34 @@ int material_get_param_count(material_t material) {
 
 ///////////////////////////////////////////
 
-material_buffer_t material_buffer_create(int32_t register_slot, int32_t size) {
-	if (register_slot < 1 || register_slot == 2 || register_slot >= (sizeof(material_buffers)/sizeof(material_buffers[0]))) {
-		log_errf("material_buffer_create: bad slot id '%d', use 3-%d.", register_slot, (sizeof(material_buffers)/sizeof(material_buffers[0])) - 1);
-		return nullptr;
+material_buffer_t material_buffer_create(int32_t size) {
+	_material_buffer_t* buffer = sk_malloc_t(_material_buffer_t, 1);
+	buffer->size   = size;
+	buffer->refs   = 1;
+	buffer->buffer = skg_buffer_create(nullptr, 1, size, skg_buffer_type_constant, skg_use_dynamic);
+	return buffer;
+}
+
+///////////////////////////////////////////
+
+void material_buffer_addref(material_buffer_t buffer) {
+	atomic_increment(&buffer->refs);
+}
+
+///////////////////////////////////////////
+
+void material_buffer_destroy(material_buffer_t buffer) {
+	skg_buffer_destroy(&buffer->buffer);
+	*buffer = {};
+	sk_free(buffer);
+}
+
+///////////////////////////////////////////
+
+void material_buffer_release(material_buffer_t buffer) {
+	if (buffer && atomic_decrement(&buffer->refs) == 0) {
+		material_buffer_destroy(buffer);
 	}
-	if (material_buffers[register_slot].size != 0) {
-		log_errf("material_buffer_create: slot id '%d' is already in use.", register_slot);
-		return nullptr;
-	}
-	material_buffers[register_slot].buffer = skg_buffer_create(nullptr, 1, size, skg_buffer_type_constant, skg_use_dynamic);
-	material_buffers[register_slot].size   = size;
-#if !defined(SKG_OPENGL) && (defined(_DEBUG) || defined(SK_GPU_LABELS))
-	char name[64];
-	snprintf(name, sizeof(name), "render/material_buffer/register_%d", register_slot);
-	skg_buffer_name(&material_buffers[register_slot].buffer, name);
-#endif
-	return &material_buffers[register_slot];
 }
 
 ///////////////////////////////////////////
@@ -900,13 +911,6 @@ void material_check_dirty(material_t material) {
 
 	skg_buffer_set_contents(&material->args.buffer_gpu, material->args.buffer, (uint32_t)material->args.buffer_size);
 	material->args.buffer_dirty = false;
-}
-
-///////////////////////////////////////////
-
-void material_buffer_release(material_buffer_t buffer) {
-	skg_buffer_destroy(&buffer->buffer);
-	*buffer = {};
 }
 
 } // namespace sk

--- a/StereoKitC/asset_types/material.h
+++ b/StereoKitC/asset_types/material.h
@@ -38,6 +38,7 @@ struct _material_t {
 };
 
 struct _material_buffer_t {
+	int32_t      refs;
 	int32_t      size;
 	skg_buffer_t buffer;
 };
@@ -46,7 +47,5 @@ void   material_destroy          (material_t material);
 void   material_check_dirty      (material_t material);
 void   material_check_tex_changes(material_t material);
 size_t material_param_size       (material_param_ type);
-
-extern _material_buffer_t material_buffers[14];
 
 } // namespace sk

--- a/StereoKitC/asset_types/material.h
+++ b/StereoKitC/asset_types/material.h
@@ -31,6 +31,7 @@ struct _material_t {
 	bool32_t          wireframe;
 	depth_test_       depth_test;
 	bool32_t          depth_write;
+	bool32_t          depth_clip;
 	int32_t           queue_offset;
 	skg_pipeline_t    pipeline;
 	material_t        chain;

--- a/StereoKitC/asset_types/texture.cpp
+++ b/StereoKitC/asset_types/texture.cpp
@@ -784,8 +784,7 @@ void tex_set_surface(tex_t texture, void *native_surface, tex_type_ type, int64_
 		skg_tex_destroy (&texture->tex);
 
 	skg_tex_type_ skg_type = skg_tex_type_image;
-	if      (type & tex_type_cubemap     ) skg_type = skg_tex_type_cubemap;
-	else if (type & tex_type_zbuffer     ) skg_type = skg_tex_type_zbuffer;
+	if      (type & tex_type_zbuffer     ) skg_type = skg_tex_type_zbuffer;
 	else if (type & tex_type_rendertarget) skg_type = skg_tex_type_rendertarget;
 	else if (type & tex_type_depthtarget ) skg_type = skg_tex_type_depthtarget;
 
@@ -817,8 +816,7 @@ void tex_set_surface_layer(tex_t texture, void *native_surface, tex_type_ type, 
 		skg_tex_destroy (&texture->tex);
 
 	skg_tex_type_ skg_type = skg_tex_type_image;
-	if      (type & tex_type_cubemap     ) skg_type = skg_tex_type_cubemap;
-	else if (type & tex_type_zbuffer     ) skg_type = skg_tex_type_zbuffer;
+	if      (type & tex_type_zbuffer     ) skg_type = skg_tex_type_zbuffer;
 	else if (type & tex_type_rendertarget) skg_type = skg_tex_type_rendertarget;
 	else if (type & tex_type_depthtarget ) skg_type = skg_tex_type_depthtarget;
 
@@ -928,8 +926,8 @@ void _tex_set_color_arr(tex_t texture, int32_t width, int32_t height, void **arr
 		skg_use_      use      = texture->type & tex_type_dynamic ? skg_use_dynamic  : skg_use_static;
 		skg_mip_      use_mips = texture->type & tex_type_mips    ? skg_mip_generate : skg_mip_none;
 		skg_tex_type_ type     = skg_tex_type_image;
-		if      (texture->type & tex_type_cubemap)      type = skg_tex_type_cubemap;
-		else if (texture->type & tex_type_zbuffer)      type = skg_tex_type_zbuffer;
+		if (texture->type & tex_type_cubemap) use = (skg_use_)(use | skg_use_cubemap);
+		if      (texture->type & tex_type_zbuffer)      type = skg_tex_type_zbuffer;
 		else if (texture->type & tex_type_rendertarget) type = skg_tex_type_rendertarget;
 		else if (texture->type & tex_type_depthtarget)  type = skg_tex_type_depthtarget;
 

--- a/StereoKitC/asset_types/texture.h
+++ b/StereoKitC/asset_types/texture.h
@@ -8,22 +8,23 @@
 namespace sk {
 
 struct _tex_t {
-	asset_header_t header;
-	tex_t          fallback;
-	bool32_t       owned;
+	asset_header_t   header;
+	tex_t            fallback;
+	bool32_t         owned;
 
 	// Metadata fields
-	int32_t        width;
-	int32_t        height;
-	tex_format_    format;
-	uint64_t       meta_hash;
+	int32_t          width;
+	int32_t          height;
+	tex_format_      format;
+	uint64_t         meta_hash;
 
-	tex_type_      type;
-	tex_sample_    sample_mode;
-	tex_address_   address_mode;
-	int32_t        anisotropy;
-	skg_tex_t      tex;
-	tex_t          depth_buffer;
+	tex_type_        type;
+	tex_sample_      sample_mode;
+	tex_sample_comp_ sample_comp;
+	tex_address_     address_mode;
+	int32_t          anisotropy;
+	skg_tex_t        tex;
+	tex_t            depth_buffer;
 	spherical_harmonics_t *light_info;
 };
 

--- a/StereoKitC/asset_types/texture_.h
+++ b/StereoKitC/asset_types/texture_.h
@@ -5,7 +5,7 @@
 namespace sk {
 
 void        tex_set_zbuffer      (tex_t texture, tex_t depth_texture);
-void        tex_set_options      (tex_t texture, tex_sample_ sample = tex_sample_linear, tex_address_ address_mode = tex_address_wrap, int32_t anisotropy_level = 4);
+void        tex_set_options      (tex_t texture, tex_sample_ sample = tex_sample_linear, tex_address_ address_mode = tex_address_wrap, tex_sample_comp_ compare = tex_sample_comp_none, int32_t anisotropy_level = 4);
 void        tex_set_surface_layer(tex_t texture, void *native_surface, tex_type_ type, int64_t native_fmt, int32_t width, int32_t height, int32_t surface_index);
 size_t      tex_format_size      (tex_format_ format, int32_t width, int32_t height);
 tex_format_ tex_get_tex_format   (int64_t native_fmt);

--- a/StereoKitC/stereokit.h
+++ b/StereoKitC/stereokit.h
@@ -1016,8 +1016,14 @@ typedef enum tex_type_ {
 	  that might be passed in as a target to Renderer.Blit, or other
 	  such situations.*/
 	tex_type_rendertarget  = 1 << 2,
-	/*This texture contains depth data, not color data!*/
+	/*This texture contains depth data, not color data! It is writeable, but
+	  not readable. This makes it great for zbuffers, but not shadowmaps or
+	  other textures that need to be read from later on.*/
 	tex_type_depth         = 1 << 3,
+	/*This texture contains depth data, not color data! It is writeable, but
+	  not readable. This makes it great for zbuffers, but not shadowmaps or
+	  other textures that need to be read from later on.*/
+	tex_type_zbuffer       = 1 << 3,
 	/*This texture will generate mip-maps any time the contents
 	  change. Mip-maps are a list of textures that are each half the
 	  size of the one before them! This is used to prevent textures from
@@ -1027,6 +1033,10 @@ typedef enum tex_type_ {
 	  CPU (not renders)! This ensures the graphics card stores it
 	  someplace where writes are easy to do quickly.*/
 	tex_type_dynamic       = 1 << 5,
+	/*This texture contains depth data, not color data! It is writeable and
+	  readable. This makes it great for shadowmaps or other textures that need to
+	  be read from later on.*/
+	tex_type_depthtarget   = 1 << 6,
 	/*A standard color image that also generates mip-maps
 	  automatically.*/
 	tex_type_image         = tex_type_image_nomips | tex_type_mips,

--- a/StereoKitC/stereokit.h
+++ b/StereoKitC/stereokit.h
@@ -1349,9 +1349,10 @@ SK_API int32_t           material_get_param_count (material_t material);
 SK_API void              material_set_shader      (material_t material, shader_t shader);
 SK_API shader_t          material_get_shader      (material_t material);
 
-SK_API material_buffer_t material_buffer_create   (int32_t register_slot, int32_t size);
-SK_API void              material_buffer_set_data (material_buffer_t buffer, const void *buffer_data);
+SK_API material_buffer_t material_buffer_create   (int32_t size);
+SK_API void              material_buffer_addref   (material_buffer_t buffer);
 SK_API void              material_buffer_release  (material_buffer_t buffer);
+SK_API void              material_buffer_set_data (material_buffer_t buffer, const void *buffer_data);
 
 ///////////////////////////////////////////
 
@@ -1725,6 +1726,7 @@ SK_API color128              render_get_clear_color(void);
 SK_API void                  render_enable_skytex  (bool32_t show_sky);
 SK_API bool32_t              render_enabled_skytex (void);
 SK_API void                  render_global_texture (int32_t register_slot, tex_t texture);
+SK_API void                  render_global_buffer  (int32_t register_slot, material_buffer_t buffer);
 SK_API void                  render_add_mesh       (mesh_t  mesh,  material_t material,          const sk_ref(matrix) transform, color128 color_linear sk_default({1,1,1,1}), render_layer_ layer sk_default(render_layer_0));
 SK_API void                  render_add_model      (model_t model,                               const sk_ref(matrix) transform, color128 color_linear sk_default({1,1,1,1}), render_layer_ layer sk_default(render_layer_0));
 SK_API void                  render_add_model_mat  (model_t model, material_t material_override, const sk_ref(matrix) transform, color128 color_linear sk_default({1,1,1,1}), render_layer_ layer sk_default(render_layer_0));

--- a/StereoKitC/stereokit.h
+++ b/StereoKitC/stereokit.h
@@ -1116,8 +1116,8 @@ SK_API asset_state_ tex_asset_state         (const tex_t texture);
 SK_API void         tex_on_load             (tex_t texture, void (*asset_on_load_callback)(tex_t texture, void *context), void *context);
 SK_API void         tex_on_load_remove      (tex_t texture, void (*asset_on_load_callback)(tex_t texture, void *context));
 SK_API void         tex_set_colors          (tex_t texture, int32_t width, int32_t height, void *data);
-SK_API void         tex_set_color_arr       (tex_t texture, int32_t width, int32_t height, void** array_data, int32_t array_count, spherical_harmonics_t* out_sh_lighting_info sk_default(nullptr), int32_t multisample sk_default(1));
-SK_API void         tex_set_color_arr_mips  (tex_t texture, int32_t width, int32_t height, void** array_data, int32_t array_count, int32_t mip_count, int32_t multisample sk_default(1), spherical_harmonics_t* sh_lighting_info sk_default(nullptr));
+SK_API void         tex_set_color_arr       (tex_t texture, int32_t width, int32_t height, void** array_data, int32_t array_count,                    int32_t multisample sk_default(1), spherical_harmonics_t* out_sh_lighting_info sk_default(nullptr));
+SK_API void         tex_set_color_arr_mips  (tex_t texture, int32_t width, int32_t height, void** array_data, int32_t array_count, int32_t mip_count, int32_t multisample sk_default(1), spherical_harmonics_t* out_sh_lighting_info sk_default(nullptr));
 SK_API void         tex_set_mem             (tex_t texture, void* data, size_t data_size, bool32_t srgb_data sk_default(true), bool32_t blocking sk_default(false), int32_t priority sk_default(10));
 SK_API void         tex_add_zbuffer         (tex_t texture, tex_format_ format sk_default(tex_format_depthstencil));
 SK_API void         tex_set_zbuffer         (tex_t texture, tex_t depth_texture);
@@ -1731,8 +1731,7 @@ SK_API void                  render_screenshot     (const char *file_utf8, int32
 //TODO: for v0.4, reorder parameters, context in particular should be next to callback
 SK_API void                  render_screenshot_capture  (void (*render_on_screenshot_callback)(color32* color_buffer, int32_t width, int32_t height, void* context), pose_t viewpoint, int32_t width, int32_t height, float field_of_view_degrees, tex_format_ tex_format sk_default(tex_format_rgba32), void *context sk_default(nullptr));
 SK_API void                  render_screenshot_viewpoint(void (*render_on_screenshot_callback)(color32* color_buffer, int32_t width, int32_t height, void* context), matrix camera, matrix projection, int32_t width, int32_t height, render_layer_ layer_filter sk_default(render_layer_all), render_clear_ clear sk_default(render_clear_all), rect_t viewport sk_default(rect_t{}), tex_format_ tex_format sk_default(tex_format_rgba32), void* context sk_default(nullptr));
-SK_API void                  render_to             (tex_t to_rendertarget, const sk_ref(matrix) camera, const sk_ref(matrix) projection, render_layer_ layer_filter sk_default(render_layer_all), render_clear_ clear sk_default(render_clear_all), rect_t viewport sk_default({}));
-SK_API void                  render_material_to    (tex_t to_rendertarget, material_t override_material, const sk_ref(matrix) camera, const sk_ref(matrix) projection, render_layer_ layer_filter sk_default(render_layer_all), render_clear_ clear sk_default(render_clear_all), rect_t viewport sk_default({}));
+SK_API void                  render_to             (tex_t to_rendertarget, int32_t to_target_index, material_t override_material, const sk_ref(matrix) camera, const sk_ref(matrix) projection, render_layer_ layer_filter sk_default(render_layer_all), render_clear_ clear sk_default(render_clear_all), rect_t viewport sk_default({}));
 SK_API void                  render_get_device     (void **device, void **context);
 SK_API render_list_t         render_get_primary_list(void);
 

--- a/StereoKitC/stereokit.h
+++ b/StereoKitC/stereokit.h
@@ -1060,6 +1060,18 @@ typedef enum tex_sample_ {
 	tex_sample_anisotropic
 } tex_sample_;
 
+typedef enum tex_sample_comp_ {
+	tex_sample_comp_none = 0,
+	tex_sample_comp_less,
+	tex_sample_comp_less_or_eq,
+	tex_sample_comp_greater,
+	tex_sample_comp_greater_or_eq,
+	tex_sample_comp_equal,
+	tex_sample_comp_not_equal,
+	tex_sample_comp_always,
+	tex_sample_comp_never,
+} tex_sample_comp_;
+
 /*What happens when the shader asks for a texture coordinate
   that's outside the texture?? Believe it or not, this happens plenty
   often!*/
@@ -1120,6 +1132,8 @@ SK_API int32_t      tex_get_width           (tex_t texture);
 SK_API int32_t      tex_get_height          (tex_t texture);
 SK_API void         tex_set_sample          (tex_t texture, tex_sample_ sample sk_default(tex_sample_linear));
 SK_API tex_sample_  tex_get_sample          (tex_t texture);
+SK_API void             tex_set_sample_comp (tex_t texture, tex_sample_comp_ compare sk_default(tex_sample_comp_none));
+SK_API tex_sample_comp_ tex_get_sample_comp (tex_t texture);
 SK_API void         tex_set_address         (tex_t texture, tex_address_ address_mode sk_default(tex_address_wrap));
 SK_API tex_address_ tex_get_address         (tex_t texture);
 SK_API void         tex_set_anisotropy      (tex_t texture, int32_t anisotropy_level sk_default(4));

--- a/StereoKitC/stereokit.h
+++ b/StereoKitC/stereokit.h
@@ -1301,6 +1301,7 @@ SK_API void              material_set_cull        (material_t material, cull_ mo
 SK_API void              material_set_wireframe   (material_t material, bool32_t wireframe);
 SK_API void              material_set_depth_test  (material_t material, depth_test_ depth_test_mode);
 SK_API void              material_set_depth_write (material_t material, bool32_t write_enabled);
+SK_API void              material_set_depth_clip  (material_t material, bool32_t clip_enabled);
 SK_API void              material_set_queue_offset(material_t material, int32_t offset);
 SK_API void              material_set_chain       (material_t material, material_t chain_material);
 SK_API transparency_     material_get_transparency(material_t material);
@@ -1308,6 +1309,7 @@ SK_API cull_             material_get_cull        (material_t material);
 SK_API bool32_t          material_get_wireframe   (material_t material);
 SK_API depth_test_       material_get_depth_test  (material_t material);
 SK_API bool32_t          material_get_depth_write (material_t material);
+SK_API bool32_t          material_get_depth_clip  (material_t material);
 SK_API int32_t           material_get_queue_offset(material_t material);
 SK_API material_t        material_get_chain       (material_t material);
 SK_API void              material_set_float       (material_t material, const char *name, float    value);

--- a/StereoKitC/systems/render.cpp
+++ b/StereoKitC/systems/render.cpp
@@ -1063,7 +1063,7 @@ void render_to(tex_t to_rendertarget, const matrix &camera, const matrix &projec
 ///////////////////////////////////////////
 
 void render_material_to(tex_t to_rendertarget, material_t override_material, const matrix& camera, const matrix& projection, render_layer_ layer_filter, render_clear_ clear, rect_t viewport) {
-	if ((to_rendertarget->type & tex_type_rendertarget) == 0) {
+	if (!(to_rendertarget->type & tex_type_rendertarget || to_rendertarget->type & tex_type_depthtarget || to_rendertarget->type & tex_type_zbuffer)) {
 		log_err("render_to texture must be a render target texture type!");
 		return;
 	}

--- a/StereoKitC/systems/render.h
+++ b/StereoKitC/systems/render.h
@@ -41,6 +41,7 @@ void          render_draw_queue           (render_list_t list, const matrix* vie
 void          render_check_screenshots    ();
 void          render_check_viewpoints     ();
 void          render_check_pending_skytex ();
+void          render_global_buffer_internal(int32_t register_slot, material_buffer_t buffer);
 
 void          render_list_destroy         (      render_list_t list);
 void          render_list_execute         (      render_list_t list, render_layer_ filter, uint32_t inst_multiplier, int32_t queue_start, int32_t queue_end);

--- a/StereoKitC/systems/render_pipeline.cpp
+++ b/StereoKitC/systems/render_pipeline.cpp
@@ -198,6 +198,11 @@ void render_pipeline_surface_to_swapchain(pipeline_surface_id surface_id, skg_sw
 
 	skg_event_begin("Present");
 	{
+		// If this is a zbuffer, then we don't need depth data after this point. We
+		// discard it if we can.
+		if (surface->tex->depth_buffer)
+			skg_tex_target_discard(&surface->tex->depth_buffer->tex);
+
 		// This copies the color data over to the swapchain, and resolves any
 		// multisampling on the primary target texture.
 		skg_tex_copy_to_swapchain(&surface->tex->tex, swapchain);
@@ -215,6 +220,11 @@ void render_pipeline_surface_to_tex(pipeline_surface_id surface_id, tex_t destin
 
 	skg_event_begin("Present to Tex");
 	{
+		// If this is a zbuffer, then we don't need depth data after this point. We
+		// discard it if we can.
+		if (surface->tex->depth_buffer)
+			skg_tex_target_discard(&surface->tex->depth_buffer->tex);
+
 		if (mat) {
 			material_set_texture(mat, "source", surface->tex);
 			render_blit(destination, mat);

--- a/StereoKitC/systems/render_pipeline.cpp
+++ b/StereoKitC/systems/render_pipeline.cpp
@@ -165,7 +165,7 @@ bool32_t render_pipeline_surface_resize(pipeline_surface_id surface_id, int32_t 
 		surface->tex         = tex_create(tex_type_image_nomips | tex_type_rendertarget, surface->color);
 		surface->multisample = multisample;
 		surface->enabled     = true;
-		tex_set_color_arr(surface->tex, width, height, nullptr, surface->array_count, nullptr, multisample);
+		tex_set_color_arr(surface->tex, width, height, nullptr, surface->array_count, multisample, nullptr);
 
 		char name[64];
 		snprintf(name, sizeof(name), "sk/render/pipeline_surface_%d", surface_id);
@@ -186,7 +186,7 @@ bool32_t render_pipeline_surface_resize(pipeline_surface_id surface_id, int32_t 
 
 	log_diagf("Resizing target surface: <~grn>%d<~clr>x<~grn>%d<~clr>x<~grn>%d<~clr>@<~grn>%d<~clr>msaa", width, height, surface->array_count, multisample);
 	surface->multisample = multisample;
-	tex_set_color_arr(surface->tex, width, height, nullptr, surface->array_count, nullptr, multisample);
+	tex_set_color_arr(surface->tex, width, height, nullptr, surface->array_count, multisample, nullptr);
 
 	return true;
 }

--- a/StereoKitC/xr_backends/openxr_view.cpp
+++ b/StereoKitC/xr_backends/openxr_view.cpp
@@ -880,6 +880,12 @@ bool openxr_render_frame() {
 				if (swapchain->render_surface >= 0 && render_pipeline_surface_get_enabled(swapchain->render_surface))
 					render_pipeline_surface_to_tex(swapchain->render_surface, swapchain->textures[swapchain->render_surface_tex], nullptr);
 			}
+		} else {
+			for (int32_t i = 0; i < xr_displays.count; i++) {
+				swapchain_t* swapchain = &xr_displays[i].swapchain_color;
+				if (swapchain->render_surface >= 0 && render_pipeline_surface_get_enabled(swapchain->render_surface) && swapchain->textures[swapchain->render_surface_tex]->depth_buffer)
+					skg_tex_target_discard(&swapchain->textures[swapchain->render_surface_tex]->depth_buffer->tex);
+			}
 		}
 
 		for (int32_t i = 0; i < xr_displays    .count; i++) openxr_display_swapchain_release(&xr_displays    [i]);


### PR DESCRIPTION
Added a DemoShadows.cs, which demonstrates how to make a simple single cascade shadow map implementation! More extensive shadow tooling may come in the future, this example was simplified to make for a better demo.

Adds `Tex.SampleComp` `Material.DepthClip`, an empty `MaterialBuffer` constructor, `Renderer.SetGlobalBuffer`, and `Renderer.RenderTo` with a target array index parameter.
`Tex.SetSize` now takes array count and MSAA.
TexType has split `Depth` into `Zbuffer` and `DepthTarget`. `Depth` is equivalent to `Zbuffer`.
Cubemaps can now also be render targets.

This also contains a number of breaking changes for the C api, please review stereokit.h for details.