### PR TITLE
Profiling tools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,6 +246,7 @@ if (SK_PROFILE)
       "TRACY_ON_DEMAND ON"
   )
   add_definitions("-DTRACY_ENABLE")
+  set_target_properties(TracyClient PROPERTIES POSITION_INDEPENDENT_CODE ON)
 endif()
 
 #### sk_gpu - https://github.com/StereoKit/sk_gpu ####

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ set(SK_BUILD_SHARED_LIBS            ON  CACHE BOOL "Should StereoKit build as a 
 set(SK_DYNAMIC_OPENXR               OFF CACHE BOOL "Dynamic link with the standard OpenXR Loader. Not what you want on desktop, but on Android you may need to dynamic link with other loaders.")
 set(SK_WINDOWS_GL                   OFF CACHE BOOL "Build Windows version using OpenGL as the renderer. This is primarily for debugging GL code while developing on Windows.")
 set(SK_LOCAL_SK_GPU                 OFF CACHE BOOL "Build using a local version of sk_gpu, instead of the latest release. This is useful for testing in-progress changes to sk_gpu.")
-set(SK_PROFILE                      ON  CACHE BOOL "Build with Tracy profiler enabled.")
+set(SK_PROFILE                      OFF CACHE BOOL "Build with Tracy profiler enabled.")
 set(FORCE_COLORED_OUTPUT            OFF CACHE BOOL "Always produce ANSI-colored output (GNU/Clang only).")
 
 ###########################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ set(SK_BUILD_SHARED_LIBS            ON  CACHE BOOL "Should StereoKit build as a 
 set(SK_DYNAMIC_OPENXR               OFF CACHE BOOL "Dynamic link with the standard OpenXR Loader. Not what you want on desktop, but on Android you may need to dynamic link with other loaders.")
 set(SK_WINDOWS_GL                   OFF CACHE BOOL "Build Windows version using OpenGL as the renderer. This is primarily for debugging GL code while developing on Windows.")
 set(SK_LOCAL_SK_GPU                 OFF CACHE BOOL "Build using a local version of sk_gpu, instead of the latest release. This is useful for testing in-progress changes to sk_gpu.")
+set(SK_PROFILE                      ON  CACHE BOOL "Build with Tracy profiler enabled.")
 set(FORCE_COLORED_OUTPUT            OFF CACHE BOOL "Always produce ANSI-colored output (GNU/Clang only).")
 
 ###########################################
@@ -231,6 +232,21 @@ add_compile_definitions(BASISD_SUPPORT_ATC=0)
 add_compile_definitions(BASISD_SUPPORT_ETC2_EAC_A8=0)
 add_compile_definitions(BASISD_SUPPORT_BC7=0)
 add_compile_definitions(BASISD_SUPPORT_BC7_MODE5=0)
+
+#### Tracy Profiler - https://github.com/wolfpld/tracy ####
+
+if (SK_PROFILE)
+  CPMAddPackage(
+    NAME tracy
+    GITHUB_REPOSITORY wolfpld/tracy
+    GIT_TAG v0.12.2
+    GIT_SHALLOW 1
+    OPTIONS
+      "TRACY_ENABLE ON"
+      "TRACY_ON_DEMAND ON"
+  )
+  add_definitions("-DTRACY_ENABLE")
+endif()
 
 #### sk_gpu - https://github.com/StereoKit/sk_gpu ####
 if (NOT SK_LOCAL_SK_GPU)
@@ -622,6 +638,10 @@ target_link_libraries( StereoKitC
     ${OPENXR_LIB}
     ${ANDROID_LIBS}
 )
+
+if (SK_PROFILE)
+  target_link_libraries( StereoKitC PRIVATE TracyClient )
+endif()
 
 # Compiler options for all the targets, now that they're all present
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")

--- a/Examples/StereoKitTest/Tools/LogWindow.cs
+++ b/Examples/StereoKitTest/Tools/LogWindow.cs
@@ -32,7 +32,6 @@ namespace StereoKit.Framework
 		static float  logIndex = 0;
 
 		DiagGraph fpsGraph        = new DiagGraph(5f, 20f);
-		DiagGraph ramGraph        = new DiagGraph(0,0);
 		DiagGraph managedRamGraph = new DiagGraph(0,0);
 		ulong lastMemPoll = 0;
 
@@ -127,18 +126,13 @@ namespace StereoKit.Framework
 			if (lastMemPoll != memPollIdx)
 			{
 				lastMemPoll = memPollIdx;
-				using (Process process = Process.GetCurrentProcess())
-				{
-					long managedMem = GC.GetTotalMemory(false);
-					long workingMem = process.WorkingSet64;
-					ramGraph       .Add(workingMem / (1024.0f * 1024.0f));
-					managedRamGraph.Add(managedMem / (1024.0f * 1024.0f));
-				}
+				long managedMem = GC.GetTotalMemory(false);
+				managedRamGraph.Add(managedMem / (1024.0f * 1024.0f));
 			}
 			#endif
 
-			float thirdWidth = (UI.LayoutRemaining.x - UI.Settings.gutter*2) / 3.0f;
-			Vec2  graphSize  = V.XY(thirdWidth, UI.LineHeight);
+			float halfWidth = (UI.LayoutRemaining.x - UI.Settings.gutter*2) / 2.0f;
+			Vec2  graphSize  = V.XY(halfWidth, UI.LineHeight);
 
 			fpsGraph.Add(Time.Stepf*1000);
 			fpsGraph.Draw(styleGraph, "Frame (ms)", UI.LayoutAt + V.XYZ(0,0,-0.004f), graphSize);
@@ -148,9 +142,6 @@ namespace StereoKit.Framework
 			managedRamGraph.Draw(styleGraph, "Managed (mb)", UI.LayoutAt + V.XYZ(0,0,-0.004f), graphSize);
 			UI.LayoutReserve(graphSize);
 			UI.SameLine();
-
-			ramGraph.Draw(styleGraph, "Total (mb)", UI.LayoutAt + V.XYZ(0, 0, -0.004f), graphSize);
-			UI.LayoutReserve(graphSize);
 		}
 
 		struct DiagGraph

