### PR TITLE
Fix a few issues with tests

### DIFF
--- a/Examples/StereoKitTest/Tests/TestAudio.cs
+++ b/Examples/StereoKitTest/Tests/TestAudio.cs
@@ -14,13 +14,16 @@ class TestAudio : ITest
 	float     rotateTime = 0;
 	float     intensity  = 0;
 
+	float oldNear, oldFar;
 	public void Initialize()
 	{
+		Renderer.GetClip(out oldNear, out oldFar);
 		Renderer.SetClip(0.08f,250);
 	}
 
 	public void Shutdown()
 	{
+		Renderer.SetClip(oldNear, oldFar);
 		inst.Stop();
 		Platform.FilePickerClose();
 	}

--- a/Examples/StereoKitTest/Tests/TestInteractorPoints.cs
+++ b/Examples/StereoKitTest/Tests/TestInteractorPoints.cs
@@ -117,6 +117,8 @@ class TestInteractorPoints : ITest
 			}
 		}
 		UI.WindowEnd();
+
+		frameIdx++;
 	}
 
 	static bool TestUpdate(Interactor ray, Update[] update, Vec3 prevPoint, Vec3 elementCenter, int frame)

--- a/Examples/StereoKitTest/Tests/TestRenderProps.cs
+++ b/Examples/StereoKitTest/Tests/TestRenderProps.cs
@@ -13,7 +13,7 @@ class TestRenderProps : ITest
 		if (newNear != 0.1f || newFar != 1000.0f)
 			result = false;
 
-		Renderer.SetClip(oldFar, oldNear);
+		Renderer.SetClip(oldNear, oldFar);
 		return result;
 	}
 


### PR DESCRIPTION
Depth was flipped due to a mistake in TestRenderProps.
TestInteractorPoints wasn't stepping properly due to a missed line.
TestAudio was modifying clip planes without restoring them when finished.