### PR TITLE
Performance and quality improvements for shaders

### DIFF
--- a/Examples/Assets/edged_quadrant.hlsl
+++ b/Examples/Assets/edged_quadrant.hlsl
@@ -55,7 +55,7 @@ psIn vs(vsIn input, uint id : SV_InstanceID) {
 }
 
 float4 ps(psIn input) : SV_TARGET {
-	float  glow = sk_finger_glow(input.world.xyz, input.normal);
+	float  glow = sk_finger_glow(input.world.xyz);
 
 	float  edge = saturate((input.light_edge.a - 0.15) / fwidth(input.light_edge.a));
 

--- a/StereoKitC/shaders_builtin/shader_builtin_pbr.hlsl
+++ b/StereoKitC/shaders_builtin/shader_builtin_pbr.hlsl
@@ -28,19 +28,19 @@ Texture2D    occlusion   : register(t3);
 SamplerState occlusion_s : register(s3);
 
 struct vsIn {
-	float4 pos     : SV_Position;
-	float3 norm    : NORMAL0;
-	float2 uv      : TEXCOORD0;
-	float4 color   : COLOR0;
+	float4 pos       : SV_Position;
+	float3 norm      : NORMAL0;
+	float2 uv        : TEXCOORD0;
+	float4 color     : COLOR0;
 };
 struct psIn {
-	float4 pos     : SV_POSITION;
-	float3 normal  : NORMAL0;
-	float2 uv      : TEXCOORD0;
-	float4 color   : COLOR0;
-	float3 irradiance: COLOR1;
-	float3 world   : TEXCOORD1;
-	float3 view_dir: TEXCOORD2;
+	float4 pos       : SV_POSITION;
+	half3  normal    : NORMAL0;
+	float2 uv        : TEXCOORD0;
+	half4  color     : COLOR0;
+	half3  irradiance: COLOR1;
+	float3 world     : TEXCOORD1;
+	float3 view_dir  : TEXCOORD2;
 	uint view_id : SV_RenderTargetArrayIndex;
 };
 
@@ -49,10 +49,11 @@ psIn vs(vsIn input, uint id : SV_InstanceID) {
 	o.view_id = id % sk_view_count;
 	id        = id / sk_view_count;
 
-	o.world = mul(float4(input.pos.xyz, 1), sk_inst[id].world).xyz;
-	o.pos   = mul(float4(o.world,  1), sk_viewproj[o.view_id]);
+	float3x3 world3x3 = (float3x3)sk_inst[id].world;
+	o.world = mul(input.pos.xyz, world3x3) + sk_inst[id].world[3].xyz;
+	o.pos   = mul(float4(o.world, 1), sk_viewproj[o.view_id]);
 
-	o.normal     = normalize(mul(float4(input.norm, 0), sk_inst[id].world).xyz);
+	o.normal     = normalize(mul(input.norm, world3x3));
 	o.uv         = (input.uv * tex_trans.zw) + tex_trans.xy;
 	o.color      = input.color * sk_inst[id].color * color;
 	o.irradiance = sk_lighting(o.normal);
@@ -61,15 +62,15 @@ psIn vs(vsIn input, uint id : SV_InstanceID) {
 }
 
 float4 ps(psIn input) : SV_TARGET {
-	float4 albedo      = diffuse  .Sample(diffuse_s,  input.uv) * input.color;
-	float3 emissive    = emission .Sample(emission_s, input.uv).rgb * emission_factor.rgb;
-	float2 metal_rough = metal    .Sample(metal_s,    input.uv).gb; // rough is g, b is metallic
-	float  ao          = occlusion.Sample(occlusion_s,input.uv).r;  // occlusion is sometimes part of the metal tex, uses r channel
+	half2 metal_rough = (half2)metal    .Sample(metal_s,     input.uv).gb; // rough is g, b is metallic
+	half  ao          = (half )occlusion.Sample(occlusion_s, input.uv).r;  // occlusion is sometimes part of the metal tex, uses r channel
+	half4 albedo      = (half4)diffuse  .Sample(diffuse_s,   input.uv)     * input.color;
+	half3 emissive    = (half3)emission .Sample(emission_s,  input.uv).rgb * (half3)emission_factor.rgb;
 
-	float metallic_final = metal_rough.y * metallic;
-	float rough_final    = metal_rough.x * roughness;
+	half metallic_final = metal_rough.y * (half)metallic;
+	half rough_final    = metal_rough.x * (half)roughness;
 
 	float4 color = sk_pbr_shade(albedo, input.irradiance, ao, metallic_final, rough_final, input.view_dir, input.normal);
-	color.rgb += emissive;
+	color.rgb += (float3)emissive;
 	return color;
 }

--- a/StereoKitC/shaders_builtin/shader_builtin_pbr_clip.hlsl
+++ b/StereoKitC/shaders_builtin/shader_builtin_pbr_clip.hlsl
@@ -30,19 +30,19 @@ Texture2D    occlusion   : register(t3);
 SamplerState occlusion_s : register(s3);
 
 struct vsIn {
-	float4 pos     : SV_Position;
-	float3 norm    : NORMAL0;
-	float2 uv      : TEXCOORD0;
-	float4 color   : COLOR0;
+	float4 pos       : SV_Position;
+	float3 norm      : NORMAL0;
+	float2 uv        : TEXCOORD0;
+	float4 color     : COLOR0;
 };
 struct psIn {
-	float4 pos     : SV_POSITION;
-	float3 normal  : NORMAL0;
-	float2 uv      : TEXCOORD0;
-	float4 color   : COLOR0;
-	float3 irradiance: COLOR1;
-	float3 world   : TEXCOORD1;
-	float3 view_dir: TEXCOORD2;
+	float4 pos       : SV_POSITION;
+	half3  normal    : NORMAL0;
+	float2 uv        : TEXCOORD0;
+	half4  color     : COLOR0;
+	half3  irradiance: COLOR1;
+	float3 world     : TEXCOORD1;
+	float3 view_dir  : TEXCOORD2;
 	uint view_id : SV_RenderTargetArrayIndex;
 };
 
@@ -51,10 +51,11 @@ psIn vs(vsIn input, uint id : SV_InstanceID) {
 	o.view_id = id % sk_view_count;
 	id        = id / sk_view_count;
 
-	o.world = mul(float4(input.pos.xyz, 1), sk_inst[id].world).xyz;
-	o.pos   = mul(float4(o.world,  1), sk_viewproj[o.view_id]);
+	float3x3 world3x3 = (float3x3)sk_inst[id].world;
+	o.world = mul(input.pos.xyz, world3x3) + sk_inst[id].world[3].xyz;
+	o.pos   = mul(float4(o.world, 1), sk_viewproj[o.view_id]);
 
-	o.normal     = normalize(mul(float4(input.norm, 0), sk_inst[id].world).xyz);
+	o.normal     = normalize(mul(input.norm, world3x3));
 	o.uv         = (input.uv * tex_trans.zw) + tex_trans.xy;
 	o.color      = input.color * sk_inst[id].color * color;
 	o.irradiance = sk_lighting(o.normal);
@@ -63,18 +64,18 @@ psIn vs(vsIn input, uint id : SV_InstanceID) {
 }
 
 float4 ps(psIn input) : SV_TARGET {
-	float4 albedo = diffuse.Sample(diffuse_s,  input.uv);
-	if (albedo.a < cutoff) discard;
-	albedo = albedo*input.color;
+	half4 albedo = (half4)diffuse.Sample(diffuse_s, input.uv);
+	if (albedo.a < (half)cutoff) discard;
+	albedo *= input.color;
 
-	float3 emissive    = emission .Sample(emission_s, input.uv).rgb * emission_factor.rgb;
-	float2 metal_rough = metal    .Sample(metal_s,    input.uv).gb; // b is metallic, rough is g
-	float  ao          = occlusion.Sample(occlusion_s,input.uv).r;  // occlusion is sometimes part of the metal tex, uses r channel
+	half2 metal_rough = (half2)metal    .Sample(metal_s,     input.uv).gb; // rough is g, b is metallic
+	half  ao          = (half )occlusion.Sample(occlusion_s, input.uv).r;  // occlusion is sometimes part of the metal tex, uses r channel
+	half3 emissive    = (half3)emission .Sample(emission_s,  input.uv).rgb * (half3)emission_factor.rgb;
 
-	float metallic_final = metal_rough.y * metallic;
-	float rough_final    = metal_rough.x * roughness;
+	half metallic_final = metal_rough.y * (half)metallic;
+	half rough_final    = metal_rough.x * (half)roughness;
 
 	float4 color = sk_pbr_shade(albedo, input.irradiance, ao, metallic_final, rough_final, input.view_dir, input.normal);
-	color.rgb += emissive;
+	color.rgb += (float3)emissive;
 	return color;
 }

--- a/StereoKitC/shaders_builtin/shader_builtin_ui.hlsl
+++ b/StereoKitC/shaders_builtin/shader_builtin_ui.hlsl
@@ -38,7 +38,7 @@ psIn vs(vsIn input, uint id : SV_InstanceID) {
 }
 
 float4 ps(psIn input) : SV_TARGET {
-	float  glow = pow(1 - saturate(sk_finger_distance(input.world) / 0.12), 10);
+	half   glow = sk_finger_glow(input.world);
 	float4 col  = float4(lerp(input.color.rgb, half3(1, 1, 1), glow), input.color.a);
 
 	return diffuse.Sample(diffuse_s, input.uv) * col;

--- a/StereoKitC/shaders_builtin/shader_builtin_ui_aura.hlsl
+++ b/StereoKitC/shaders_builtin/shader_builtin_ui_aura.hlsl
@@ -23,27 +23,27 @@ psIn vs(vsIn input, uint id : SV_InstanceID) {
 	o.view_id = id % sk_view_count;
 	id        = id / sk_view_count;
 
-	// Extract scale from the matrix
 	float4x4 world_mat = sk_inst[id].world;
-	float3   scale     = float3(
-		length(float3(world_mat._11,world_mat._12,world_mat._13)),
-		length(float3(world_mat._21,world_mat._22,world_mat._23)),
-		length(float3(world_mat._31,world_mat._32,world_mat._33))
-	);
-	// Restore scale to 1
-	world_mat[0] = world_mat[0] / scale.x;
-	world_mat[1] = world_mat[1] / scale.y;
-	world_mat[2] = world_mat[2] / scale.z;
-	// Translate the position using the quadrant (TEXCOORD0) information and
-	// the extracted scale.
-	float4 sized_pos;
-	sized_pos.xy = input.pos.xy + input.quadrant * scale.xy * 0.5;
-	sized_pos.zw = input.pos.zw;
 
+	// Quadrant offset uses the original (scaled) rows directly:
+	// scale * normalized_row = original_row, so no explicit scale needed.
+	float3 row0 = float3(world_mat._11, world_mat._12, world_mat._13);
+	float3 row1 = float3(world_mat._21, world_mat._22, world_mat._23);
+	float3 quadrant_offset = (input.quadrant.x * 0.5) * row0
+	                       + (input.quadrant.y * 0.5) * row1;
+
+	// Normalize all rows via rsqrt + multiply (no divide)
+	world_mat[0] *= rsqrt(dot(row0, row0));
+	world_mat[1] *= rsqrt(dot(row1, row1));
+	float3 row2 = float3(world_mat._31, world_mat._32, world_mat._33);
+	world_mat[2] *= rsqrt(dot(row2, row2));
+
+	float4 sized_pos = input.pos;
 	sized_pos.xyz += input.norm * sk_inst[id].color.a * 0.002;
 
-	float4 world = mul(sized_pos, world_mat);
-	float3 normal = normalize(mul(input.norm, (float3x3) world_mat));
+	float4 world  = mul(sized_pos, world_mat);
+	world.xyz    += quadrant_offset;
+	float3 normal = normalize(mul(input.norm, (float3x3)world_mat));
 	o.pos   = mul(world, sk_viewproj[o.view_id]);
 	o.world = world.xyz;
 	o.color = lerp(color.rgb, sk_inst[id].color.rgb, input.color.a) * sk_lighting(normal);
@@ -51,6 +51,6 @@ psIn vs(vsIn input, uint id : SV_InstanceID) {
 }
 
 float4 ps(psIn input) : SV_TARGET {
-	float  glow = pow(saturate(1 - sk_finger_distance(input.world) / 0.12), 2) * 0.2;
+	half   glow = sk_finger_glow(input.world) * 0.2h;
 	return float4(lerp(input.color.rgb, float3(2,2,2), glow), 1);
 }

--- a/StereoKitC/shaders_builtin/shader_builtin_ui_box.hlsl
+++ b/StereoKitC/shaders_builtin/shader_builtin_ui_box.hlsl
@@ -50,7 +50,7 @@ psIn vs(vsIn input, uint id : SV_InstanceID) {
 	return o;
 }
 float4 ps(psIn input) : SV_TARGET {
-	float  glow = pow(1 - saturate(sk_finger_distance(input.world.xyz) / 0.12), 10);
+	half   glow = sk_finger_glow(input.world.xyz);
 	
 	float  border_grow = glow * border_size_grow + border_size;
 	float2 border_pos  = (0.5-abs(input.uv)) * input.scale;

--- a/StereoKitC/shaders_builtin/shader_builtin_ui_quadrant.hlsl
+++ b/StereoKitC/shaders_builtin/shader_builtin_ui_quadrant.hlsl
@@ -20,23 +20,23 @@ psIn vs(vsIn input, uint id : SV_InstanceID) {
 	o.view_id = id % sk_view_count;
 	id        = id / sk_view_count;
 
-	// Extract scale from the matrix
 	float4x4 world_mat = sk_inst[id].world;
-	float2   scale     = float2(
-		length(float3(world_mat._11,world_mat._12,world_mat._13)),
-		length(float3(world_mat._21,world_mat._22,world_mat._23))
-	);
-	// Restore scale to 1
-	world_mat[0] = world_mat[0] / scale.x;
-	world_mat[1] = world_mat[1] / scale.y;
-	// Translate the position using the quadrant (TEXCOORD0) information and
-	// the extracted scale.
-	float4 sized_pos;
-	sized_pos.xy = input.pos.xy + input.quadrant * scale * 0.5;
-	sized_pos.zw = input.pos.zw;
+
+	// Quadrant offset uses the original (scaled) rows directly:
+	// scale * normalized_row = original_row, so no explicit scale needed.
+	// This avoids 2 sqrt transcendentals vs the old length() approach.
+	float3 row0 = float3(world_mat._11, world_mat._12, world_mat._13);
+	float3 row1 = float3(world_mat._21, world_mat._22, world_mat._23);
+	float3 quadrant_offset = (input.quadrant.x * 0.5) * row0
+	                       + (input.quadrant.y * 0.5) * row1;
+
+	// Normalize rows 0 and 1 via rsqrt + multiply (no divide)
+	world_mat[0] *= rsqrt(dot(row0, row0));
+	world_mat[1] *= rsqrt(dot(row1, row1));
 
 	float3 normal = normalize(mul(input.norm, (float3x3)world_mat));
-	float4 world  = mul(sized_pos, world_mat);
+	float4 world  = mul(input.pos, world_mat);
+	world.xyz    += quadrant_offset;
 	o.pos    = mul(world, sk_viewproj[o.view_id]);
 	o.world  = world.xyz;
 	o.color.rgb = input.color.rgb * sk_inst[id].color.rgb * sk_lighting(normal);
@@ -45,6 +45,6 @@ psIn vs(vsIn input, uint id : SV_InstanceID) {
 }
 
 float4 ps(psIn input) : SV_TARGET {
-	float glow = pow(1-saturate(sk_finger_distance(input.world) / 0.12), 10);
+	half glow = sk_finger_glow(input.world);
 	return float4(lerp(input.color.rgb, half3(1, 1, 1), glow), input.color.a);
 }

--- a/StereoKitC/spherical_harmonics.cpp
+++ b/StereoKitC/spherical_harmonics.cpp
@@ -192,24 +192,43 @@ vec3 sh_dominant_dir(const sk_ref(spherical_harmonics_t) harmonics) {
 
 ///////////////////////////////////////////
 
-inline vec4 to_vec4(const vec3& vec) { return { vec.x, vec.y, vec.z, 0 }; }
-
-void sh_to_fast(const spherical_harmonics_t& lookup, vec4* fast_9) {
+void sh_to_fast(const spherical_harmonics_t& lookup, vec4* fast_7) {
 	static const float CosineA0 = 3.141592654f;
 	static const float CosineA1 = (2.0f * CosineA0) / 3.0f;
 	static const float CosineA2 = CosineA0 * 0.25f;
 
-	fast_9[0] = to_vec4(lookup.coefficients[0] * (0.282095f * CosineA0));
+	// Pre-bake SH basis constants into coefficients
+	vec3 sh0 = lookup.coefficients[0] * (0.282095f * CosineA0);
+	vec3 sh1 = lookup.coefficients[1] * (0.488603f * CosineA1);
+	vec3 sh2 = lookup.coefficients[2] * (0.488603f * CosineA1);
+	vec3 sh3 = lookup.coefficients[3] * (0.488603f * CosineA1);
+	vec3 sh4 = lookup.coefficients[4] * (1.092548f * CosineA2);
+	vec3 sh5 = lookup.coefficients[5] * (1.092548f * CosineA2);
+	vec3 sh6 = lookup.coefficients[6] * (0.315392f * CosineA2);
+	vec3 sh7 = lookup.coefficients[7] * (1.092548f * CosineA2);
+	vec3 sh8 = lookup.coefficients[8] * (0.546274f * CosineA2);
 
-	fast_9[1] = to_vec4(lookup.coefficients[1] * (0.488603f * CosineA1));
-	fast_9[2] = to_vec4(lookup.coefficients[2] * (0.488603f * CosineA1));
-	fast_9[3] = to_vec4(lookup.coefficients[3] * (0.488603f * CosineA1));
+	// Pack into dot-product form for efficient GPU evaluation.
+	// Shader evaluates as:
+	//   vA = float4(normal, 1)
+	//   vB = float4(n.x*n.y, n.y*n.z, n.z*n.z, n.z*n.x)
+	//   vC = n.x*n.x - n.y*n.y
+	//   result.c = dot(shA[c], vA) + dot(shB[c], vB) + shC.c * vC
+	// The (3*nz^2-1) term is split: 3*sh6 goes into shB.z, -sh6 folds
+	// into shA.w alongside the band 0 constant.
 
-	fast_9[4] = to_vec4(lookup.coefficients[4] * (1.092548f * CosineA2));
-	fast_9[5] = to_vec4(lookup.coefficients[5] * (1.092548f * CosineA2));
-	fast_9[6] = to_vec4(lookup.coefficients[6] * (0.315392f * CosineA2));
-	fast_9[7] = to_vec4(lookup.coefficients[7] * (1.092548f * CosineA2));
-	fast_9[8] = to_vec4(lookup.coefficients[8] * (0.546274f * CosineA2));
+	// Band 0+1 per channel: dot(shA, float4(normal, 1))
+	fast_7[0] = { sh3.x, sh1.x, sh2.x, sh0.x - sh6.x };
+	fast_7[1] = { sh3.y, sh1.y, sh2.y, sh0.y - sh6.y };
+	fast_7[2] = { sh3.z, sh1.z, sh2.z, sh0.z - sh6.z };
+
+	// Band 2 per channel: dot(shB, float4(n.x*n.y, n.y*n.z, n.z*n.z, n.z*n.x))
+	fast_7[3] = { sh4.x, sh5.x, 3.0f*sh6.x, sh7.x };
+	fast_7[4] = { sh4.y, sh5.y, 3.0f*sh6.y, sh7.y };
+	fast_7[5] = { sh4.z, sh5.z, 3.0f*sh6.z, sh7.z };
+
+	// Last band 2 term: (n.x^2 - n.y^2)
+	fast_7[6] = { sh8.x, sh8.y, sh8.z, 0 };
 }
 
 }

--- a/StereoKitC/spherical_harmonics.h
+++ b/StereoKitC/spherical_harmonics.h
@@ -9,6 +9,6 @@ namespace sk {
 spherical_harmonics_t sh_calculate(void **env_map_data, tex_format_ format, int32_t face_size);
 void                  sh_add      (spherical_harmonics_t &to, vec3 light_dir, vec3 light_color);
 void                  sh_windowing(spherical_harmonics_t &harmonics, float window_width);
-void                  sh_to_fast  (const spherical_harmonics_t &lookup, vec4 *fast_9);
+void                  sh_to_fast  (const spherical_harmonics_t &lookup, vec4 *fast_7);
 
 }

--- a/StereoKitC/systems/lighting.cpp
+++ b/StereoKitC/systems/lighting.cpp
@@ -26,7 +26,7 @@ struct lighting_state_t {
 	material_t              sky_mat_default;
 	bool32_t                sky_show;
 	tex_t                   sky_pending_tex;
-	vec4                    lighting[9];
+	vec4                    lighting[7];
 	spherical_harmonics_t   lighting_src;
 };
 static lighting_state_t local = {};

--- a/StereoKitC/systems/render.cpp
+++ b/StereoKitC/systems/render.cpp
@@ -52,7 +52,7 @@ struct render_global_buffer_t {
 	XMMATRIX proj[2];
 	XMMATRIX proj_inv[2];
 	XMMATRIX viewproj[2];
-	vec4     lighting[9];
+	vec4     lighting[7];
 	vec4     camera_pos[2];
 	vec4     camera_dir[2];
 	vec4     fingertip[2];
@@ -766,7 +766,7 @@ void render_draw_queue(render_list_t list, const matrix *views, const matrix *pr
 	}
 
 	// Copy in the other global shader variables
-	memcpy(local.global_buffer.lighting, lighting_get_lighting(), sizeof(vec4) * 9);
+	memcpy(local.global_buffer.lighting, lighting_get_lighting(), sizeof(vec4) * 7);
 	local.global_buffer.time       = time_totalf();
 	local.global_buffer.view_count = view_count;
 	local.global_buffer.eye_offset = eye_offset;

--- a/tools/include/stereokit.hlsli
+++ b/tools/include/stereokit.hlsli
@@ -8,7 +8,7 @@ cbuffer stereokit_buffer : register(b1) {
 	float4x4 sk_proj       [2];
 	float4x4 sk_proj_inv   [2];
 	float4x4 sk_viewproj   [2];
-	float4   sk_lighting_sh[9];
+	float4   sk_lighting_sh[7];
 	float4   sk_camera_pos [2];
 	float4   sk_camera_dir [2];
 	float4   sk_fingertip  [2];
@@ -27,27 +27,20 @@ SamplerState sk_cubemap_s : register(s11);
 
 ///////////////////////////////////////////
 
-// A spherical harmonics lighting lookup!
-// Some calculations have been offloaded to 'sh_to_fast'
-// in StereoKitC
+// L2 spherical harmonics lighting lookup, packed into dot-product
+// form for efficient evaluation. Coefficients are pre-baked by
+// 'sh_to_fast' in StereoKitC into 7 float4s:
+//   [0..2] = band 0+1 per channel (R,G,B)
+//   [3..5] = band 2   per channel (R,G,B)
+//   [6]    = last band 2 term (.rgb)
 float3 sk_lighting(float3 normal) {
-	// Band 0
-	float3 result = sk_lighting_sh[0].xyz;
-
-	// Band 1
-	result += sk_lighting_sh[1].xyz * normal.y;
-	result += sk_lighting_sh[2].xyz * normal.z;
-	result += sk_lighting_sh[3].xyz * normal.x;
-
-	// Band 2
-	float3 n  = normal.xyz * normal.yzx;
-	float3 n2 = normal * normal;
-	result += sk_lighting_sh[4].xyz * n.x;
-	result += sk_lighting_sh[5].xyz * n.y;
-	result += sk_lighting_sh[6].xyz * (3.0f * n2.z - 1.0f);
-	result += sk_lighting_sh[7].xyz * n.z;
-	result += sk_lighting_sh[8].xyz * (n2.x - n2.y);
-	return result;
+	float4 vA = float4(normal, 1);
+	float4 vB = normal.xyzz * normal.yzzx;
+	float  vC = normal.x * normal.x - normal.y * normal.y;
+	return float3(
+		dot(sk_lighting_sh[0], vA) + dot(sk_lighting_sh[3], vB) + sk_lighting_sh[6].x * vC,
+		dot(sk_lighting_sh[1], vA) + dot(sk_lighting_sh[4], vB) + sk_lighting_sh[6].y * vC,
+		dot(sk_lighting_sh[2], vA) + dot(sk_lighting_sh[5], vB) + sk_lighting_sh[6].z * vC);
 }
 // Legacy name, use sk_lighting
 float3 Lighting(float3 normal) { return sk_lighting(normal); }
@@ -79,47 +72,27 @@ finger_dist_t sk_finger_distance_info(float3 world_pos, float3 world_norm) {
 
 	return result;
 }
-// Legacy name, use sk_finger_distance_info
-finger_dist_t FingerDistanceInfo(float3 world_pos, float3 world_norm) { return sk_finger_distance_info(world_pos, world_norm); }
 
 ///////////////////////////////////////////
 
-float2 sk_finger_glow_ex(float3 world_pos, float3 world_norm) {
-	float dist = 1;
-	float ring = 0;
-	for (int i = 0; i < 2; i++) {
-		float3 to_finger = sk_fingertip[i].xyz - world_pos;
-		float  d         = dot(world_norm, to_finger);
-		float3 on_plane  = sk_fingertip[i].xyz - d * world_norm;
-
-		float dist_from_finger = length(to_finger);
-		float dist_on_plane    = length(world_pos - on_plane);
-		ring = max(ring, saturate(1 - abs(d * 0.5 - dist_on_plane) * 600));
-		dist = min(dist, dist_from_finger);
-	}
-
-	return float2(dist, ring);
+float sk_finger_distance_sq(float3 world_pos) {
+	float3 d0 = sk_fingertip[0].xyz - world_pos;
+	float3 d1 = sk_fingertip[1].xyz - world_pos;
+	return min(dot(d0, d0), dot(d1, d1));
 }
-// Legacy name, use sk_finger_glow_ex
-float2 FingerGlowEx(float3 world_pos, float3 world_norm) { return sk_finger_glow_ex(world_pos, world_norm); }
 
 ///////////////////////////////////////////
 
 float sk_finger_distance(float3 world_pos) {
-	return min(
-		length(sk_fingertip[0].xyz - world_pos),
-		length(sk_fingertip[1].xyz - world_pos));
+	return sqrt(sk_finger_distance_sq(world_pos));
 }
 
 ///////////////////////////////////////////
 
-float sk_finger_glow(float3 world_pos, float3 world_norm) {
-	float2 glow = sk_finger_glow_ex(world_pos, world_norm);
-	glow.x = pow(saturate(1 - glow.x / 0.12), 2);
-	return (glow.x * 0.2) + (glow.y * glow.x);
+half sk_finger_glow(float3 world_pos) {
+	half d_sq = sk_finger_distance_sq(world_pos);
+	return max(0, 1/(1+10000*d_sq)-0.0069h);
 }
-// Legacy name, use sk_finger_glow
-float FingerGlow(float3 world_pos, float3 world_norm) { return sk_finger_glow(world_pos, world_norm); }
 
 ///////////////////////////////////////////
 

--- a/tools/include/stereokit_pbr.hlsli
+++ b/tools/include/stereokit_pbr.hlsli
@@ -14,14 +14,17 @@ float sk_pbr_mip_level(float ndotv) {
 
 ///////////////////////////////////////////
 
-float3 sk_pbr_fresnel_schlick_roughness(float ndotv, float3 F0, float roughness) {
-	return F0 + (max(1 - roughness, F0) - F0) * pow(1.0 - ndotv, 5.0);
+half3 sk_pbr_fresnel_schlick_roughness(half ndotv, half3 F0, half roughness) {
+	// Sebastian approximates pow(1.0 - ndotv, 5.0) as exp2(-5.55473 * ndotv - 6.98316 * ndotv)
+	// https://seblagarde.wordpress.com/2012/06/03/spherical-gaussien-approximation-for-blinn-phong-phong-and-fresnel/
+	return F0 + (max(1.0h - roughness, F0) - F0) * exp2((-5.55473h * ndotv - 6.98316h) * ndotv);
 }
 
 ///////////////////////////////////////////
 
+// Karis, "Real Shading in Unreal Engine 4" (SIGGRAPH 2013)
 // See: https://www.unrealengine.com/en-US/blog/physically-based-shading-on-mobile
-float2 sk_pbr_brdf_appx(half roughness, half ndotv) {
+half2 sk_pbr_brdf_appx(half roughness, half ndotv) {
 	const half4 c0   = { -1, -0.0275, -0.572,  0.022 };
 	const half4 c1   = {  1,  0.0425,  1.04,  -0.04  };
 	half4       r    = roughness * c0 + c1;
@@ -32,38 +35,63 @@ float2 sk_pbr_brdf_appx(half roughness, half ndotv) {
 
 ///////////////////////////////////////////
 
-float4 sk_pbr_shade(float4 albedo, float3 irradiance, float3 ao, float metal, float rough, float3 view_dir, float3 surface_normal) {
+float4 sk_pbr_shade(half4 albedo, half3 irradiance, half ao, half metal, half rough, float3 view_dir, half3 surface_normal) {
+	// View direction and reflection must stay float for precision
 	float3 view        = normalize(view_dir);
-	float3 reflection  = reflect(-view, surface_normal);
-	float  ndotv       = max(0, dot(surface_normal, view));
-	
-	// Reduce specular aliasing by capping roughness at glancing angles.
-	// See Advanced VR Rendering p43 by Alex Vlachos:
-	// https://gdcvault.com/play/1021772/Advanced-VR
-	float3 norm_ddx        = ddx(surface_normal.xyz);
-	float3 norm_ddy        = ddy(surface_normal.xyz);
-	float  geometric_rough = pow(saturate(max(dot(norm_ddx.xyz, norm_ddx.xyz), dot(norm_ddy.xyz, norm_ddy.xyz))), 0.45);
-	rough = max(rough, geometric_rough);
-	
-	float3 F0 = lerp(0.04, albedo.rgb, metal);
-	float3 F  = sk_pbr_fresnel_schlick_roughness(ndotv, F0, rough);
-	float3 kS = F;
+	float3 reflection  = reflect(-view, (float3)surface_normal);
+	half   ndotv       = (half)max(0, dot((float3)surface_normal, view));
 
-	float mip = (1 - pow(1 - rough, 2)) * sk_cubemap_i.z;
+	// Pre-compute specular AA kernel from screen-space normal derivatives.
+	// All ddx/ddy calls stay in the same WQM region; only the sqrt is
+	// deferred until after the cubemap fetch is issued.
+	// Tokuyoshi, "Improved Geometric Specular Antialiasing" (JCGT 2021)
+	half3 dndu            = ddx(surface_normal);
+	half3 dndv            = ddy(surface_normal);
+	half  variance        = 0.25h * (dot(dndu, dndu) + dot(dndv, dndv));
+	half  kernelRoughness = min(variance, 0.18h);
+
+	// Issue cubemap fetch from pre-AA roughness to shorten the dependent
+	// read chain — removes v_sqrt (~16 clk) from the critical path.
+	// The mip is an approximation anyway (Lagarde 2014); Tokuyoshi's
+	// kernel only adds roughness at silhouette edges where the pre-filtered
+	// map / BRDF lobe mismatch is already largest.
+	// Lazarov, "Getting More Physical in Call of Duty: Black Ops II"
+	// (SIGGRAPH 2013)
+	float mip = (float)(rough * (1.7h - 0.7h * rough)) * sk_cubemap_i.z;
 	mip = max(mip, sk_pbr_mip_level(ndotv));
-	float3 prefilteredColor = sk_cubemap.SampleLevel(sk_cubemap_s, reflection, mip).rgb;
-	float2 envBRDF          = sk_pbr_brdf_appx(rough, ndotv);
-	float3 specular         = prefilteredColor * (F * envBRDF.x + envBRDF.y);
+	half3  prefilteredColor = (half3)sk_cubemap.SampleLevel(sk_cubemap_s, reflection, mip).rgb;
 
-	float3 kD = 1 - kS;
-	kD *= 1.0 - metal;
+	// Apply specular AA after cubemap is in flight — sqrt runs hidden
+	// under cubemap memory latency instead of extending the dep chain.
+	rough = sqrt(saturate(rough * rough + kernelRoughness));
 
-	float3 diffuse = albedo.rgb * irradiance * ao;
-	float3 color   = (kD * diffuse + specular*ao);
+	half3 F0 = lerp(0.04h, albedo.rgb, metal);
+	half3 F  = sk_pbr_fresnel_schlick_roughness(ndotv, F0, rough);
+	half3 kS = F;
 
-	return float4(color, albedo.a);
+	half2  envBRDF          = sk_pbr_brdf_appx(rough, ndotv);
+	half3  specular         = prefilteredColor * (F * envBRDF.x + envBRDF.y);
+
+	// Multi-scattering energy compensation: recovers energy lost to
+	// inter-reflections at high roughness, brightening rough metals.
+	// Fdez-Aguera, "A Multiple-Scattering Microfacet Model for Real-Time
+	// Image Based Lighting" (SIGGRAPH 2019)
+	half3 energyCompensation = 1.0h + F0 * (1.0h / max(envBRDF.x + envBRDF.y, 0.001h) - 1.0h);
+	specular *= energyCompensation;
+
+	half3 kD = 1.0h - kS;
+	kD *= 1.0h - metal;
+
+	half3 diffuse = albedo.rgb * irradiance * ao;
+	// Gotanda (tri-Ace, 2014): roughness-dependent retroreflection boost
+	// approximating Disney/Burley diffuse for IBL. Near-free.
+	// diffuse *= 1.0h + 0.5h * rough;
+	half3 color   = kD * diffuse + specular * ao;
+
+	return float4((float3)color, albedo.a);
 }
 
 ///////////////////////////////////////////
 
 #endif
+


### PR DESCRIPTION
Spherical harmonics are packed a bit tighter, enabling dots! Shaders were switched to half precision logic.
Cubemap sampling is a dependant read, shifted calculations to enable dependency to resolve earlier. Better energy preservation in rough metallic materials. Switched mip calculation method to Tokuyoshi.
Picked up a small opt in the fresnel as well.
Re-worked finger glow to be faster.
Faster scale extraction for quadrant shaders.