### PR TITLE
Add Material Variants

### DIFF
--- a/Examples/Assets/Shaders/basic_shadow_caster.hlsl
+++ b/Examples/Assets/Shaders/basic_shadow_caster.hlsl
@@ -1,0 +1,31 @@
+#include "stereokit.hlsli"
+
+///////////////////////////////////////////
+
+struct vsIn {
+	float4 pos  : SV_Position;
+	float3 norm : NORMAL0;
+	float2 uv   : TEXCOORD0;
+	float4 col  : COLOR0;
+};
+struct psIn : sk_ps_input_t {
+	float4 pos : SV_Position;
+};
+
+///////////////////////////////////////////
+
+psIn vs(vsIn input, sk_vs_input_t sk_in) {
+	psIn o;
+	uint view_id = sk_view_init(sk_in, o);
+	uint id      = sk_inst_id  (sk_in);
+
+	float4 world = mul(input.pos, sk_inst[id].world);
+	o.pos        = mul(world,     sk_viewproj[view_id]);
+	return o;
+}
+
+///////////////////////////////////////////
+
+float4 ps(psIn input) : SV_TARGET {
+	return float4(1, 1, 1, 1);
+}

--- a/Examples/StereoKitTest/Demos/DemoShadows.cs
+++ b/Examples/StereoKitTest/Demos/DemoShadows.cs
@@ -25,6 +25,7 @@ class DemoShadows : ITest
 	const int   ShadowMapResolution = 1024;
 	const float ShadowMapNearClip   = 0.01f;
 	const float ShadowMapFarClip    = 20.0f;
+	const int   ShadowMapVariant    = 1;
 
 	Model model;
 	Pose  modelPose = Matrix.T(0,-0.2f,0) * Demo.contentPose.Pose;
@@ -41,9 +42,15 @@ class DemoShadows : ITest
 		shadowMap.SampleComp  = TexSampleComp.LessOrEq;
 		shadowMap.AddressMode = TexAddress.Clamp;
 		
+		Material casterMat = new Material("Shaders/basic_shadow_caster.hlsl");
+		casterMat.DepthClip = false;
+		casterMat.DepthTest = DepthTest.LessOrEq;
+		// This can help with shadow acne if biasing isn't working out, but can introduce peter-panning.
+		//casterMat.FaceCull  = Cull.Front;
 
 		Material shadowMat = new Material("Shaders/basic_shadow.hlsl");
-		shadowMat.DepthTest = DepthTest.LessOrEq;
+		shadowMat.SetVariant(ShadowMapVariant, casterMat);
+
 		Material floorMat = shadowMat.Copy();
 		floorMat[MatParamName.DiffuseTex] = Tex.FromFile("floor.png");
 		floorMat[MatParamName.TexTransform] = new Vec4(0, 0, 2, 2);
@@ -100,7 +107,7 @@ class DemoShadows : ITest
 		// Render the shadow map, and bind it globally so it can be used from
 		// any shader.
 		Renderer.SetGlobalTexture(12, null); // Can't draw to it if it's bound
-		Renderer.RenderTo(shadowMap, view, proj, RenderLayer.All &~ RenderLayer.Vfx);
+		Renderer.RenderTo(shadowMap, view, proj, RenderLayer.All &~ RenderLayer.Vfx, ShadowMapVariant);
 		Renderer.SetGlobalTexture(12, shadowMap);
 	}
 

--- a/StereoKit/Assets/Material.cs
+++ b/StereoKit/Assets/Material.cs
@@ -541,6 +541,36 @@ namespace StereoKit
 			Marshal.FreeHGlobal(memory);
 		}
 
