### PR TITLE
Packed float color formats

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,8 +229,8 @@ add_compile_definitions(BASISD_SUPPORT_BC7_MODE5=0)
 #### sk_gpu - https://github.com/StereoKit/sk_gpu ####
 if (NOT SK_LOCAL_SK_GPU)
   CPMAddPackage( # We're scraping the comment after the NAME for some other scripts
-    NAME sk_gpu # 2025.8.12
-    URL https://github.com/StereoKit/sk_gpu/releases/download/v2025.8.12/sk_gpu.v2025.8.12.zip
+    NAME sk_gpu # 2025.8.15
+    URL https://github.com/StereoKit/sk_gpu/releases/download/v2025.8.15/sk_gpu.v2025.8.15.zip
   )
 else()
   # For building directly with in-progress sk_gpu changes, point this to your

--- a/Examples/StereoKitTest/Program.cs
+++ b/Examples/StereoKitTest/Program.cs
@@ -19,6 +19,7 @@ class Program
 		appName         = "StereoKit C#",
 		blendPreference = DisplayBlend.AnyTransparent,
 		mode            = AppMode.XR,
+		renderScaling   = 1.5f,
 	};
 
 	static Mesh      floorMesh;
@@ -50,9 +51,9 @@ class Program
 
 		// OpenXR extensions need added before SK.Initialize, so does
 		// LogWindow for early log registration!
-		SK.AddStepper<PassthroughFBExt>();
 		SK.AddStepper<Win32PerformanceCounterExt>();
 		SK.AddStepper<XrCompLayers>();
+		SK.AddStepper(new XrRefreshRate(120));
 		WindowLog = SK.AddStepper<LogWindow>();
 		WindowLog.Enabled = false;
 

--- a/Examples/StereoKitTest/Tests/TestTextures.cs
+++ b/Examples/StereoKitTest/Tests/TestTextures.cs
@@ -39,8 +39,10 @@ internal class TestTextures : ITest
 		int oh = 33;
 		testTextures.Add(MakeTest(TexFormat.Rgba32,       new Color32(255,0,0,255), new Color32(0,0,0,255), w,  h ));
 		testTextures.Add(MakeTest(TexFormat.Rgba32Linear, new Color32(255,0,0,255), new Color32(0,0,0,255), ow, oh));
+#if !ANDROID
 		testTextures.Add(MakeTest(TexFormat.Bgra32,       new Color32(0,0,255,255), new Color32(0,0,0,255), w,  h ));
 		testTextures.Add(MakeTest(TexFormat.Bgra32Linear, new Color32(0,0,255,255), new Color32(0,0,0,255), ow, oh));
+#endif
 		testTextures.Add(MakeTest(TexFormat.Rgba64f,      on64, off64, w,  h ));
 		testTextures.Add(MakeTest(TexFormat.Rgba64f,      on64, off64, ow, oh));
 		testTextures.Add(MakeTest(TexFormat.Rgba128,      new Color(1,0,0,1), new Color(0,0,0,1), w,  h ));
@@ -55,10 +57,10 @@ internal class TestTextures : ITest
 		testTextures.Add(MakeTest(TexFormat.R32,          1.0f, 0, ow, oh));
 		testTextures.Add(MakeTest(TexFormat.R8g8,         onRG, offRG, w,  h ));
 		testTextures.Add(MakeTest(TexFormat.R8g8,         onRG, offRG, ow, oh));
-		testTextures.Add(MakeTest(TexFormat.Rgb10a2,      onRGB10A2, offRGB10A2, w, h));
-		testTextures.Add(MakeTest(TexFormat.Rgb10a2,      onRGB10A2, offRGB10A2, ow, oh));
 		testTextures.Add(MakeTest(TexFormat.Rg11b10,      onRG11B10, offRG11B10A2, w, h));
 		testTextures.Add(MakeTest(TexFormat.Rg11b10,      onRG11B10, offRG11B10A2, ow, oh));
