### PR TITLE
Loading improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -201,7 +201,7 @@ jobs:
       with:
         arch: arm64
     - name: Install cross-compilation tools
-      run: sudo apt-get install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu lld:arm64 libx11-dev:arm64 libxfixes-dev:arm64 libegl-dev:arm64 libgbm-dev:arm64 libfontconfig-dev:arm64
+      run: sudo apt-get install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu lld:arm64 libx11-dev:arm64 libxfixes-dev:arm64 libfontconfig-dev:arm64
 
     - name: Build Linux Arm64
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -171,7 +171,7 @@ jobs:
     - name: Install Prerequisites
       run: |
         sudo apt-get update
-        sudo apt-get install clang lld ninja-build libx11-dev libxfixes-dev libegl-dev libgbm-dev libfontconfig-dev
+        sudo apt-get install clang llvm lld ninja-build libx11-dev libxfixes-dev libfontconfig-dev
     
     - name: Set Version
       shell: pwsh

--- a/.github/workflows/verify_compile.yml
+++ b/.github/workflows/verify_compile.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Install Prerequisites
       run: |
         sudo apt-get update
-        sudo apt-get install clang-12 lld-12 ninja-build libx11-dev libxfixes-dev libegl-dev libgbm-dev libfontconfig-dev
+        sudo apt-get install clang llvm lld ninja-build libx11-dev libxfixes-dev libfontconfig-dev
 
     - name: Build Native Linux x64
       run: |

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -57,7 +57,7 @@ Here's the pre-reqs you'll need first!
 ```shell
 # here's the commands for installing Linux build pre-reqs:
 sudo apt-get update
-sudo apt-get install cmake ninja-build clang lld libx11-dev libxfixes-dev libegl-dev libgbm-dev libfontconfig-dev
+sudo apt-get install cmake ninja-build clang llvm lld libx11-dev libxfixes-dev libfontconfig-dev
 ```
 
 To build with cmake:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,7 +129,6 @@ elseif(EMSCRIPTEN)
 elseif (UNIX)
   set(LINUX_LIBS
     Threads::Threads
-    gbm
     X11
     Xfixes
     fontconfig )

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -198,15 +198,7 @@
       "description": "Build for Linux",
       "hidden":      true,
       "generator":   "Ninja",