--- a/StereoKitC/asset_types/animation.cpp
+++ b/StereoKitC/asset_types/animation.cpp
@@ -3,6 +3,7 @@
 #include "mesh.h"
 #include "../sk_math.h"
 #include "../libraries/stref.h"
+#include "../libraries/profiler.h"
 
 namespace sk {
 
@@ -342,6 +343,8 @@ anim_data_t anim_data_copy(anim_data_t *data) {
 ///////////////////////////////////////////
 
 void anim_step() {
+	profiler_zone();
+
 	animation_list.each(_anim_update_skin);
 	animation_list.clear();
 }

--- a/StereoKitC/asset_types/assets.cpp
+++ b/StereoKitC/asset_types/assets.cpp
@@ -23,6 +23,7 @@
 #include "../libraries/sokol_time.h"
 #include "../libraries/atomic_util.h"
 #include "../libraries/ferr_thread.h"
+#include "../libraries/profiler.h"
 #include "../systems/render_.h"
 
 #include <stdio.h>
@@ -397,6 +398,8 @@ char *assets_file(const char *file_name) {
 ///////////////////////////////////////////
 
 bool assets_init() {
+	profiler_zone();
+
 	assets_lock                     = ft_mutex_create();
 	assets_multithread_destroy_lock = ft_mutex_create();
 	assets_job_lock                 = ft_mutex_create();
@@ -424,6 +427,8 @@ bool assets_init() {
 
 array_t<asset_load_callback_t> assets_load_call_list = {};
 void assets_step() {
+	profiler_zone();
+
 	// If we have no asset threads for some reason (like WASM), then we'll need
 	// to make sure assets still get loaded here!
 	if (asset_threads.count <= 0) {
@@ -739,6 +744,8 @@ void asset_step_task() {
 	asset_task_t* task = assets_acquire_task();
 	if (task == nullptr) return;
 
+	profiler_zone();
+
 	asset_load_action_t* action = &task->actions[task->action_curr];
 	if (action->thread_affinity == asset_thread_asset) {
 		// Execute the asset loading action!
@@ -804,6 +811,10 @@ int32_t asset_thread(void *thread_inst_obj) {
 	thread->id      = ft_id_current();
 	thread->running = true;
 
+	char name[64];
+	snprintf(name, sizeof(name), "StereoKit Assets 0x%X", (uint32_t)(uint64_t)&thread->id);
+	profiler_thread_name("StereoKit Assets", 1);
+
 	// Don't start processing assets until initialization is finished
 	while (asset_thread_enabled && !sk_is_initialized())
 		platform_sleep(1);
@@ -831,6 +842,8 @@ void assets_block_until(asset_header_t *asset, asset_state_ state) {
 	if (asset->state >= state || asset->state <= asset_state_none)
 		return;
 
+	profiler_zone();
+
 	ft_id_t curr_id = ft_id_current();
 	for (int32_t i = 0; i < asset_threads.count; i++)
 	{
@@ -850,6 +863,8 @@ void assets_block_until(asset_header_t *asset, asset_state_ state) {
 ///////////////////////////////////////////
 
 void assets_block_for_priority(int32_t priority) {
+	profiler_zone();
+
 	ft_id_t curr_id = ft_id_current();
 	for (int32_t i = 0; i < asset_threads.count; i++)
 	{

--- a/StereoKitC/asset_types/model.cpp
+++ b/StereoKitC/asset_types/model.cpp
@@ -6,6 +6,7 @@
 #include "model.h"
 #include "mesh.h"
 #include "../libraries/stref.h"
+#include "../libraries/profiler.h"
 #include "../platforms/platform.h"
 
 using namespace DirectX;
@@ -50,6 +51,8 @@ model_t model_find(const char *id) {
 ///////////////////////////////////////////
 
 model_t model_copy(model_t model) {
+	profiler_zone();
+
 	if (model == nullptr) {
 		log_err("model_copy was provided a null model!");
 		return nullptr;
@@ -99,6 +102,8 @@ model_t model_create_mesh(mesh_t mesh, material_t material) {
 ///////////////////////////////////////////
 
 model_t model_create_mem(const char *filename, const void *data, size_t data_size, shader_t shader) {
+	profiler_zone();
+
 	model_t result = model_create();
 	
 	if (string_endswith(filename, ".glb",  false) || 
@@ -125,13 +130,15 @@ model_t model_create_mem(const char *filename, const void *data, size_t data_siz
 ///////////////////////////////////////////
 
 model_t model_create_file(const char *filename, shader_t shader) {
+	profiler_zone();
+
 	model_t result = model_find(filename);
 	if (result != nullptr)
 		return result;
 
 	void*    data;
 	size_t   length;
-	bool32_t loaded         = platform_read_file(filename, &data, &length);
+	bool32_t loaded = platform_read_file(filename, &data, &length);
 	if (!loaded) {
 		log_warnf("Model file failed to load: %s", filename);
 		return nullptr;

--- a/StereoKitC/asset_types/model_gltf.cpp
+++ b/StereoKitC/asset_types/model_gltf.cpp
@@ -133,7 +133,7 @@ bool gltf_parseskin(mesh_t sk_mesh, cgltf_node *node, int primitive_id, const ch
 				w->z = w->z * sum;
 			}
 			if (component_num == 4) {
-				free(weights);
+				sk_free(weights);
 				weights = (vec4*)floats;
 				for (int32_t j = 0; j < weight_ct; j++) {
 					vec4 *w   = &weights[j];

--- a/StereoKitC/asset_types/texture.cpp
+++ b/StereoKitC/asset_types/texture.cpp
@@ -9,6 +9,7 @@
 #include "../libraries/qoi.h"
 #include "../libraries/stref.h"
 #include "../libraries/ferr_halffloat.h"
+#include "../libraries/profiler.h"
 #include "../sk_math.h"
 #include "../sk_memory.h"
 #include "../spherical_harmonics.h"
@@ -85,6 +86,8 @@ void tex_load_free(asset_header_t *, void *job_data) {
 ///////////////////////////////////////////
 
 bool32_t tex_load_arr_files_shared(asset_task_t* task, asset_header_t* asset, void* job_data) {
+	profiler_zone();
+
 	tex_load_t* data = (tex_load_t*)job_data;
 	tex_t       tex  = (tex_t)asset;
 
@@ -170,6 +173,8 @@ bool32_t tex_load_arr_files(asset_task_t *task, asset_header_t *asset, void *job
 ///////////////////////////////////////////
 
 bool32_t tex_load_arr_parse(asset_task_t *, asset_header_t *asset, void *job_data) {
+	profiler_zone();
+
 	tex_load_t *data = (tex_load_t *)job_data;
 	tex_t       tex  = (tex_t)asset;
 
@@ -537,6 +542,8 @@ tex_t tex_create_file_arr(const char **files, int32_t file_count, bool32_t srgb_
 ///////////////////////////////////////////
 
 tex_t tex_create_cubemap_file(const char *cubemap_file, bool32_t srgb_data, int32_t priority) {
+	profiler_zone();
+
 	char cubemap_id[64];
 	snprintf(cubemap_id, sizeof(cubemap_id), "sk/tex/cubemap/%" PRIu64, hash_string(cubemap_file));
 
@@ -588,6 +595,8 @@ tex_t tex_create_cubemap_file(const char *cubemap_file, bool32_t srgb_data, int3
 	///////////////////////////////////////////
 
 	bool32_t(*upload)(asset_task_t*, asset_header_t*, void*) = [](asset_task_t* task, asset_header_t * asset, void* job_data) {
+		profiler_zone();
+
 		tex_load_t *data = (tex_load_t *)job_data;
 		tex_t       tex  = (tex_t)asset;
 
@@ -728,6 +737,8 @@ tex_t tex_create_cubemap_files(const char **cube_face_file_xxyyzz, bool32_t srgb
 ///////////////////////////////////////////
 
 tex_t tex_copy(const tex_t texture, tex_type_ type, tex_format_ format) {
+	profiler_zone();
+
 	tex_t result = tex_create(type, format == tex_format_none ? texture->format : format);
 	tex_set_color_arr_mips(result, texture->width, texture->height, nullptr, 1, skg_mip_count(texture->width, texture->height));
 
@@ -961,6 +972,8 @@ void tex_on_load_remove(tex_t texture, void (*on_load)(tex_t texture, void *cont
 ///////////////////////////////////////////
 
 void _tex_set_color_arr(tex_t texture, int32_t width, int32_t height, void **array_data, int32_t array_count, int32_t mip_count, spherical_harmonics_t *sh_lighting_info, int32_t multisample) {
+	profiler_zone();
+
 	bool dynamic        = texture->type & tex_type_dynamic;
 	bool different_size = texture->width != width || texture->height != height || texture->tex.array_count != array_count;
 	if (!different_size && (array_data == nullptr || *array_data == nullptr))
@@ -1020,6 +1033,8 @@ void tex_set_color_arr(tex_t texture, int32_t width, int32_t height, void** arra
 ///////////////////////////////////////////
 
 void tex_set_color_arr_mips(tex_t texture, int32_t width, int32_t height, void **array_data, int32_t array_count, int32_t mip_count, int32_t multisample, spherical_harmonics_t * out_sh_lighting_info) {
+	profiler_zone();
+
 	struct tex_upload_job_t {
 		tex_t                  texture;
 		int32_t                width;
@@ -1047,6 +1062,8 @@ void tex_set_color_arr_mips(tex_t texture, int32_t width, int32_t height, void *
 ///////////////////////////////////////////
 
 void tex_set_mem(tex_t texture, void* data, size_t data_size, bool32_t srgb_data, bool32_t blocking, int32_t priority) {
+	profiler_zone();
+
 	tex_load_t* load_data = sk_malloc_zero_t(tex_load_t, 1);
 	load_data->is_srgb       = srgb_data;
 	load_data->file_count    = 1;
@@ -1087,6 +1104,8 @@ void tex_set_mem(tex_t texture, void* data, size_t data_size, bool32_t srgb_data
 ///////////////////////////////////////////
 
 spherical_harmonics_t tex_get_cubemap_lighting(tex_t cubemap_texture) {
+	profiler_zone();
+
 	assets_block_until(&cubemap_texture->header, asset_state_loaded);
 
 	skg_tex_t *tex = &cubemap_texture->tex;

--- a/StereoKitC/libraries/profiler.h
+++ b/StereoKitC/libraries/profiler.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #if defined(TRACY_ENABLE)
 #include <tracy/Tracy.hpp>
 #define profiler_frame_mark() FrameMark
@@ -6,6 +8,7 @@
 #define profiler_zone_text(fmt, ...) ZoneScoped; ZoneNameF(fmt, __VA_ARGS__)
 #define profiler_alloc(ptr, size) TracyAlloc(ptr, size)
 #define profiler_free(ptr) TracyFree(ptr)
+#define profiler_thread_name(name, groupId) tracy::SetThreadNameWithHint(name, groupId)
 #else
 #define profiler_frame_mark()
 #define profiler_zone()
@@ -13,4 +16,5 @@
 #define profiler_zone_text(fmt, ...)
 #define profiler_alloc(ptr, size)
 #define profiler_free(ptr)
+#define profiler_thread_name(name, groupId)
 #endif

--- a/StereoKitC/libraries/profiler.h
+++ b/StereoKitC/libraries/profiler.h
@@ -4,9 +4,13 @@
 #define profiler_zone() ZoneScoped
 #define profiler_zone_name(name) ZoneScopedN(name)
 #define profiler_zone_text(fmt, ...) ZoneScoped; ZoneNameF(fmt, __VA_ARGS__)
+#define profiler_alloc(ptr, size) TracyAlloc(ptr, size)
+#define profiler_free(ptr) TracyFree(ptr)
 #else
 #define profiler_frame_mark()
 #define profiler_zone()
 #define profiler_zone_name(name)
 #define profiler_zone_text(fmt, ...)
+#define profiler_alloc(ptr, size)
+#define profiler_free(ptr)
 #endif

--- a/StereoKitC/libraries/profiler.h
+++ b/StereoKitC/libraries/profiler.h
@@ -1,0 +1,12 @@
+#if defined(TRACY_ENABLE)
+#include <tracy/Tracy.hpp>
+#define profiler_frame_mark() FrameMark
+#define profiler_zone() ZoneScoped
+#define profiler_zone_name(name) ZoneScopedN(name)
+#define profiler_zone_text(fmt, ...) ZoneScoped; ZoneNameF(fmt, __VA_ARGS__)
+#else
+#define profiler_frame_mark()
+#define profiler_zone()
+#define profiler_zone_name(name)
+#define profiler_zone_text(fmt, ...)
+#endif

--- a/StereoKitC/platforms/linux.cpp
+++ b/StereoKitC/platforms/linux.cpp
@@ -529,7 +529,7 @@ font_t platform_default_font() {
 	FcConfigDestroy(config);
 
 	result = font_create_files((const char**)fonts.data, fonts.count);
-	fonts.each(free);
+	for(int32_t i=0; i<fonts.count; i++) sk_free(fonts[i]);
 	fonts.free();
 	return result;
 }

--- a/StereoKitC/platforms/platform.cpp
+++ b/StereoKitC/platforms/platform.cpp
@@ -13,6 +13,7 @@
 #include "../log.h"
 #include "../libraries/stref.h"
 #include "../libraries/ferr_thread.h"
+#include "../libraries/profiler.h"
 #include "../xr_backends/openxr.h"
 #include "../xr_backends/simulator.h"
 #include "../xr_backends/window.h"
@@ -70,6 +71,8 @@ void        platform_stop_mode();
 ///////////////////////////////////////////
 
 bool platform_init() {
+	profiler_zone();
+
 	device_data_init(&device_data);
 
 	local = sk_malloc_zero_t(platform_state_t, 1);
@@ -150,6 +153,8 @@ bool platform_set_mode(app_mode_ mode) {
 
 
 void platform_step_begin() {
+	profiler_zone();
+
 	platform_impl_step();
 	switch (local->mode) {
 	case app_mode_offscreen: offscreen_step_begin(); break;
@@ -163,6 +168,8 @@ void platform_step_begin() {
 ///////////////////////////////////////////
 
 void platform_step_end() {
+	profiler_zone();
+
 	switch (local->mode) {
 	case app_mode_offscreen: offscreen_step_end(); break;
 	case app_mode_simulator: simulator_step_end(); break;

--- a/StereoKitC/platforms/win32.cpp
+++ b/StereoKitC/platforms/win32.cpp
@@ -414,7 +414,7 @@ void platform_iterate_dir(const char *directory_path, void *callback_data, void 
 				on_item(callback_data, filename_u8, file_attr);
 			}
 		}
-		free(filename_u8);
+		sk_free(filename_u8);
 
 		if (!FindNextFileW(handle, &info)) {
 			FindClose(handle);

--- a/StereoKitC/sk_memory.cpp
+++ b/StereoKitC/sk_memory.cpp
@@ -126,8 +126,8 @@ void *sk_calloc_d(size_t bytes, const char* type, const char* filename, int32_t 
 void *sk_realloc_d(void *memory, size_t bytes, const char* type, const char* filename, int32_t line) {
 	if (memory == nullptr) return sk_malloc_d(bytes, type, filename, line);
 
-	profiler_free(memory);
 	mem_info_t* prev_info = (mem_info_t*)(((uint8_t*)memory) - sizeof(mem_info_t));
+	profiler_free(prev_info);
 	void *result = realloc(prev_info, bytes + sizeof(mem_info_t));
 	if (result == nullptr && bytes > 0) {
 		fprintf(stderr, "Memory alloc failed!");

--- a/StereoKitC/sk_memory.h
+++ b/StereoKitC/sk_memory.h
@@ -44,7 +44,7 @@ void  _sk_free_d      (void *memory, const char* filename, int32_t line);
 #define sk_free(memory) { _sk_free_d(memory, __FILE__, __LINE__); memory = nullptr; };
 
 #define sk_malloc_t(T, count) ((T*)sk_malloc_d((count) * sizeof(T), #T, __FILE__, __LINE__))
-#define sk_calloc_t(T, count) ((T*)sk_calloc_d((count) * sizeof(T), #T, __FILE__, __LINE__))
+#define sk_malloc_zero_t(T, count) ((T*)sk_calloc_d((count) * sizeof(T), #T, __FILE__, __LINE__))
 #define sk_realloc_t(T, memory, count) ((T*)sk_realloc_d(memory, (count) * sizeof(T), #T, __FILE__, __LINE__))
 
 #endif

--- a/StereoKitC/stereokit.cpp
+++ b/StereoKitC/stereokit.cpp
@@ -14,6 +14,7 @@
 #include "libraries/sokol_time.h"
 #include "libraries/ferr_thread.h"
 #include "libraries/ferr_hash.h"
+#include "libraries/profiler.h"
 #include "utils/random.h"
 #include "platforms/platform.h"
 
@@ -208,8 +209,10 @@ bool32_t sk_step(void (*app_step)(void)) {
 	}
 
 	sk_step_begin();
-	if (app_step)
+	if (app_step) {
+		profiler_zone_name("App");
 		app_step();
+	}
 
 	return true;
 }
@@ -243,6 +246,8 @@ bool32_t sk_step_end() {
 	if (device_display_get_type() == display_type_flatscreen && local.focus != app_focus_active && local.settings.standby_mode != standby_mode_none)
 		platform_sleep(100);
 	local.in_step = false;
+	
+	profiler_frame_mark();
 	return local.running;
 }
 

--- a/StereoKitC/stereokit.cpp
+++ b/StereoKitC/stereokit.cpp
@@ -82,6 +82,9 @@ bool32_t sk_step_end  ();
 ///////////////////////////////////////////
 
 bool32_t sk_init(sk_settings_t settings) {
+	profiler_thread_name("StereoKit Main", 0);
+	profiler_zone();
+
 	local = {};
 	local.timev_scale = 1;
 	local.quit_reason = quit_reason_none;
@@ -300,6 +303,8 @@ void sk_run_data(void (*app_step)(void* step_data), void* step_data, void (*app_
 ///////////////////////////////////////////
 
 void sk_app_step() {
+	profiler_zone();
+
 	if (local.app_step_func != nullptr)
 		local.app_step_func();
 }

--- a/StereoKitC/systems/audio.cpp
+++ b/StereoKitC/systems/audio.cpp
@@ -6,6 +6,7 @@
 #include "../platforms/platform.h"
 
 #include "../libraries/stref.h"
+#include "../libraries/profiler.h"
 #include "../libraries/isac_spatial_sound.h"
 
 #include <string.h>
@@ -411,6 +412,8 @@ bool32_t mic_is_recording() {
 ///////////////////////////////////////////
 
 bool audio_init() {
+	profiler_zone();
+
 	au_mix_temp = sk_malloc_t(float, au_mix_temp_size);
 	memset(au_mix_temp, 0, sizeof(float) * au_mix_temp_size);
 
@@ -482,6 +485,8 @@ bool audio_init() {
 ///////////////////////////////////////////
 
 void audio_step() {
+	profiler_zone();
+
 	au_head_transform = pose_matrix_inv(input_head());
 
 	for (size_t i = 0; i < _countof(au_active_sounds); i++) {

--- a/StereoKitC/systems/bvh.cpp
+++ b/StereoKitC/systems/bvh.cpp
@@ -480,7 +480,7 @@ mesh_bvh_create(const mesh_t mesh, int acc_leaf_size, bool show_stats)
 
     // Clean up
 
-    free(triangle_centroids);
+    sk_free(triangle_centroids);
 
     return bvh;
 }
@@ -488,8 +488,8 @@ mesh_bvh_create(const mesh_t mesh, int acc_leaf_size, bool show_stats)
 void
 mesh_bvh_destroy(mesh_bvh_t *bvh)
 {
-    free(bvh->nodes);
-    free(bvh->sorted_triangles);
+    sk_free(bvh->nodes);
+    sk_free(bvh->sorted_triangles);
     *bvh = {};
 }
 

--- a/StereoKitC/systems/defaults.cpp
+++ b/StereoKitC/systems/defaults.cpp
@@ -6,6 +6,7 @@
 #include "../asset_types/texture_.h"
 #include "../libraries/default_controller_l.h"
 #include "../libraries/default_controller_r.h"
+#include "../libraries/profiler.h"
 
 #include <string.h>
 
@@ -124,6 +125,8 @@ tex_t dev_texture(const char *id, color128 base_color, float contrast_boost) {
 ///////////////////////////////////////////
 
 bool defaults_init() {
+	profiler_zone();
+
 	// Textures
 	sk_default_tex       = defaults_texture(default_id_tex,       {1,1,1,1}         );
 	sk_default_tex_black = defaults_texture(default_id_tex_black, {0,0,0,1}         );

--- a/StereoKitC/systems/input.cpp
+++ b/StereoKitC/systems/input.cpp
@@ -11,6 +11,7 @@
 #include "../hands/input_hand.h"
 #include "../libraries/array.h"
 #include "../libraries/ferr_thread.h"
+#include "../libraries/profiler.h"
 #include "../xr_backends/openxr.h"
 #include "../xr_backends/openxr_input.h"
 #include "../systems/render.h"
@@ -90,6 +91,8 @@ void input_mouse_update();
 ///////////////////////////////////////////
 
 bool input_init() {
+	profiler_zone();
+
 	local = {};
 	input_head_pose_local = pose_identity;
 	local.eyes_pose_local = pose_identity;
@@ -250,6 +253,8 @@ void input_buttons_update() {
 ///////////////////////////////////////////
 
 void input_step() {
+	profiler_zone();
+
 	///////////////////////////////////////////
 	// Update input sources
 	///////////////////////////////////////////
@@ -331,6 +336,8 @@ void input_step() {
 ///////////////////////////////////////////
 
 void input_step_late() {
+	profiler_zone();
+
 	input_update_poses();
 	input_pose_info_update();
 	input_render_step_late();

--- a/StereoKitC/systems/line_drawer.cpp
+++ b/StereoKitC/systems/line_drawer.cpp
@@ -4,6 +4,7 @@
 #include "../sk_memory.h"
 #include "../hierarchy.h"
 #include "../libraries/array.h"
+#include "../libraries/profiler.h"
 
 #include <stdlib.h>
 
@@ -23,6 +24,8 @@ static line_drawer_state_t local = {};
 ///////////////////////////////////////////
 
 bool line_drawer_init() {
+	profiler_zone();
+
 	local = {};
 
 	shader_t line_shader = shader_find(default_id_shader_lines);
@@ -53,6 +56,8 @@ void line_drawer_shutdown() {
 ///////////////////////////////////////////
 
 void line_drawer_step() {
+	profiler_zone();
+
 	if (local.line_inds.count <= 0)
 		return;
 

--- a/StereoKitC/systems/render.cpp
+++ b/StereoKitC/systems/render.cpp
@@ -11,6 +11,7 @@
 #include "../_stereokit.h"
 #include "../device.h"
 #include "../libraries/stref.h"
+#include "../libraries/profiler.h"
 #include "../sk_math_dx.h"
 #include "../sk_memory.h"
 #include "../spherical_harmonics.h"
@@ -185,6 +186,8 @@ void          radix_sort_init         ();
 ///////////////////////////////////////////
 
 bool render_init() {
+	profiler_zone();
+
 	local = {};
 	local.initialized           = true;
 	local.sim_origin            = matrix_identity;
@@ -304,6 +307,8 @@ void render_shutdown() {
 ///////////////////////////////////////////
 
 void render_step() {
+	profiler_zone();
+
 	render_reset_buffer_pool();
 
 	hierarchy_step();

--- a/StereoKitC/systems/render_pipeline.cpp
+++ b/StereoKitC/systems/render_pipeline.cpp
@@ -1,6 +1,7 @@
 #include "render_pipeline.h"
 #include "render.h"
 #include "../asset_types/texture.h"
+#include "../libraries/profiler.h"
 
 #include <sk_gpu.h>
 #include <stdio.h>
@@ -208,7 +209,10 @@ void render_pipeline_surface_to_swapchain(pipeline_surface_id surface_id, skg_sw
 		skg_tex_copy_to_swapchain(&surface->tex->tex, swapchain);
 
 		// Present to the screen
-		skg_swapchain_present(swapchain);
+		{
+			profiler_zone_name("VSync");
+			skg_swapchain_present(swapchain);
+		}
 	}
 	skg_event_end();
 }

--- a/StereoKitC/systems/sprite_drawer.cpp
+++ b/StereoKitC/systems/sprite_drawer.cpp
@@ -3,6 +3,7 @@
 #include "../asset_types/sprite.h"
 
 #include "../libraries/array.h"
+#include "../libraries/profiler.h"
 #include "../hierarchy.h"
 #include "../sk_math_dx.h"
 #include "../sk_memory.h"
@@ -113,6 +114,8 @@ void sprite_drawer_add_at(sprite_t sprite, matrix at, pivot_ pivot_position, col
 ///////////////////////////////////////////
 
 bool sprite_drawer_init() {
+	profiler_zone();
+
 	sprite_quad = mesh_find(default_id_mesh_quad);
 
 	// Default rendering quad
@@ -134,6 +137,8 @@ bool sprite_drawer_init() {
 ///////////////////////////////////////////
 
 void sprite_drawer_step() {
+	profiler_zone();
+
 	for (int32_t i = 0; i < sprite_buffers.count; i++) {
 		sprite_buffer_t &buffer = sprite_buffers[i];
 		if (buffer.vert_count <= 0)

--- a/StereoKitC/systems/system.cpp
+++ b/StereoKitC/systems/system.cpp
@@ -6,6 +6,7 @@
 #include "../libraries/stref.h"
 #include "../libraries/array.h"
 #include "../libraries/sokol_time.h"
+#include "../libraries/profiler.h"
 #include "../stereokit.h"
 #include "../sk_memory.h"
 
@@ -164,9 +165,10 @@ void system_execute(system_t *sys) {
 
 	// start timing
 	sys->profile_frame_start = stm_now();
-
-	sys->func_step();
-
+	{
+		profiler_zone_text("%s", sys->name);
+		sys->func_step();
+	}
 	// end timing
 	if (sys->profile_frame_duration == 0)
 		sys->profile_frame_duration = stm_since(sys->profile_frame_start);

--- a/StereoKitC/systems/text.cpp
+++ b/StereoKitC/systems/text.cpp
@@ -8,6 +8,7 @@
 #include "../sk_memory.h"
 #include "../libraries/array.h"
 #include "../libraries/unicode.h"
+#include "../libraries/profiler.h"
 
 #include <ctype.h>
 #include <stdio.h>
@@ -712,6 +713,8 @@ float text_add_in_16(const char16_t *text, const matrix &transform, vec2 size, t
 ///////////////////////////////////////////
 
 void text_step() {
+	profiler_zone();
+
 	font_update_fonts();
 
 	for (int32_t i = 0; i < text_buffers.count; i++) {

--- a/StereoKitC/systems/world.cpp
+++ b/StereoKitC/systems/world.cpp
@@ -9,6 +9,7 @@
 #include "../xr_backends/openxr.h"
 #include "../xr_backends/simulator.h"
 #include "../xr_backends/extensions/msft_scene_understanding.h"
+#include "../libraries/profiler.h"
 #include "render.h"
 
 #include <float.h>
@@ -23,6 +24,8 @@ material_t   world_occlusion_material = {};
 ///////////////////////////////////////////
 
 bool world_init() {
+	profiler_zone();
+
 	world_occlusion_material = material_copy_id(default_id_material_unlit);
 	material_set_id   (world_occlusion_material, "sk/world/material");
 	material_set_color(world_occlusion_material, "color", { 0,0,0,0 });
@@ -48,6 +51,7 @@ void world_shutdown() {
 ///////////////////////////////////////////
 
 void world_step() {
+	profiler_zone();
 }
 
 ///////////////////////////////////////////

--- a/StereoKitC/tools/file_picker.cpp
+++ b/StereoKitC/tools/file_picker.cpp
@@ -347,7 +347,7 @@ void file_picker_open_folder(const char *folder) {
 	char *new_folder = string_copy(folder);
 	sk_free(fp_path.folder);
 	sk_free(dir_mem);
-	fp_path.fragments.each(free);
+	for (int32_t i = 0; i < fp_path.fragments.count; i++) sk_free(fp_path.fragments[i]);
 	fp_path.fragments.clear();
 
 	fp_path.folder   = new_folder;
@@ -395,7 +395,7 @@ void file_picker_click_item(fp_item_t item) {
 	else {
 		char* path = platform_push_path_new(fp_path.folder, item.name);
 		file_picker_open_folder(path);
-		free(path);
+		sk_free(path);
 	}
 }
 
@@ -613,7 +613,7 @@ void file_picker_update() {
 void file_picker_shutdown() {
 	sk_free(fp_title      );
 	sk_free(fp_path.folder);
-	fp_path.fragments.each(free);
+	for (int32_t i = 0; i < fp_path.fragments.count; i++) sk_free(fp_path.fragments[i]);
 	fp_path.fragments.free();
 	fp_path = {};
 	fp_items.free();

--- a/StereoKitC/tools/tools.cpp
+++ b/StereoKitC/tools/tools.cpp
@@ -2,12 +2,15 @@
 
 #include "../tools/file_picker.h"
 #include "../tools/virtual_keyboard.h"
+#include "../libraries/profiler.h"
 
 namespace sk {
 
 ///////////////////////////////////////////
 
 bool tools_init() {
+	profiler_zone();
+
 	virtualkeyboard_initialize();
 	return true;
 }
@@ -15,6 +18,8 @@ bool tools_init() {
 ///////////////////////////////////////////
 
 void tools_step() {
+	profiler_zone();
+
 	file_picker_update();
 	virtualkeyboard_step();
 }

--- a/StereoKitC/tools/virtual_keyboard.cpp
+++ b/StereoKitC/tools/virtual_keyboard.cpp
@@ -537,7 +537,7 @@ bool virtualkeyboard_parse_layout(const char* text_start, int32_t text_length, k
 		out_layout->width_cells   += result[i].width;
 		out_layout->width_gutters += 1 + (int32_t)(result[i].width / 2.0f - 0.5f);
 	}
-	free(escape_text);
+	sk_free(escape_text);
 	return true;
 }
 

--- a/StereoKitC/ui/stereokit_ui.cpp
+++ b/StereoKitC/ui/stereokit_ui.cpp
@@ -14,6 +14,7 @@
 #include "../hierarchy.h"
 #include "../libraries/array.h"
 #include "../libraries/unicode.h"
+#include "../libraries/profiler.h"
 
 #include <math.h>
 
@@ -42,6 +43,8 @@ bool32_t ui_text_at(const char16_t* text, vec2* opt_ref_scroll, ui_scroll_ scrol
 ///////////////////////////////////////////
 
 bool ui_init() {
+	profiler_zone();
+
 	skui_input_target        = 0;
 	skui_input_carat         = 0;
 	skui_input_carat_end     = 0;
@@ -70,6 +73,8 @@ void ui_shutdown() {
 ///////////////////////////////////////////
 
 void ui_step() {
+	profiler_zone();
+
 	ui_core_update();
 	ui_theming_update();
 
@@ -81,6 +86,8 @@ void ui_step() {
 ///////////////////////////////////////////
 
 void ui_step_late() {
+	profiler_zone();
+
 	ui_pop_surface();
 
 	// If the active input target was not confirmed to exist, we should drop

--- a/StereoKitC/utils/sdf.cpp
+++ b/StereoKitC/utils/sdf.cpp
@@ -76,7 +76,9 @@ tex_t sdf_create_tex(int32_t width, int32_t height, float (*sdf)(vec2 pt), float
 			data[x + yoff] = {255,255,255,(uint8_t)(lerp * 255)};
 		}
 	}
-	return tex_create_color32(data, width, height, false);
+	tex_t result = tex_create_color32(data, width, height, false);
+	sk_free(data);
+	return result;
 }
 
 ///////////////////////////////////////////

--- a/StereoKitC/xr_backends/extensions/ext_management.cpp
+++ b/StereoKitC/xr_backends/extensions/ext_management.cpp
@@ -11,6 +11,7 @@
 #include "../../_stereokit.h"
 #include "../../libraries/array.h"
 #include "../../libraries/stref.h"
+#include "../../libraries/profiler.h"
 
 typedef struct ext_management_state_t {
 	array_t<const char*>     exts_user;
@@ -198,6 +199,8 @@ bool ext_management_evt_pre_session_create(XrSessionCreateInfo* ref_session_info
 ///////////////////////////////////////////
 
 void ext_management_evt_step_begin() {
+	profiler_zone();
+
 	for (int32_t i = 0; i < local.callbacks_step_begin.count; i++) {
 		context_callback_t* evt = &local.callbacks_step_begin[i];
 		evt->callback(evt->context);
@@ -207,6 +210,8 @@ void ext_management_evt_step_begin() {
 ///////////////////////////////////////////
 
 void ext_management_evt_step_end() {
+	profiler_zone();
+
 	for (int32_t i = 0; i < local.callbacks_step_end.count; i++) {
 		context_callback_t* evt = &local.callbacks_step_end[i];
 		evt->callback(evt->context);

--- a/StereoKitC/xr_backends/extensions/ext_management.cpp
+++ b/StereoKitC/xr_backends/extensions/ext_management.cpp
@@ -282,8 +282,8 @@ void ext_management_cleanup() {
 	}
 
 	// Some of these lists are in charge of allocated memory
-	local.exts_all_m    .each(_sk_free);
-	local.exts_exclude_m.each(_sk_free);
+	for (int32_t i =0; i<local.exts_all_m    .count; i++) sk_free(local.exts_all_m    [i]);
+	for (int32_t i =0; i<local.exts_exclude_m.count; i++) sk_free(local.exts_exclude_m[i]);
 	local.exts_all_m    .free();
 	local.exts_exclude_m.free();
 

--- a/StereoKitC/xr_backends/extensions/msft_anchors.cpp
+++ b/StereoKitC/xr_backends/extensions/msft_anchors.cpp
@@ -250,7 +250,7 @@ void xr_ext_msft_spatial_anchors_destroy(anchor_t anchor) {
 	oxr_msft_world_anchor_t* data = (oxr_msft_world_anchor_t*)anchor->data;
 	xrDestroySpace(data->space);
 	xrDestroySpatialAnchorMSFT(data->anchor);
-	free(data);
+	sk_free(data);
 }
 
 ///////////////////////////////////////////

--- a/StereoKitC/xr_backends/openxr.cpp
+++ b/StereoKitC/xr_backends/openxr.cpp
@@ -213,11 +213,11 @@ bool openxr_create_system() {
 	// Always log the extension table, this may contain information about why
 	// we failed to load.
 	openxr_show_ext_table(exts_request, exts_available, layers_request, layers_available);
-	exts_request  .free();
-	exts_available.each(_sk_free);
+	exts_request.free();
+	for (int32_t i =0; i<exts_available.count; i++) sk_free(exts_available[i]);
 	exts_available.free();
-	layers_request  .free();
-	layers_available.each(_sk_free);
+	layers_request.free();
+	for (int32_t i =0; i<layers_available.count; i++) sk_free(layers_available[i]);
 	layers_available.free();
 
 	// If the instance is null here, the user needs to install an OpenXR

--- a/StereoKitC/xr_backends/openxr_view.cpp
+++ b/StereoKitC/xr_backends/openxr_view.cpp
@@ -25,6 +25,7 @@
 #include "../systems/input.h"
 #include "../systems/system.h"
 #include "../libraries/sokol_time.h"
+#include "../libraries/profiler.h"
 
 #include <sk_gpu.h>
 #include <stdio.h>
@@ -747,6 +748,8 @@ bool openxr_preferred_blend(XrViewConfigurationType view_type, display_blend_ pr
 ///////////////////////////////////////////
 
 bool openxr_render_frame() {
+	profiler_zone();
+
 	// We may have some stuff to render that doesn't require the swapchain to
 	// be available, so we can call 'begin' before then.
 	render_pipeline_begin();
@@ -763,11 +766,16 @@ bool openxr_render_frame() {
 		secondary_states.viewConfigurationStates = xr_display_2nd_states.data;
 		frame_state.next = &secondary_states;
 	}
-	XrResult xrWaitFrameResult = xrWaitFrame(xr_session, &wait_info, &frame_state);
-	if (xrWaitFrameResult == XR_ERROR_SESSION_LOST) {
-		sk_quit(quit_reason_session_lost);
+
+	{
+		profiler_zone_name("xrWaitFrame");
+
+		XrResult xrWaitFrameResult = xrWaitFrame(xr_session, &wait_info, &frame_state);
+		if (xrWaitFrameResult == XR_ERROR_SESSION_LOST) {
+			sk_quit(quit_reason_session_lost);
+		}
+		xr_check(xrWaitFrameResult, "xrWaitFrame");
 	}
-	xr_check(xrWaitFrameResult, "xrWaitFrame");
 
 	// Don't track sync time, start the frame timer after xrWaitFrame
 	xr_render_sys->profile_frame_start = stm_now();
@@ -792,8 +800,12 @@ bool openxr_render_frame() {
 	// interesting flags, like XR_SESSION_VISIBILITY_UNAVAILABLE, which means
 	// we could skip rendering this frame and call xrEndFrame right away.
 	XrFrameBeginInfo begin_info = { XR_TYPE_FRAME_BEGIN_INFO };
-	xr_check(xrBeginFrame(xr_session, &begin_info),
-		"xrBeginFrame");
+	{
+		profiler_zone_name("xrBeginFrame");
+
+		xr_check(xrBeginFrame(xr_session, &begin_info),
+			"xrBeginFrame");
+	}
 
 	// Timing also needs some work, may be best as some sort of anchor system
 	xr_time = frame_state.predictedDisplayTime;
@@ -809,6 +821,7 @@ bool openxr_render_frame() {
 		(xr_session_state == XR_SESSION_STATE_VISIBLE || xr_session_state == XR_SESSION_STATE_FOCUSED) &&
 		(sk_get_settings_ref()->omit_empty_frames == false || render_list_item_count(render_get_primary_list()) != 0);
 	if (render_displays) {
+		profiler_zone_name("Render Setup");
 		// Set up the primary displays
 		for (int32_t i = 0; i < xr_displays.count; i++) {
 			device_display_t* display = &xr_displays[i];
@@ -870,10 +883,15 @@ bool openxr_render_frame() {
 			render_pipeline_surface_set_enabled(xr_displays[i].swapchain_color.render_surface, false);
 	}
 
-	render_pipeline_draw();
+	{
+		profiler_zone_name("Render");
+
+		render_pipeline_draw();
+	}
 
 	// Release the swapchains for all active displays
 	if (render_displays) {
+		profiler_zone_name("Render Finalize");
 		if (xr_draw_to_swapchain == false) {
 			for (int32_t i = 0; i < xr_displays.count; i++) {
 				swapchain_t* swapchain = &xr_displays[i].swapchain_color;
@@ -901,9 +919,12 @@ bool openxr_render_frame() {
 	end_info.layers               = composition_layers->data;
 	xr_chain_insert_extensions((XrBaseHeader*)&end_info, xr_end_frame_chain_bytes, xr_end_frame_chain_offset);
 
-	xr_check(xrEndFrame(xr_session, &end_info),
-		"xrEndFrame");
+	{
+		profiler_zone_name("xrEndFrame");
 
+		xr_check(xrEndFrame(xr_session, &end_info),
+			"xrEndFrame");
+	}
 	return true;
 }
 


### PR DESCRIPTION
- Adds the [tracy profiler](https://github.com/wolfpld/tracy) as an optional flag in the cmake. Defaults to off.
- Has some initial profiling zones that covers a decent bit of the codebase for when the platform can't capture stack traces.
- Fixed a number of inconsistent memory function calls, and a leak or two. There's a few more that mix up Tracy on occasions.
- Tracy on Android hangs on occasions, haven't figured it out entirely yet.
- Fixed a perf issue with the Log window tool that would frequently drop a frame or two.