### PR TITLE
Early input event fix

### DIFF
--- a/StereoKitC/systems/input.cpp
+++ b/StereoKitC/systems/input.cpp
@@ -78,6 +78,8 @@ struct input_state_t {
 	array_t<evt_button_t> evt_buttons;
 	array_t<evt_float_t>  evt_floats;
 	array_t<evt_xy_t>     evt_xys;
+
+	bool                  initialized;
 };
 static input_state_t local = {};
 
@@ -93,11 +95,18 @@ void input_mouse_update();
 bool input_init() {
 	profiler_zone();
 
+	// Preserve values that may have been set before init, such as palm
+	// offsets from OpenXR interaction profile events.
+	pose_t palm_offset[2]     = { local.palm_offset[0],     local.palm_offset[1]     };
+	bool   controller_hand[2] = { local.controller_hand[0], local.controller_hand[1] };
+
 	local = {};
-	input_head_pose_local = pose_identity;
-	local.eyes_pose_local = pose_identity;
-	local.palm_offset[0] = pose_identity;
-	local.palm_offset[1] = pose_identity;
+	input_head_pose_local    = pose_identity;
+	local.eyes_pose_local    = pose_identity;
+	local.palm_offset[0]     = palm_offset[0];
+	local.palm_offset[1]     = palm_offset[1];
+	local.controller_hand[0] = controller_hand[0];
+	local.controller_hand[1] = controller_hand[1];
 
 	local.mtx_poses   = ft_mutex_create();
 	local.mtx_floats  = ft_mutex_create();
@@ -108,6 +117,8 @@ bool input_init() {
 	input_hand_init();
 	input_mouse_update();
 	input_render_init();
+
+	local.initialized = true;
 	return true;
 }
 
@@ -503,6 +514,8 @@ vec2          input_xy_get        (input_xy_     xy_type)     { return xy_type  
 ///////////////////////////////////////////
 
 void input_reset() {
+	if (!local.initialized) return;
+
 	// Set all poses to un-tracked.
 	ft_mutex_lock(local.mtx_poses);
 	local.evt_poses.clear();

--- a/StereoKitC/xr_backends/openxr.cpp
+++ b/StereoKitC/xr_backends/openxr.cpp
@@ -753,11 +753,16 @@ bool openxr_poll_events() {
 					xr_has_session = true;
 					log_diag("OpenXR session began.");
 
-					// FoV normally updates right before drawing, but we need it to
-					// be available as soon as the session begins, for apps that
-					// are listening to sk_app_focus changing to determine if FoV
-					// is ready.
+					// FoV normally updates right before drawing, but we need
+					// it to be available as soon as the session begins, for
+					// apps that are listening to sk_app_focus changing to
+					// determine if FoV is ready.
 					openxr_views_update_fov(changed->time);
+
+					// After session begins, we want to break out of the
+					// polling loop so we can call ext_management_evt_session_ready
+					// before processing any more events!
+					return result;
 				}
 			} break;
 			case XR_SESSION_STATE_SYNCHRONIZED: break; // We're connected to a session, but not visible to users yet.


### PR DESCRIPTION
When receiving input related events immediately after OpenXR session begin, some objects were not initialized properly to receive the event. In particular, some mutexes were not initialized.

These changes guard against using the mutexes before initialization, preserves early input data, and (most importantly) also defers any events immediately after session begin until after initialization.