+		/// <summary>Variants are used by special effects when a manual render
+		/// pass selects a variant to use for the whole pass! Variants default
+		/// to null, and null variants are not drawn.
+		/// 
+		/// For example, a shadow map render pass might use variant 1, and sets
+		/// it to a simplified Material that skips textures and only does
+		/// positional vertex transforms.</summary>
+		/// <param name="variantIndex">Which variant index should we set? 0 is
+		/// reserved for the primary material, and SK has a max of 4 total
+		/// variants, including the default.</param>
+		/// <param name="variantMaterial">The Material to use for the variant.
+		/// Sub-variants are ignored, and a null variant means nothing will be
+		/// drawn when using the variant.</param>
+		public void SetVariant(int variantIndex, Material variantMaterial)
+			=> NativeAPI.material_set_variant(_inst, variantIndex, variantMaterial?._inst ?? IntPtr.Zero);
+
+		/// <summary>This retreives the variant assigned to the specified
+		/// variant index. Null is the default value for variants, and it's not
+		/// valid to ask for variant 0 (already the current Material).
+		/// </summary>
+		/// <param name="variantIndex">The variant to retreive. 0 is already
+		/// the current material, and an invalid index here. SK has a max of 4
+		/// total variants, including the default.</param>
+		/// <returns>The Material variant, or null.</returns>
+		public Material GetVariant(int variantIndex)
+		{
+			IntPtr mat = NativeAPI.material_get_variant(_inst, variantIndex);
+			return mat == IntPtr.Zero ? null : new Material(mat);
+		}
+
 		/// <summary>Gets the value of a shader parameter with the given name.
 		/// If no parameter is found, a default value of '0' will be returned.
 		/// </summary>

--- a/StereoKit/Native/NativeAPI.cs
+++ b/StereoKit/Native/NativeAPI.cs
@@ -267,6 +267,7 @@ namespace StereoKit
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   material_set_depth_clip  (IntPtr material, [MarshalAs(UnmanagedType.Bool)] bool clip_enabled);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   material_set_queue_offset(IntPtr material, int          offset);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   material_set_chain       (IntPtr material, IntPtr       chain_material);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   material_set_variant     (IntPtr material, int variant_index, IntPtr variant_material);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern Transparency material_get_transparency(IntPtr material);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern Cull         material_get_cull        (IntPtr material);
 		[return: MarshalAs(UnmanagedType.Bool)]
@@ -278,6 +279,7 @@ namespace StereoKit
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern bool         material_get_depth_clip  (IntPtr material);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern int          material_get_queue_offset(IntPtr material);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr       material_get_chain       (IntPtr material);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr       material_get_variant     (IntPtr material, int variant_index);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   material_set_float       (IntPtr material, string name, float  value);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   material_set_color       (IntPtr material, string name, Color  value);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void   material_set_vector4     (IntPtr material, string name, Vec4   value);
@@ -483,7 +485,7 @@ namespace StereoKit
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void               render_screenshot     ([In] byte[] file_utf8, int file_quality_100, Pose viewpoint, int width, int height, float field_of_view_degrees);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void               render_screenshot_capture  ([MarshalAs(UnmanagedType.FunctionPtr)] RenderOnScreenshotCallback render_on_screenshot_callback, Pose viewpoint, int width, int height, float fov_degrees, TexFormat tex_format, IntPtr context);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void               render_screenshot_viewpoint([MarshalAs(UnmanagedType.FunctionPtr)] RenderOnScreenshotCallback render_on_screenshot_callback, Matrix camera, Matrix projection, int width, int height, RenderLayer layer_filter, RenderClear clear, Rect viewport, TexFormat tex_format, IntPtr context);
-		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void               render_to             (IntPtr to_rendertarget, int to_target_index, IntPtr override_material, in Matrix camera, in Matrix projection, RenderLayer layer_filter, RenderClear clear, Rect viewport);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void               render_to             (IntPtr to_rendertarget, int to_target_index, in Matrix camera, in Matrix projection, RenderLayer layer_filter, int material_variant, RenderClear clear, Rect viewport);
 		//[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void render_get_device  (void **device, void **context);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr             render_get_primary_list();
 

