### PR TITLE
Add fallback cubemap textures

### DIFF
--- a/StereoKitC/systems/defaults.cpp
+++ b/StereoKitC/systems/defaults.cpp
@@ -158,6 +158,9 @@ bool defaults_init() {
 	sk_default_cubemap = tex_gen_cubemap_sh(lighting, 16, 0.3f);
 	tex_set_id(sk_default_cubemap, default_id_cubemap);
 
+	tex_set_loading_fallback(sk_default_cubemap);
+	tex_set_error_fallback  (sk_default_cubemap);
+
 	// Default quad mesh
 	sk_default_quad = mesh_create();
 	vert_t verts[4] = {


### PR DESCRIPTION
This fixes validation errors when fallback textures get used for cubemaps. For the moment, this reuses tex_set_loading/error_fallback for assigning both the default fallback texture for cubemaps as well as 2D textures. It switches based on the type of texture provided. Probably should be separated in the future.