### PR TITLE
Fixes for spherical harmonics calculation

### DIFF
--- a/Examples/StereoKitTest/Tests/TestGradientCubemap.cs
+++ b/Examples/StereoKitTest/Tests/TestGradientCubemap.cs
@@ -1,0 +1,38 @@
+using StereoKit;
+
+class TestGradientCubemap : ITest
+{
+	Tex                 cubemap;
+	SphericalHarmonics  lighting;
+	Tex                 oldSkyTex;
+	SphericalHarmonics  oldSkyLight;
+
+	public void Initialize()
+	{
+		oldSkyTex   = Renderer.SkyTex;
+		oldSkyLight = Renderer.SkyLight;
+
+		Gradient gradient = new Gradient(
+			new GradientKey(new Color(0.1f, 0.1f, 0.2f), 0.0f),
+			new GradientKey(new Color(0.4f, 0.6f, 0.9f), 0.5f),
+			new GradientKey(new Color(1.0f, 0.9f, 0.7f), 1.0f));
+
+		cubemap = Tex.GenCubemap(gradient, out lighting, Vec3.Up, 64);
+
+		Renderer.SkyTex   = cubemap;
+		Renderer.SkyLight = lighting;
+	}
+
+	public void Shutdown()
+	{
+		Renderer.SkyTex   = oldSkyTex;
+		Renderer.SkyLight = oldSkyLight;
+	}
+
+	public void Step()
+	{
+		Tests.Screenshot("Tests/GradientCubemap.jpg", 400, 400, V.XYZ(0, 0, 0), V.XYZ(0, 0, -0.5f));
+
+		Mesh.Sphere.Draw(Material.Default, Matrix.TS(0, 0, -0.5f, 0.2f));
+	}
+}

--- a/StereoKitC/spherical_harmonics.cpp
+++ b/StereoKitC/spherical_harmonics.cpp
@@ -5,9 +5,6 @@
 
 namespace sk {
 
-void sh_add      (spherical_harmonics_t &to, vec3 light_dir, vec3 light_color);
-void sh_windowing(spherical_harmonics_t &harmonics, float window_width);
-
 ///////////////////////////////////////////
 
 vec3 to_color_128(uint8_t *color) { return *(vec3 *)color; }
@@ -181,11 +178,16 @@ color128 sh_lookup(const spherical_harmonics_t &harmonics, vec3 normal) {
 vec3 sh_dominant_dir(const sk_ref(spherical_harmonics_t) harmonics) {
 	// Reference from here:
 	// https://seblagarde.wordpress.com/2011/10/09/dive-in-sh-buffer-idea/
-	vec3 dir = vec3_normalize({
+	vec3 dir = {
 		harmonics.coefficients[3].x * 0.3f + harmonics.coefficients[3].y * 0.59f + harmonics.coefficients[3].z,
 		harmonics.coefficients[1].x * 0.3f + harmonics.coefficients[1].y * 0.59f + harmonics.coefficients[1].z,
-		harmonics.coefficients[2].x * 0.3f + harmonics.coefficients[2].y * 0.59f + harmonics.coefficients[2].z });
-	return -dir;
+		harmonics.coefficients[2].x * 0.3f + harmonics.coefficients[2].y * 0.59f + harmonics.coefficients[2].z };
+
+	// If no lighting data, default to light from above
+	if (vec3_magnitude_sq(dir) < 0.0001f)
+		return { 0, 1, 0 };
+
+	return -vec3_normalize(dir);
 }
 
 ///////////////////////////////////////////

--- a/StereoKitC/spherical_harmonics.h
+++ b/StereoKitC/spherical_harmonics.h
@@ -7,6 +7,8 @@ namespace sk {
 ///////////////////////////////////////////
 
 spherical_harmonics_t sh_calculate(void **env_map_data, tex_format_ format, int32_t face_size);
+void                  sh_add      (spherical_harmonics_t &to, vec3 light_dir, vec3 light_color);
+void                  sh_windowing(spherical_harmonics_t &harmonics, float window_width);
 void                  sh_to_fast  (const spherical_harmonics_t &lookup, vec4 *fast_9);
 
 }


### PR DESCRIPTION
Fixes tex_gen_cubemap providing an empty SH due to changes in how/when SH is calculated.
Fixes NaNs from sh_dominant_dir when working with 0 SHs.