### PR TITLE
Added getters for some Renderer properties

### DIFF
--- a/Examples/StereoKitTest/Tests/TestRenderProps.cs
+++ b/Examples/StereoKitTest/Tests/TestRenderProps.cs
@@ -1,0 +1,62 @@
+﻿using StereoKit;
+
+class TestRenderProps : ITest
+{
+	static bool TestClip()
+	{
+		bool result = true;
+		Renderer.GetClip(out float oldNear, out float oldFar);
+		Log.Info($"Default Clip: Near {oldNear}, Far {oldFar}");
+
+		Renderer.SetClip(0.1f, 1000.0f);
+		Renderer.GetClip(out float newNear, out float newFar);
+		if (newNear != 0.1f || newFar != 1000.0f)
+			result = false;
+
+		Renderer.SetClip(oldFar, oldNear);
+		return result;
+	}
+
+	static bool TestFOV()
+	{
+		bool result = true;
+		float oldFOV = Renderer.FOV;
+		Log.Info($"Default FOV: {oldFOV}");
+
+		Renderer.FOV = 45.0f;
+		if (Renderer.FOV != 45.0f)
+			result = false;
+
+		Renderer.FOV = oldFOV;
+		return result;
+	}
+
+	static bool TestOrthoSize()
+	{
+		bool result = true;
+		float oldOrthoSize = Renderer.OrthoSize;
+		Log.Info($"Default OrthoSize: {oldOrthoSize}");
+
+		Renderer.OrthoSize = 0.5f;
+		if (Renderer.OrthoSize != 0.5f)
+			result = false;
+
+		Renderer.OrthoSize = oldOrthoSize;
+		return result;
+	}
+
+	public void Initialize()
+	{
+		Tests.Test(TestClip);
+		Tests.Test(TestFOV);
+		Tests.Test(TestOrthoSize);
+	}
+
+	public void Shutdown()
+	{
+	}
+
+	public void Step()
+	{
+	}
+}

--- a/StereoKit/Native/NativeAPI.cs
+++ b/StereoKit/Native/NativeAPI.cs
@@ -441,6 +441,7 @@ namespace StereoKit
 		///////////////////////////////////////////
 
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void               render_set_clip       (float near_plane, float far_plane);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void               render_get_clip       (out float out_near_plane, out float out_far_plane);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void               render_set_fov        (float field_of_view_degrees);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void               render_set_ortho_clip (float near_plane, float far_plane);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void               render_set_ortho_size (float viewport_height_meters);

--- a/StereoKit/Native/NativeAPI.cs
+++ b/StereoKit/Native/NativeAPI.cs
@@ -442,9 +442,11 @@ namespace StereoKit
 
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void               render_set_clip       (float near_plane, float far_plane);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void               render_get_clip       (out float out_near_plane, out float out_far_plane);
-		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void               render_set_fov        (float field_of_view_degrees);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void               render_set_fov        (float vertical_field_of_view_degrees);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern float              render_get_fov        ();
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void               render_set_ortho_clip (float near_plane, float far_plane);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void               render_set_ortho_size (float viewport_height_meters);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern float              render_get_ortho_size ();
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void               render_set_projection (Projection proj);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern Projection         render_get_projection ();
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern Matrix             render_get_cam_root   ();

--- a/StereoKit/Systems/Renderer.cs
+++ b/StereoKit/Systems/Renderer.cs
@@ -253,15 +253,29 @@ namespace StereoKit
 		public static void GetClip(out float nearPlane, out float farPlane)
 			=> NativeAPI.render_get_clip(out nearPlane, out farPlane);
 
-		/// <summary>Only works for flatscreen! This updates the camera's 
-		/// projection matrix with a new field of view.
+		/// <summary>Only works for 2D windowed modes! This updates the
+		/// camera's projection matrix with a new vertical field of view.
 		/// 
 		/// This value only affects perspective mode projection, which is the
 		/// default projection mode.</summary>
-		/// <param name="fieldOfViewDegrees">Vertical field of view in degrees.
+		/// <param name="verticalFieldOfViewDegrees">Vertical field of view in degrees.
 		/// </param>
