### PR TITLE
Misc fixes

### DIFF
--- a/StereoKit/BuildStereoKitSDK.targets
+++ b/StereoKit/BuildStereoKitSDK.targets
@@ -72,7 +72,7 @@
 			<SKSDKCacheFile Condition="'$(SKSDKBuildOS)'=='Win32'">$(SKSDKFolder)\bin\intermediate\$(SKSDKBuildOS)_$(SKSDKBuildModePreset)$(SKSDKPresetFast)\CMakeCache.txt</SKSDKCacheFile>
 			<SKSDKCacheFile Condition="'$(SKSDKCacheFile)'==''"   >$(SKSDKFolder)\bin\intermediate\$(SKSDKBuildOS)_$(SKSDKBuildModePreset)_$(Configuration)$(SKSDKPresetFast)\CMakeCache.txt</SKSDKCacheFile>
 
-			<SKBuildCommand                                         >cd $(SKSDKFolder)</SKBuildCommand>
+			<SKBuildCommand                                         >cd "$(SKSDKFolder)"</SKBuildCommand>
 			<SKBuildCommand Condition="!Exists('$(SKSDKCacheFile)')">$(SKBuildCommand) &amp;&amp; cmake --preset $(SKSDKPreset) -DSK_BUILD_TESTS=OFF</SKBuildCommand>
 			<SKBuildCommand                                         >$(SKBuildCommand) &amp;&amp; cmake --build --preset $(SKSDKPreset)</SKBuildCommand>
 		</PropertyGroup>

--- a/StereoKit/SKShaders.targets
+++ b/StereoKit/SKShaders.targets
@@ -52,7 +52,7 @@
 		<!-- Setup metadata for custom build tool -->
 		<ItemGroup>
 			<SKShader Condition="'%(SKShader.RelFile)'!=''">
-				<Command>$(SKShadercPath) $(SKOpt) -e -i "$(IncludeFolderNormalized)" -o "$([System.String]::Copy('$(IntermediateOutputPath)$(SKAssetDestination)/%(SKShader.RelFolder)').Replace('\','/'))" "%(SKShader.Identity)"</Command>
+				<Command>"$(SKShadercPath)" $(SKOpt) -e -i "$(IncludeFolderNormalized)" -o "$([System.String]::Copy('$(IntermediateOutputPath)$(SKAssetDestination)/%(SKShader.RelFolder)').Replace('\','/'))" "%(SKShader.Identity)"</Command>
 				<Outputs>$(IntermediateOutputPath)$(SKAssetDestination)/%(SKShader.RelFile).sks</Outputs>
 				<RelativeName>%(SKShader.RelFile).sks</RelativeName>
 			</SKShader>
@@ -96,7 +96,7 @@
 	<Target Name="StereoKit_Shader_Code" BeforeTargets="BeforeCompile" Inputs="@(SKShaderCode->'%(FullPath)')" Outputs="@(SKShaderCode->'$(IntermediateOutputPath)%(RecursiveDir)Material%(Filename).gen.cs')">
 		<Message Text="[StereoKit NuGet] Generating C# for %(SKShaderCode.Identity) -> $(IntermediateOutputPath)%(SKShaderCode.RecursiveDir)Material%(SKShaderCode.Filename).gen.cs" Importance="high" />
 
-		<Exec Command='$(SKShadercPath) $(SKOpt) -e -sk -i "$(IncludeFolderNormalized)" "%(SKShaderCode.Identity)" -o "$(IntermediateOutputPath)%(SKShaderCode.RecursiveDir)Material%(SKShaderCode.Filename).gen.cs"'></Exec>
+		<Exec Command='"$(SKShadercPath)" $(SKOpt) -e -sk -i "$(IncludeFolderNormalized)" "%(SKShaderCode.Identity)" -o "$(IntermediateOutputPath)%(SKShaderCode.RecursiveDir)Material%(SKShaderCode.Filename).gen.cs"'></Exec>
 
 		<ItemGroup>
 			<Compile Remove ="@(SKShaderCode->'$(IntermediateOutputPath)%(RecursiveDir)Material%(Filename).gen.cs')"/>

