### PR TITLE
Initial render command queueing

### DIFF
--- a/StereoKitC/systems/render.h
+++ b/StereoKitC/systems/render.h
@@ -39,9 +39,10 @@ void          render_set_sim_origin       (pose_t pose);
 void          render_set_sim_head         (pose_t pose);
 void          render_draw_queue           (render_list_t list, const matrix* views, const matrix* projections, int32_t eye_offset, int32_t view_count, int32_t inst_multiplier, render_layer_ filter);
 void          render_check_screenshots    ();
-void          render_check_viewpoints     ();
 void          render_check_pending_skytex ();
-void          render_global_buffer_internal(int32_t register_slot, material_buffer_t buffer);
+void          render_global_buffer_internal (int32_t register_slot, material_buffer_t buffer);
+void          render_global_texture_internal(int32_t register_slot, tex_t             texture);
+void          render_action_list_execute  ();
 
 void          render_list_destroy         (      render_list_t list);
 void          render_list_execute         (      render_list_t list, render_layer_ filter, uint32_t inst_multiplier, int32_t queue_start, int32_t queue_end);

--- a/StereoKitC/systems/render_pipeline.cpp
+++ b/StereoKitC/systems/render_pipeline.cpp
@@ -44,7 +44,7 @@ void render_pipeline_begin() {
 	skg_event_end();
 	skg_event_begin("Offscreen");
 	{
-		render_check_viewpoints();
+		render_action_list_execute();
 		render_check_screenshots();
 	}
 	skg_event_end();


### PR DESCRIPTION
This allows some render actions to happen "in-order" despite being deferred to the end of the frame. Notably, this allows us to unbind a shadow map texture, draw to it, then rebind it before the main pass happens.

Previously, binding and unbinding the shadow map texture happened immediately, while drawing to the shadow map was deferred until the end of the frame. This change now queues these commands up, then executes them all in-order at the end of the frame.

This eliminates the "one frame behind" artifacts you would see when waving objects around in the Shadow demo.