-		public static void SetFOV(float fieldOfViewDegrees)
-			=> NativeAPI.render_set_fov(fieldOfViewDegrees);
+		public static void SetFOV(float verticalFieldOfViewDegrees)
+			=> NativeAPI.render_set_fov(verticalFieldOfViewDegrees);
+
+		/// <summary>Only works for 2D windowed modes! This retrieves the
+		/// vertical field of view of the camera's projection matrix when in
+		/// perspective projection mode.</summary>
+		/// <returns>The vertical field of view in degrees.</returns>
+		public static float GetFOV()
+			=> NativeAPI.render_get_fov();
+
+		/// <summary>Only works for 2D windowed modes! This updates the
+		/// camera's projection matrix with a new vertical field of view.
+		/// 
+		/// This value only affects perspective mode projection, which is the
+		/// default projection mode.</summary>
+		public static float FOV { get => NativeAPI.render_get_fov(); set => NativeAPI.render_set_fov(value); }
 
 		/// <summary>Set the near and far clipping planes of the camera!
 		/// These are important to z-buffer quality, especially when using
@@ -271,7 +285,7 @@ namespace StereoKit
 		/// objects that are overlapping, try making the range smaller.
 		/// 
 		/// These values only affect orthographic mode projection, which is 
-		/// only available in flatscreen.</summary>
+		/// only available in 2D window modes.</summary>
 		/// <param name="nearPlane">The GPU discards pixels that are too
 		/// close to the camera, this is that distance!</param>
 		/// <param name="farPlane">At what distance from the camera does the
@@ -284,11 +298,25 @@ namespace StereoKit
 		/// viewport. You can use this feature to zoom in and out of the scene.
 		/// 
 		/// This value only affects orthographic mode projection, which is only
-		/// available in flatscreen.</summary>
+		/// available in 2D window modes.</summary>
 		/// <param name="viewportHeightMeters">The vertical size of the
 		/// projection's viewport, in meters.</param>
 		public static void SetOrthoSize(float viewportHeightMeters)
 			=> NativeAPI.render_set_ortho_size(viewportHeightMeters);
+
+		/// <summary>This sets the size of the orthographic projection's
+		/// viewport. You can use this feature to zoom in and out of the scene.
+		/// 
+		/// This value only affects orthographic mode projection, which is only
+		/// available in 2D window modes.</summary>
+		public static float OrthoSize { get => NativeAPI.render_get_ortho_size(); set => NativeAPI.render_set_ortho_size(value); }
+
+		/// <summary>This retrieves the size the primary render surface's view
+		/// when using orthographic projection mode.</summary>
+		/// <returns>The vertical size of the projection's viewport, in meters.
+		/// </returns>
+		public static float GetOrthoSize()
+			=> NativeAPI.render_get_ortho_size();
 
 		/// <summary>Renders a Material onto a rendertarget texture! StereoKit uses a 4 vert quad stretched
 		/// over the surface of the texture, and renders the material onto it to the texture.</summary>

--- a/StereoKit/Systems/Renderer.cs
+++ b/StereoKit/Systems/Renderer.cs
@@ -239,6 +239,20 @@ namespace StereoKit
 		public static void SetClip(float nearPlane = 0.08f, float farPlane = 50)
 			=> NativeAPI.render_set_clip(nearPlane, farPlane);
 
+		/// <summary>This retrieves the current near and far clipping planes
+		/// for the perspective matrix of the primary draw surface.</summary>
+		/// <param name="nearPlane">The GPU discards pixels that are too
+		/// close to the camera, this is that distance! It will be larger
+		/// than zero, due to the projection math, which also means that
+		/// numbers too close to zero will produce z-fighting artifacts. This
+		/// has an enforced minimum of 0.001, but will probably be closer to
+		/// 0.1.</param>
+		/// <param name="farPlane">At what distance from the camera does the
+		/// GPU discard pixel? This is not true distance, but rather Z-axis
+		/// distance from zero in View Space coordinates!</param>
+		public static void GetClip(out float nearPlane, out float farPlane)
+			=> NativeAPI.render_get_clip(out nearPlane, out farPlane);
+
 		/// <summary>Only works for flatscreen! This updates the camera's 
 		/// projection matrix with a new field of view.
 		/// 