--- a/StereoKitC/asset_types/texture.cpp
+++ b/StereoKitC/asset_types/texture.cpp
@@ -906,10 +906,12 @@ tex_t tex_get_zbuffer(tex_t texture) {
 ///////////////////////////////////////////
 
 void tex_set_surface(tex_t texture, void *native_surface, tex_type_ type, int64_t native_fmt, int32_t width, int32_t height, int32_t surface_count, int32_t multisample, bool32_t owned) {
-	texture->owned = owned;
-
-	if (texture->owned && skr_tex_is_valid(&texture->gpu_tex))
+	// Always destroy old GPU resources when valid - skr_tex_destroy handles
+	// is_external internally to decide whether to destroy the VkImage.
+	if (skr_tex_is_valid(&texture->gpu_tex))
 		skr_tex_destroy(&texture->gpu_tex);
+
+	texture->owned = owned;
 
 	texture->type   = type;
 	texture->format = tex_get_tex_format(native_fmt);
@@ -924,7 +926,7 @@ void tex_set_surface(tex_t texture, void *native_surface, tex_type_ type, int64_
 		info.array_layers  = surface_count;
 		info.owns_image    = owned;
 
-		skr_tex_create_external(info, &texture->gpu_tex);
+		skr_tex_create_external_vk(info, &texture->gpu_tex);
 	} else {
 		texture->gpu_tex = {};
 	}
@@ -1005,7 +1007,11 @@ void tex_destroy(tex_t tex) {
 	assets_on_load_remove(&tex->header, nullptr);
 
 	sk_free(tex->light_info);
-	if (tex->owned && skr_tex_is_valid(&tex->gpu_tex)) {
+	// Always destroy GPU resources when valid - skr_tex_destroy checks is_external
+	// internally to decide whether to destroy the VkImage (external images like
+	// OpenXR swapchains won't have their VkImage destroyed, but ImageViews and
+	// Framebuffers that we created will still be cleaned up).
+	if (skr_tex_is_valid(&tex->gpu_tex)) {
 		skr_tex_destroy(&tex->gpu_tex);
 	}
 	if (tex->depth_buffer != nullptr) tex_release(tex->depth_buffer);

--- a/StereoKitC/asset_types/texture.cpp
+++ b/StereoKitC/asset_types/texture.cpp
@@ -926,7 +926,7 @@ void tex_set_surface(tex_t texture, void *native_surface, tex_type_ type, int64_
 		info.array_layers  = surface_count;
 		info.owns_image    = owned;
 
-		skr_tex_create_external_vk(info, &texture->gpu_tex);
+		skr_tex_create_external(info, &texture->gpu_tex);
 	} else {
 		texture->gpu_tex = {};
 	}

--- a/StereoKitC/xr_backends/openxr_view.cpp
+++ b/StereoKitC/xr_backends/openxr_view.cpp
@@ -350,6 +350,12 @@ bool32_t xr_view_type_valid(XrViewConfigurationType type) {
 ///////////////////////////////////////////
 
 void openxr_views_destroy() {
+	// Wait for all GPU work to complete before destroying swapchain resources.
+	// The textures have ImageViews/Framebuffers that may still be referenced
+	// by in-flight command buffers, and OpenXR swapchain images can't be
+	// destroyed while in use.
+	vkDeviceWaitIdle(skr_get_vk_device());
+
 	for (int32_t i = 0; i < xr_displays.count; i++) {
 		device_display_delete(&xr_displays[i]);
 	}
@@ -506,10 +512,12 @@ bool openxr_display_swapchain_update(device_display_t *display) {
 	// Update or set the native textures
 	for (uint32_t back = 0; back < sc_color->backbuffer_count; back++) {
 		// Update our textures with the new swapchain display surfaces (VkImage for Vulkan)
+		// OpenXR swapchain images are owned by the runtime, not the application - they get
+		// destroyed when xrDestroySwapchain is called, so we pass owned=false here.
 		void *native_surface_col   = (void*)sc_color->backbuffers[back].image;
 		void *native_surface_depth = (void*)sc_depth->backbuffers[back].image;
-		tex_set_surface(sc_color->textures[back], native_surface_col,   tex_type_rendertarget, xr_preferred_color_format, sc_color->width, sc_color->height, array_count, 1);
-		tex_set_surface(sc_depth->textures[back], native_surface_depth, tex_type_depth,        xr_preferred_depth_format, sc_depth->width, sc_depth->height, array_count, 1);
+		tex_set_surface(sc_color->textures[back], native_surface_col,   tex_type_rendertarget, xr_preferred_color_format, sc_color->width, sc_color->height, array_count, 1, false);
+		tex_set_surface(sc_depth->textures[back], native_surface_depth, tex_type_depth,        xr_preferred_depth_format, sc_depth->width, sc_depth->height, array_count, 1, false);
 		tex_set_zbuffer(sc_color->textures[back], sc_depth->textures[back]);
 	}
 


### PR DESCRIPTION
Fix for swapchains getting improper destroy on shutdown from OpenXR, causing validation issues on exit.
Fix unquoted paths in shader compilation, which would trip when calling skshaderc on a user with spaces in their windows username.