--- a/StereoKit/Systems/Renderer.cs
+++ b/StereoKit/Systems/Renderer.cs
@@ -470,6 +470,12 @@ namespace StereoKit
 		/// change which layers StereoKit renders for this particular render
 		/// viewpoint. To change what layers a visual is on, use a Draw
 		/// method that includes a RenderLayer as a parameter.</param>
+		/// <param name="materialVariant">Specifies which Material variant
+		/// should be used for rendering. 0 will be the normal default
+		/// material, any others will generally be application-defined by
+		/// setting up each Material's Variant with specific shaders. If a
+		/// Material has no corresponding variant, it will not be drawn.
+		/// </param>
 		/// <param name="clear">Describes if and how the rendertarget should
 		/// be cleared before rendering. Note that clearing the target is
 		/// unaffected by the viewport, so this will clean the entire 
@@ -478,14 +484,14 @@ namespace StereoKit
 		/// rendertarget to draw to! This is in normalized coordinates, 0-1.
 		/// If the width of this value is zero, then this will render to the
 		/// entire texture.</param>
-		public static void RenderTo(Tex toRendertarget, Matrix camera, Matrix projection, RenderLayer layerFilter = RenderLayer.All, RenderClear clear = RenderClear.All, Rect viewport = default(Rect))
-			=> NativeAPI.render_to(toRendertarget._inst, 0, IntPtr.Zero, camera, projection, layerFilter, clear, viewport);
+		public static void RenderTo(Tex toRendertarget, Matrix camera, Matrix projection, RenderLayer layerFilter = RenderLayer.All, int materialVariant = 0, RenderClear clear = RenderClear.All, Rect viewport = default(Rect))
+			=> NativeAPI.render_to(toRendertarget._inst, 0, camera, projection, layerFilter, materialVariant, clear, viewport);
 
-		/// <inheritdoc cref="RenderTo(Tex, Matrix, Matrix, RenderLayer, RenderClear, Rect)"/>
+		/// <inheritdoc cref="RenderTo(Tex, Matrix, Matrix, RenderLayer, int, RenderClear, Rect)"/>
 		/// <param name="toTargetIndex">Index of the render target's array
 		/// texture we want to draw to.</param>
-		public static void RenderTo(Tex toRendertarget, int toTargetIndex, Matrix camera, Matrix projection, RenderLayer layerFilter = RenderLayer.All, RenderClear clear = RenderClear.All, Rect viewport = default(Rect))
-			=> NativeAPI.render_to(toRendertarget._inst, toTargetIndex, IntPtr.Zero, camera, projection, layerFilter, clear, viewport);
+		public static void RenderTo(Tex toRendertarget, int toTargetIndex, Matrix camera, Matrix projection, RenderLayer layerFilter = RenderLayer.All, int materialVariant = 0, RenderClear clear = RenderClear.All, Rect viewport = default(Rect))
+			=> NativeAPI.render_to(toRendertarget._inst, toTargetIndex, camera, projection, layerFilter, materialVariant, clear, viewport);
 
 		/// <summary>This attaches a texture resource globally across all
 		/// shaders. StereoKit uses this to attach the sky cubemap for use in

