### PR TITLE
Fix issue calling xrLocateViews with a time of 0

### DIFF
--- a/StereoKitC/xr_backends/openxr.cpp
+++ b/StereoKitC/xr_backends/openxr.cpp
@@ -757,7 +757,7 @@ bool openxr_poll_events() {
 					// be available as soon as the session begins, for apps that
 					// are listening to sk_app_focus changing to determine if FoV
 					// is ready.
-					openxr_views_update_fov();
+					openxr_views_update_fov(changed->time);
 				}
 			} break;
 			case XR_SESSION_STATE_SYNCHRONIZED: break; // We're connected to a session, but not visible to users yet.

--- a/StereoKitC/xr_backends/openxr_view.cpp
+++ b/StereoKitC/xr_backends/openxr_view.cpp
@@ -1034,7 +1034,7 @@ void openxr_display_swapchain_release(device_display_t *display) {
 
 ///////////////////////////////////////////
 
-void openxr_views_update_fov() {
+void openxr_views_update_fov(XrTime time) {
 	if (xr_display_primary_idx == -1) return;
 	device_display_t* disp = &xr_displays[xr_display_primary_idx];
 
@@ -1043,7 +1043,7 @@ void openxr_views_update_fov() {
 	XrViewState      view_state  = { XR_TYPE_VIEW_STATE };
 	XrViewLocateInfo locate_info = { XR_TYPE_VIEW_LOCATE_INFO };
 	locate_info.viewConfigurationType = disp->type;
-	locate_info.displayTime           = xr_time;
+	locate_info.displayTime           = time;
 	locate_info.space                 = xr_head_space; // We don't need app space here, and app space may not be valid yet
 	if (XR_FAILED(xrLocateViews(xr_session, &locate_info, &view_state, disp->view_cap, &view_count, disp->view_xr)))
 		return;

--- a/StereoKitC/xr_backends/openxr_view.h
+++ b/StereoKitC/xr_backends/openxr_view.h
@@ -16,7 +16,7 @@ namespace sk {
 
 bool openxr_views_create    ();
 void openxr_views_destroy   ();
-void openxr_views_update_fov();
+void openxr_views_update_fov(XrTime time);
 
 void     xr_extension_structs_clear();
 bool32_t xr_set_blend              (display_blend_ blend);


### PR DESCRIPTION
This meant initial FoV would be bad, and left a sad log in the console. This fix now uses a more appropriate time value as well.