### PR TITLE
Allow SK to load GLTF meshes that only contain points.

### DIFF
--- a/StereoKitC/asset_types/mesh.cpp
+++ b/StereoKitC/asset_types/mesh.cpp
@@ -198,8 +198,8 @@ void mesh_set_data(mesh_t mesh, const vert_t *vertices, int32_t vertex_count, co
 
 	assets_execute_gpu([](void *data) {
 		mesh_upload_job_t *job_data = (mesh_upload_job_t *)data;
-		_mesh_set_verts(job_data->mesh, job_data->vertices, job_data->vertex_count, job_data->calculate_bounds, true);
-		_mesh_set_inds (job_data->mesh, job_data->indices,  job_data->index_count);
+		if (job_data->vertex_count > 0) _mesh_set_verts(job_data->mesh, job_data->vertices, job_data->vertex_count, job_data->calculate_bounds, true);
+		if (job_data->index_count  > 0) _mesh_set_inds (job_data->mesh, job_data->indices,  job_data->index_count);
 		
 		return (bool32_t)true;
 	}, &job_data);

--- a/StereoKitC/asset_types/model_gltf.cpp
+++ b/StereoKitC/asset_types/model_gltf.cpp
@@ -299,7 +299,7 @@ mesh_t gltf_parsemesh(cgltf_mesh *mesh, int node_id, int primitive_id, const cha
 	cgltf_mesh      *m = mesh;
 	cgltf_primitive *p = &m->primitives[primitive_id];
 
-	if (p->type != cgltf_primitive_type_triangles) {
+	if (p->type != cgltf_primitive_type_triangles && p->type != cgltf_primitive_type_points) {
 		log_errf("[%s] Unimplemented GLTF primitive mode: %d", filename, p->type);
 		return nullptr;
 	}
@@ -397,10 +397,12 @@ mesh_t gltf_parsemesh(cgltf_mesh *mesh, int node_id, int primitive_id, const cha
 	vind_t *inds      = nullptr;
 	if (p->indices == nullptr) {
 		// No indices listed, create indices that map to one index per vertex
-		ind_count = vert_count;
-		inds      = sk_malloc_t(vind_t, ind_count);
-		for (size_t i = 0; i < ind_count; i++) {
-			inds[i] = (vind_t)i;
+		if (p->type == cgltf_primitive_type_triangles) {
+			ind_count = vert_count;
+			inds      = sk_malloc_t(vind_t, ind_count);
+			for (size_t i = 0; i < ind_count; i++) {
+				inds[i] = (vind_t)i;
+			}
 		}
 	} else {
 		// Extract indices from the index buffer


### PR DESCRIPTION
Useful for point cloud loading. SK doesn't natively display this data yet, but this now allows the point cloud demo to use GLTF point clouds.