-      "cacheVariables": {
-        "CMAKE_SYSTEM_NAME":         "Linux",
-        "CMAKE_C_COMPILER":          "clang",
-        "CMAKE_CXX_COMPILER":        "clang++",
-        "CMAKE_LINKER":              "lld",
-        "CMAKE_EXE_LINKER_FLAGS":    "-fuse-ld=lld",
-        "CMAKE_SHARED_LINKER_FLAGS": "-fuse-ld=lld",
-        "CMAKE_MODULE_LINKER_FLAGS": "-fuse-ld=lld"
-      },
+      "toolchainFile":  "${sourceDir}/cmake/LinuxClangToolchain.cmake",
       "condition": {
         "type": "equals",
         "lhs":  "${hostSystemName}",

--- a/Examples/StereoKitTest/StereoKitTest_NetAndroid/MainActivity.cs
+++ b/Examples/StereoKitTest/StereoKitTest_NetAndroid/MainActivity.cs
@@ -45,10 +45,13 @@ public class MainActivity : Activity, ISurfaceHolderCallback2
 		if (running) return;
 		running = true;
 
-		// Before anything else, give StereoKit the Activity. This should
-		// be set before any other SK calls, otherwise native library
-		// loading may fail.
+		// Before anything else, give StereoKit the Activity and VM. These
+		// should be set before any other SK calls, otherwise native
+		// library loading may fail.
 		SK.AndroidActivity = this;
+		// This is optional, but helps with compatibility on older devices,
+		// Android API 30 and older.
+		SK.AndroidJavaVM   = Java.Interop.JniEnvironment.Runtime.InvocationPointer;
 
 		// Task.Run will eat exceptions, but Thread.Start doesn't seem to.
 		new Thread(InvokeStereoKit).Start();

--- a/StereoKit/SK.cs
+++ b/StereoKit/SK.cs
@@ -61,6 +61,13 @@ namespace StereoKit
 		/// will be set to null after SK.Initialize is called.</summary>
 		public static object AndroidActivity { get; set; }
 
+		/// <summary>On Android systems, this is the pointer to the JavaVM
+		/// object. If not set, StereoKit will attempt to find it at runtime
+		/// via JNI_GetCreatedJavaVMs, but this may fail on Android API 24-30
+		/// due to linker namespace restrictions. Setting this ensures
+		/// compatibility across all Android versions.</summary>
+		public static IntPtr AndroidJavaVM { get; set; }
+
 		/// <summary>Initializes StereoKit window, default resources, systems,
 		/// etc.</summary>
 		/// <param name="settings">The configuration settings for StereoKit.
@@ -72,24 +79,40 @@ namespace StereoKit
 		/// initialized!</returns>
 		public static bool Initialize(SKSettings settings)
 		{
-			if (settings.androidActivity == IntPtr.Zero && AndroidActivity != null)
+			// StereoKit doesn't reference Mono.Android or Java.Interop
+			// directly, so we use reflection to extract JNI pointers from
+			// the .NET Android runtime when available.
+			if (OperatingSystem.IsAndroid())
 			{
-				Type         javaObject = Type.GetType("Java.Lang.Object, Mono.Android");
-				PropertyInfo handle     = javaObject?.GetProperty("Handle", BindingFlags.Instance | BindingFlags.Public);
-				if (handle != null)
-					settings.androidActivity = (IntPtr)handle.GetValue(AndroidActivity);
-			}
-			if (AndroidActivity == null && settings.androidActivity != IntPtr.Zero)
-			{
-				Type activityType           = Type.GetType("Android.App.Activity, Mono.Android");
-				Type jniHandleOwnershipType = Type.GetType("Android.Runtime.JniHandleOwnership, Mono.Android");
-				ConstructorInfo constructor = activityType?.GetConstructor(new Type[] { typeof(IntPtr), jniHandleOwnershipType });
-				if (constructor != null)
-					AndroidActivity = constructor.Invoke(new object[] { settings.androidActivity, 0 }); ;
+				// Get the JNI handle from the managed Activity/Context object:
+				// equivalent to ((Java.Lang.Object)AndroidActivity).Handle
+				if (settings.androidActivity == IntPtr.Zero && AndroidActivity != null)
+				{
+					Type         javaObject = Type.GetType("Java.Lang.Object, Mono.Android");
+					PropertyInfo handle     = javaObject?.GetProperty("Handle", BindingFlags.Instance | BindingFlags.Public);
+					if (handle != null)
+						settings.androidActivity = (IntPtr)handle.GetValue(AndroidActivity);
+				}
+
+				// Get the JavaVM pointer, first from the explicit property,
+				// then by reflecting into the .NET Android JNI runtime:
+				// equivalent to Java.Interop.JniEnvironment.Runtime.InvocationPointer
+				if (settings.androidJavaVm == IntPtr.Zero && AndroidJavaVM != IntPtr.Zero)
+					settings.androidJavaVm = AndroidJavaVM;
+				if (settings.androidJavaVm == IntPtr.Zero)
+				{
+					Type         jniEnv     = Type.GetType("Java.Interop.JniEnvironment, Java.Interop");
+					PropertyInfo runtime    = jniEnv?.GetProperty("Runtime", BindingFlags.Static | BindingFlags.Public);
+					PropertyInfo invocation = runtime?.PropertyType.GetProperty("InvocationPointer", BindingFlags.Instance | BindingFlags.Public);
+					object       rtInstance = runtime?.GetValue(null);
+					if (rtInstance != null && invocation != null)
+						settings.androidJavaVm = (IntPtr)invocation.GetValue(rtInstance);
+				}
 			}
 
 			IsInitialized = InitializeCall(settings);
 			AndroidActivity = null;
+			AndroidJavaVM   = IntPtr.Zero;
 			return IsInitialized;
 		}
 

--- a/StereoKitC/platforms/android.cpp
+++ b/StereoKitC/platforms/android.cpp
@@ -77,33 +77,34 @@ bool platform_win_create_surface(window_t* win);
 
 ///////////////////////////////////////////
 
-// When consumed as a static library, the user's app will need to provide its
-// own JNI_OnLoad function, which will then conflict with this one. So we only
-// provide this for shared libraries.
-#if defined(SK_BUILD_SHARED)
-
-extern "C" jint JNI_OnLoad(JavaVM* vm, void* reserved) {
-	local_persist.vm = vm;
-	return JNI_VERSION_1_6;
-}
-extern "C" jint JNI_OnLoad_L(JavaVM* vm, void* reserved) {
-	return JNI_OnLoad(vm, reserved);
-}
-
-#endif
-
-///////////////////////////////////////////
-
 bool platform_impl_init() {
 	const sk_settings_t* settings = sk_get_settings_ref();
 	local = {};
 
 	local.activity   = (jobject)settings->android_activity;
-	if (local_persist.vm == nullptr)
-		local_persist.vm = (JavaVM*)settings->android_java_vm;
+	local_persist.vm = (JavaVM*)settings->android_java_vm;
+
+	// If the VM wasn't provided via settings, find it via
+	// JNI_GetCreatedJavaVMs. This symbol isn't available at link time in
+	// the NDK, so we resolve it at runtime from libnativehelper.so.
+	//
+	// NOTE: libnativehelper.so is only in the public linker namespace on
+	// API 31+. On API 24-30 this dlopen may fail, making the VM null. In
+	// that case, the caller should set android_java_vm in sk_settings_t
+	// (or SK.AndroidJavaVM in C#) before initialization.
+	if (local_persist.vm == nullptr) {
+		typedef jint (*pfn_JNI_GetCreatedJavaVMs)(JavaVM**, jsize, jsize*);
+		void*                     lib    = dlopen("libnativehelper.so", RTLD_NOW);
+		pfn_JNI_GetCreatedJavaVMs getVMs = (pfn_JNI_GetCreatedJavaVMs)dlsym(lib ? lib : RTLD_DEFAULT, "JNI_GetCreatedJavaVMs");
+
+		jsize count = 0;
+		if (getVMs) getVMs(&local_persist.vm, 1, &count);
+	}
 
 	if (local_persist.vm == nullptr || local.activity == nullptr) {
-		log_fail_reason(95, log_error, "Couldn't find Android's Java VM or Activity, you should load the StereoKitC library with something like Xamarin's JavaSystem.LoadLibrary, or manually assign it using sk_set_settings()");
+		log_fail_reasonf(95, log_error, "Couldn't find Android's Java VM (%s) or Activity (%s), assign these using sk_set_settings().",
+			local_persist.vm ? "found" : "missing",
+			local.activity   ? "found" : "missing");
 		return false;
 	}
 

--- a/cmake/LinuxClangToolchain.cmake
+++ b/cmake/LinuxClangToolchain.cmake
@@ -1,0 +1,10 @@
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_C_COMPILER   clang)
+set(CMAKE_CXX_COMPILER clang++)
+
+find_program(CMAKE_AR      NAMES llvm-ar      REQUIRED)
+find_program(CMAKE_RANLIB  NAMES llvm-ranlib  REQUIRED)
+
+set(CMAKE_EXE_LINKER_FLAGS    "-fuse-ld=lld" CACHE STRING "")
+set(CMAKE_SHARED_LINKER_FLAGS "-fuse-ld=lld" CACHE STRING "")
+set(CMAKE_MODULE_LINKER_FLAGS "-fuse-ld=lld" CACHE STRING "")

--- a/cmake/LinuxClangToolchain.cmake
+++ b/cmake/LinuxClangToolchain.cmake
@@ -2,8 +2,13 @@ set(CMAKE_SYSTEM_NAME Linux)
 set(CMAKE_C_COMPILER   clang)
 set(CMAKE_CXX_COMPILER clang++)
 
-find_program(CMAKE_AR      NAMES llvm-ar      REQUIRED)
-find_program(CMAKE_RANLIB  NAMES llvm-ranlib  REQUIRED)
+# LTO objects are LLVM bitcode, so we need llvm-ar/llvm-ranlib to build
+# proper archives. GNU ar can't read LLVM bitcode and will produce
+# archives with broken symbol indexes.
+find_program(_LLVM_AR     NAMES llvm-ar     REQUIRED)
+find_program(_LLVM_RANLIB NAMES llvm-ranlib REQUIRED)
+set(CMAKE_AR     ${_LLVM_AR}     CACHE FILEPATH "Archiver" FORCE)
+set(CMAKE_RANLIB ${_LLVM_RANLIB} CACHE FILEPATH "Ranlib"   FORCE)
 
 set(CMAKE_EXE_LINKER_FLAGS    "-fuse-ld=lld" CACHE STRING "")
 set(CMAKE_SHARED_LINKER_FLAGS "-fuse-ld=lld" CACHE STRING "")


### PR DESCRIPTION
Fix an LTO issue on Linux that may have been skipping linking symbols.
Pull JVM from 2 different sources automatically, and add an explicit override.
Remove reliance on JNI_OnLoad, which required C#'s native library loading to do the right thing (spoiler alert, it does not seem to, probably a pre .NET 10 thing).