+		testTextures.Add(MakeTest(TexFormat.Rgb10a2,      onRGB10A2, offRGB10A2, w, h));
+		testTextures.Add(MakeTest(TexFormat.Rgb10a2,      onRGB10A2, offRGB10A2, ow, oh));
 
 		Tests.Test(CheckTextureFormats);
 		Tests.Test(CheckTextureRead);

--- a/Examples/StereoKitTest/Tests/TestTextures.cs
+++ b/Examples/StereoKitTest/Tests/TestTextures.cs
@@ -1,12 +1,11 @@
 ﻿// SPDX-License-Identifier: MIT
 // The authors below grant copyright rights under the MIT license:
-// Copyright (c) 2019-2024 Nick Klingensmith
-// Copyright (c) 2024 Qualcomm Technologies, Inc.
+// Copyright (c) 2019-2025 Nick Klingensmith
+// Copyright (c) 2024-2025 Qualcomm Technologies, Inc.
 
 using StereoKit;
 using System;
 using System.Collections.Generic;
-using System.Numerics;
 using System.Runtime.InteropServices;
 
 internal class TestTextures : ITest
@@ -28,6 +27,10 @@ internal class TestTextures : ITest
 		ushort off16 = 0x0000;
 		ushort onRG  = 0xFF00;
 		ushort offRG = 0x00FF;
+		uint   onRGB10A2    = 0xC00003FF;
+		uint   offRGB10A2   = 0xC0000000;
+		uint   onRG11B10    = 0x3C0;
+		uint   offRG11B10A2 = 0x0;
 
 		// Test a NPOT size to ensure mips work properly with that
 		int w = 32;
@@ -52,6 +55,10 @@ internal class TestTextures : ITest
 		testTextures.Add(MakeTest(TexFormat.R32,          1.0f, 0, ow, oh));
 		testTextures.Add(MakeTest(TexFormat.R8g8,         onRG, offRG, w,  h ));
 		testTextures.Add(MakeTest(TexFormat.R8g8,         onRG, offRG, ow, oh));
+		testTextures.Add(MakeTest(TexFormat.Rgb10a2,      onRGB10A2, offRGB10A2, w, h));
+		testTextures.Add(MakeTest(TexFormat.Rgb10a2,      onRGB10A2, offRGB10A2, ow, oh));
+		testTextures.Add(MakeTest(TexFormat.Rg11b10,      onRG11B10, offRG11B10A2, w, h));
+		testTextures.Add(MakeTest(TexFormat.Rg11b10,      onRG11B10, offRG11B10A2, ow, oh));
 
 		Tests.Test(CheckTextureFormats);
 		Tests.Test(CheckTextureRead);

--- a/Examples/StereoKitTest/Tools/LogWindow.cs
+++ b/Examples/StereoKitTest/Tools/LogWindow.cs
@@ -31,7 +31,7 @@ namespace StereoKit.Framework
 		List<LogItem> items = new List<LogItem>();
 		static float  logIndex = 0;
 
-		DiagGraph fpsGraph        = new DiagGraph(5f, 32f);
+		DiagGraph fpsGraph        = new DiagGraph(5f, 20f);
 		DiagGraph ramGraph        = new DiagGraph(0,0);
 		DiagGraph managedRamGraph = new DiagGraph(0,0);
 		ulong lastMemPoll = 0;

--- a/Examples/StereoKitTest/Tools/XrCompLayers.cs
+++ b/Examples/StereoKitTest/Tools/XrCompLayers.cs
@@ -20,9 +20,9 @@ namespace StereoKit.Framework
 		}
 
 		public bool Initialize()
