### PR TITLE
Fix hands vanishing in Shadow demo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -252,8 +252,8 @@ endif()
 #### sk_gpu - https://github.com/StereoKit/sk_gpu ####
 if (NOT SK_LOCAL_SK_GPU)
   CPMAddPackage( # We're scraping the comment after the NAME for some other scripts
-    NAME sk_gpu # 2025.8.25
-    URL https://github.com/StereoKit/sk_gpu/releases/download/v2025.8.25/sk_gpu.v2025.8.25.zip
+    NAME sk_gpu # 2025.9.7
+    URL https://github.com/StereoKit/sk_gpu/releases/download/v2025.9.7/sk_gpu.v2025.9.7.zip
   )
 else()
   # For building directly with in-progress sk_gpu changes, point this to your


### PR DESCRIPTION
When shadow map passes were active, corruption of certain elements would sometimes occur. I found and fixed two issues that seemed to be related to this:

glBindBufferBase apparently behaves the same as glBindBuffer in addition to its slot specific behavior! This meant that when glBindBufferBase calls wouldn't update the glBindBuffer state cache, this would then end up causing following buffer writes to redirect to random buffers. This resulted in occasional material parameter corruption. This was likely due to the Shadow demo's use of MaterialBuffers, which may have hit this code path.

Initializing empty buffers for material parameters to fill out later _may_ also be triggering driver optimizations specific to GLES? Filling out material parameter defaults immediately on initialization (instead of previous behavior of waiting for a dirty check later on) seemed to fix some empty buffer issues I was seeing. I'm not certain this was a real thing, it may have just been a manifestation of the first issue. Either way, it's a nice improvement.