--- a/StereoKitC/asset_types/material.h
+++ b/StereoKitC/asset_types/material.h
@@ -35,6 +35,7 @@ struct _material_t {
 	int32_t           queue_offset;
 	skg_pipeline_t    pipeline;
 	material_t        chain;
+	material_t        variants[3];
 };
 
 struct _material_buffer_t {

--- a/StereoKitC/stereokit.h
+++ b/StereoKitC/stereokit.h
@@ -1304,6 +1304,7 @@ SK_API void              material_set_depth_write (material_t material, bool32_t
 SK_API void              material_set_depth_clip  (material_t material, bool32_t clip_enabled);
 SK_API void              material_set_queue_offset(material_t material, int32_t offset);
 SK_API void              material_set_chain       (material_t material, material_t chain_material);
+SK_API void              material_set_variant     (material_t material, int32_t variant_idx, material_t variant_material);
 SK_API transparency_     material_get_transparency(material_t material);
 SK_API cull_             material_get_cull        (material_t material);
 SK_API bool32_t          material_get_wireframe   (material_t material);
@@ -1312,6 +1313,7 @@ SK_API bool32_t          material_get_depth_write (material_t material);
 SK_API bool32_t          material_get_depth_clip  (material_t material);
 SK_API int32_t           material_get_queue_offset(material_t material);
 SK_API material_t        material_get_chain       (material_t material);
+SK_API material_t        material_get_variant     (material_t material, int32_t variant_idx);
 SK_API void              material_set_float       (material_t material, const char *name, float    value);
 SK_API void              material_set_vector2     (material_t material, const char *name, vec2     value);
 SK_API void              material_set_vector3     (material_t material, const char *name, vec3     value);
@@ -1738,7 +1740,7 @@ SK_API void                  render_screenshot     (const char *file_utf8, int32
 //TODO: for v0.4, reorder parameters, context in particular should be next to callback
 SK_API void                  render_screenshot_capture  (void (*render_on_screenshot_callback)(color32* color_buffer, int32_t width, int32_t height, void* context), pose_t viewpoint, int32_t width, int32_t height, float field_of_view_degrees, tex_format_ tex_format sk_default(tex_format_rgba32), void *context sk_default(nullptr));
 SK_API void                  render_screenshot_viewpoint(void (*render_on_screenshot_callback)(color32* color_buffer, int32_t width, int32_t height, void* context), matrix camera, matrix projection, int32_t width, int32_t height, render_layer_ layer_filter sk_default(render_layer_all), render_clear_ clear sk_default(render_clear_all), rect_t viewport sk_default(rect_t{}), tex_format_ tex_format sk_default(tex_format_rgba32), void* context sk_default(nullptr));
-SK_API void                  render_to             (tex_t to_rendertarget, int32_t to_target_index, material_t override_material, const sk_ref(matrix) camera, const sk_ref(matrix) projection, render_layer_ layer_filter sk_default(render_layer_all), render_clear_ clear sk_default(render_clear_all), rect_t viewport sk_default({}));
+SK_API void                  render_to             (tex_t to_rendertarget, int32_t to_target_index, const sk_ref(matrix) camera, const sk_ref(matrix) projection, render_layer_ layer_filter sk_default(render_layer_all), int32_t material_variant sk_default(0), render_clear_ clear sk_default(render_clear_all), rect_t viewport sk_default({}));
 SK_API void                  render_get_device     (void **device, void **context);
 SK_API render_list_t         render_get_primary_list(void);
 
@@ -1757,7 +1759,7 @@ SK_API int32_t               render_list_prev_count   (const render_list_t list)
 SK_API void                  render_list_add_mesh     (      render_list_t list, mesh_t  mesh,  material_t material,          matrix world_transform, color128 color_linear, render_layer_ layer);
 SK_API void                  render_list_add_model    (      render_list_t list, model_t model,                               matrix world_transform, color128 color_linear, render_layer_ layer);
 SK_API void                  render_list_add_model_mat(      render_list_t list, model_t model, material_t material_override, matrix world_transform, color128 color_linear, render_layer_ layer);
-SK_API void                  render_list_draw_now     (      render_list_t list, tex_t to_rendertarget, matrix camera, matrix projection, color128 clear_color sk_default({ 0,0,0,0 }), render_clear_ clear sk_default(render_clear_all), rect_t viewport_pct sk_default({}), render_layer_ layer_filter sk_default(render_layer_all));
+SK_API void                  render_list_draw_now     (      render_list_t list, tex_t to_rendertarget, matrix camera, matrix projection, color128 clear_color sk_default({ 0,0,0,0 }), render_clear_ clear sk_default(render_clear_all), rect_t viewport_pct sk_default({}), render_layer_ layer_filter sk_default(render_layer_all), int32_t material_variant sk_default(0));
 
 SK_API void                  render_list_push         (      render_list_t list);
 SK_API void                  render_list_pop          (void);

--- a/StereoKitC/systems/render.h
+++ b/StereoKitC/systems/render.h
@@ -37,7 +37,7 @@ tex_format_   render_preferred_depth_fmt  ();
 void          render_blit_to_bound        (material_t material);
 void          render_set_sim_origin       (pose_t pose);
 void          render_set_sim_head         (pose_t pose);
-void          render_draw_queue           (render_list_t list, const matrix* views, const matrix* projections, int32_t eye_offset, int32_t view_count, int32_t inst_multiplier, render_layer_ filter);
+void          render_draw_queue           (render_list_t list, const matrix* views, const matrix* projections, int32_t eye_offset, int32_t view_count, int32_t inst_multiplier, render_layer_ filter, int32_t material_variant);
 void          render_check_screenshots    ();
 void          render_check_pending_skytex ();
 void          render_global_buffer_internal (int32_t register_slot, material_buffer_t buffer);
@@ -45,7 +45,6 @@ void          render_global_texture_internal(int32_t register_slot, tex_t       
 void          render_action_list_execute  ();
 
 void          render_list_destroy         (      render_list_t list);
-void          render_list_execute         (      render_list_t list, render_layer_ filter, uint32_t inst_multiplier, int32_t queue_start, int32_t queue_end);
-void          render_list_execute_material(      render_list_t list, render_layer_ filter, uint32_t inst_multiplier, int32_t queue_start, int32_t queue_end, material_t override_material);
+void          render_list_execute         (      render_list_t list, render_layer_ filter, int32_t material_variant, uint32_t inst_multiplier, int32_t queue_start, int32_t queue_end);
 
 } // namespace sk

--- a/StereoKitC/systems/render_pipeline.cpp
+++ b/StereoKitC/systems/render_pipeline.cpp
@@ -79,7 +79,7 @@ void render_pipeline_draw() {
 							skg_viewport(viewport);
 
 							int32_t idx = quilt_x + quilt_y * s->quilt_width + layer * s->quilt_width * s->quilt_height;
-							render_draw_queue(list, s->view_matrices, s->proj_matrices, idx, 1, 1, s->layer);
+							render_draw_queue(list, s->view_matrices, s->proj_matrices, idx, 1, 1, s->layer, 0);
 						}
 					}
 				}
@@ -102,7 +102,7 @@ void render_pipeline_draw() {
 					skg_viewport(viewport);
 
 					int32_t idx = quilt_x + quilt_y * s->quilt_width;
-					render_draw_queue(list, s->view_matrices, s->proj_matrices, idx, s->array_count, inst_multiplier, s->layer);
+					render_draw_queue(list, s->view_matrices, s->proj_matrices, idx, s->array_count, inst_multiplier, s->layer, 0);
 				} }
 			}
 		}


### PR DESCRIPTION
The native API initially had a concept of "Material Overrides" for drawing entire RenderLists with a single Material, but this wasn't a fully robust solution that completely solved the problem. For example, with ShadowMaps, a single Material would not cover cases where textures would be used for alpha testing, _and_ vertex animation, _and_ terrain vertex height, etc. Multiple Materials are still critical here.

Instead, Material Variants allow for a parallel list of Materials that can be used when drawing a RenderList! This means that each Material can have a Variant Material for Shadow Maps (or other effects), and all you have to do when drawing the RenderList is specify the variant index. Materials without the specified variant aren't drawn, so this does require more work by default, but the solution is much more robust!

This commit _replaces_ material overrides, so it does contain breaking changes, specifically within `Renderer.RenderTo` and `RenderList.DrawNow` on both C and C# side. This also adds `Material.Set/GetVariant`, and updates the Shadow demo to use these features.