--- a/StereoKitC/stereokit.h
+++ b/StereoKitC/stereokit.h
@@ -1697,6 +1697,7 @@ typedef enum projection_ {
 
 //TODO: for v0.4, rename render_set_clip and render_set_fov to indicate they are only for perspective
 SK_API void                  render_set_clip       (float near_plane sk_default(0.08f), float far_plane sk_default(50));
+SK_API void                  render_get_clip       (float* out_near_plane, float* out_far_plane);
 SK_API void                  render_set_fov        (float field_of_view_degrees sk_default(90.0f));
 SK_API void                  render_set_ortho_clip (float near_plane sk_default(0.0f), float far_plane sk_default(50));
 SK_API void                  render_set_ortho_size (float viewport_height_meters);

--- a/StereoKitC/stereokit.h
+++ b/StereoKitC/stereokit.h
@@ -1698,9 +1698,11 @@ typedef enum projection_ {
 //TODO: for v0.4, rename render_set_clip and render_set_fov to indicate they are only for perspective
 SK_API void                  render_set_clip       (float near_plane sk_default(0.08f), float far_plane sk_default(50));
 SK_API void                  render_get_clip       (float* out_near_plane, float* out_far_plane);
-SK_API void                  render_set_fov        (float field_of_view_degrees sk_default(90.0f));
+SK_API void                  render_set_fov        (float vertical_field_of_view_degrees sk_default(90.0f));
+SK_API float                 render_get_fov        (void);
 SK_API void                  render_set_ortho_clip (float near_plane sk_default(0.0f), float far_plane sk_default(50));
 SK_API void                  render_set_ortho_size (float viewport_height_meters);
+SK_API float                 render_get_ortho_size (void);
 SK_API void                  render_set_projection (projection_ proj);
 SK_API projection_           render_get_projection (void);
 SK_API matrix                render_get_cam_root   (void);

--- a/StereoKitC/systems/render.cpp
+++ b/StereoKitC/systems/render.cpp
@@ -340,6 +340,13 @@ void render_set_clip(float near_plane, float far_plane) {
 
 ///////////////////////////////////////////
 
+void render_get_clip(float* out_near_plane, float* out_far_plane) {
+	if (out_near_plane) *out_near_plane = local.clip_planes.x;
+	if (out_far_plane ) *out_far_plane  = local.clip_planes.y;
+}
+
+///////////////////////////////////////////
+
 void render_set_fov(float field_of_view_degrees) {
 	local.fov = field_of_view_degrees;
 	render_update_projection();

--- a/StereoKitC/systems/render.cpp
+++ b/StereoKitC/systems/render.cpp
@@ -347,9 +347,15 @@ void render_get_clip(float* out_near_plane, float* out_far_plane) {
 
 ///////////////////////////////////////////
 
-void render_set_fov(float field_of_view_degrees) {
-	local.fov = field_of_view_degrees;
+void render_set_fov(float vertical_field_of_view_degrees) {
+	local.fov = vertical_field_of_view_degrees;
 	render_update_projection();
+}
+
+///////////////////////////////////////////
+
+float render_get_fov() {
+	return local.fov;
 }
 
 ///////////////////////////////////////////
@@ -357,6 +363,12 @@ void render_set_fov(float field_of_view_degrees) {
 void render_set_ortho_size(float viewport_height_meters) {
 	local.ortho_viewport_height = viewport_height_meters;
 	render_update_projection();
+}
+
+///////////////////////////////////////////
+
+float render_get_ortho_size() {
+	return local.ortho_viewport_height;
 }
 
 ///////////////////////////////////////////


### PR DESCRIPTION
- Adds `Renderer.GetFOV` and `Renderer.FOV` (2D window FOV)
- Adds `Renderer.GetOrthoSize` and `Renderer.OrthoSize`
- Adds `Renderer.GetClipPlanes`
- Adds simple tests for these properties