### PR TITLE
Fix sk::ui_input buffer size handling

### DIFF
--- a/StereoKitC/ui/stereokit_ui.cpp
+++ b/StereoKitC/ui/stereokit_ui.cpp
@@ -568,10 +568,11 @@ bool32_t ui_input_at_g(const C* id, C* buffer, int32_t buffer_size, vec3 window_
 					utf_remove_chars(utf_advance_chars(buffer, start), count);
 					skui_input_carat_end = skui_input_carat = start;
 				}
-				utf_insert_char(buffer, buffer_size, utf_advance_chars(buffer, skui_input_carat), add);
-				skui_input_carat += 1;
-				skui_input_carat_end = skui_input_carat;
-				result = true;
+				if (utf_insert_char(buffer, buffer_size, utf_advance_chars(buffer, skui_input_carat), add)) {
+					skui_input_carat += 1;
+					skui_input_carat_end = skui_input_carat;
+					result = true;
+				}
 			}
 
 			curr = input_text_consume();


### PR DESCRIPTION
When I add N more characters than allowed to my string in the input field, I have to hit N times backspace before it starts removing characters from the end of the string.

This patch fixes this issue by handling the return value of utf_insert_char().

Tested for my use case, it appears to work well, however maybe a more in-depth testing is required?

Fixes https://github.com/StereoKit/StereoKit/issues/1287.