-        {
-            _androidSwapchainAvailable = Backend.OpenXR.ExtEnabled("XR_KHR_android_surface_swapchain");
-            Enabled =
+		{
+			_androidSwapchainAvailable = Backend.OpenXR.ExtEnabled("XR_KHR_android_surface_swapchain");
+			Enabled =
 				Backend.XRType == BackendXRType.OpenXR &&
 				LoadBindings();
 

--- a/Examples/StereoKitTest/Tools/XrRefreshRate.cs
+++ b/Examples/StereoKitTest/Tools/XrRefreshRate.cs
@@ -1,0 +1,57 @@
+﻿using System;
+
+namespace StereoKit.Framework
+{
+	class XrRefreshRate : IStepper
+	{
+		int _rate;
+		public bool Enabled { get; private set; }
+
+		public XrRefreshRate() : this(0) { }
+		public XrRefreshRate(int rate)
+		{
+			_rate = rate;
+
+			if (SK.IsInitialized)
+				Log.Err("XrRefreshRate must be Setup before StereoKit is initialized!");
+
+			Backend.OpenXR.RequestExt("XR_FB_display_refresh_rate");
+		}
+
+		public bool Initialize()
+		{
+			Enabled =
+				Backend.XRType == BackendXRType.OpenXR &&
+				Backend.OpenXR.ExtEnabled("XR_FB_display_refresh_rate") &&
+				LoadBindings();
+
+			if (Enabled && _rate != 0)
+				SetRefreshRate(_rate);
+
+			return true;
+		}
+
+		public void SetRefreshRate(int rate)
+		{
+			if (Enabled)
+				xrRequestDisplayRefreshRateFB(Backend.OpenXR.Session, rate);
+		}
+
+		public void Shutdown() { Enabled = false; }
+		public void Step() { }
+
+		#region OpenXR Bindings
+		enum XrResult : Int32 { Success = 0 }
+
+		delegate XrResult del_xrRequestDisplayRefreshRateFB( ulong session, float displayRefreshRate);
+		del_xrRequestDisplayRefreshRateFB xrRequestDisplayRefreshRateFB;
+
+		bool LoadBindings()
+		{
+			xrRequestDisplayRefreshRateFB = Backend.OpenXR.GetFunction<del_xrRequestDisplayRefreshRateFB>("xrRequestDisplayRefreshRateFB");
+
+			return xrRequestDisplayRefreshRateFB != null;
+		}
+		#endregion
+	}
+}

--- a/StereoKitC/spherical_harmonics.cpp
+++ b/StereoKitC/spherical_harmonics.cpp
@@ -14,6 +14,7 @@ vec3 to_color_128(uint8_t *color) { return *(vec3 *)color; }
 vec3 to_color_32 (uint8_t *color) { return vec3{color[0]/255.f,color[1]/255.f,color[2]/255.f}; }
 vec3 to_color_32_linear(uint8_t* color) { return vec3{ powf(color[0] / 255.f,2.2f),powf(color[1] / 255.f,2.2f),powf(color[2] / 255.f,2.2f) }; }
 vec3 to_color_64(uint8_t* color) { const uint16_t* c = (uint16_t*)color; vec4 r; fhf_f16_to_f32_x4(c, &r.x); return vec3{ r.x, r.y, r.z }; }
+vec3 to_color_11_11_10f(uint8_t* color) { vec3 r; fhf_r11g11b10f_to_f32_x3(*(uint32_t*)color, &r.x); return vec3{ r.x, r.y, r.z }; }
 
 ///////////////////////////////////////////
 
@@ -96,6 +97,7 @@ spherical_harmonics_t sh_calculate(void **env_map_data, tex_format_ format, int3
 	switch (format) {
 	case tex_format_rgba128:       convert = to_color_128;       col_size = sizeof(float) * 4; break;
 	case tex_format_rgba64f:       convert = to_color_64;        col_size = sizeof(uint16_t) * 4; break;
+	case tex_format_rg11b10:       convert = to_color_11_11_10f; col_size = sizeof(uint32_t); break;
 	case tex_format_rgba32:        convert = to_color_32_linear; col_size = sizeof(color32); break;
 	case tex_format_rgba32_linear: convert = to_color_32;        col_size = sizeof(color32); break;
 	default: return {};


### PR DESCRIPTION
Adds/improves/fixes rg11b10 and rgb10a2 format support.
Skyboxes and cubemaps now use rg11b10 format instead of rgba64.
Added a quick tool for setting the refresh rate using the FB extension.