### PR TITLE
Add Android mic input preset selection support

### DIFF
--- a/Examples/StereoKitTest/Demos/DemoRecordMic.cs
+++ b/Examples/StereoKitTest/Demos/DemoRecordMic.cs
@@ -3,6 +3,7 @@
 // Copyright (c) 2019-2023 Nick Klingensmith
 // Copyright (c) 2023 Qualcomm Technologies, Inc.
 
+using System;
 using System.Collections.Generic;
 using StereoKit;
 
@@ -18,7 +19,7 @@ class DemoRecordMic : ITest
 	/// and use that to create a sound for playback.
 	///
 	/// ![Audio recording window]({{site.screen_url}}/RecordAudioSnippet.jpg)
-	int         inputPreset;
+	MicInputPreset inputPreset;
 	Sound       recordedSound   = null;
 	List<float> recordedData    = new List<float>();
 	float[]     sampleBuffer    = null;
@@ -117,18 +118,13 @@ class DemoRecordMic : ITest
 			}
 		}
 
-#if ANDROID
 		UI.HSeparator();
 		UI.Label("Input Preset");
-		// More info about each preset can be found below - note that miniaudio supports all non-system presets.
-		// https://developer.android.com/reference/android/media/MediaRecorder.AudioSource
-		string[] presetNames = ["Default", "Generic", "Camcorder", "Voice Recognition", "Voice Communication", "Unprocessed", "Voice Performance"];
-		for (int i = 0; i < presetNames.Length; i++)
+		foreach (MicInputPreset preset in Enum.GetValues<MicInputPreset>())
 		{
-			if (UI.Radio(presetNames[i], inputPreset == i, size))
-				inputPreset = i;
+			if (UI.Radio(preset.ToString(), inputPreset == preset, size))
+				inputPreset = preset;
 		}
-#endif
 
 		UI.WindowEnd();
 	}

--- a/Examples/StereoKitTest/Demos/DemoRecordMic.cs
+++ b/Examples/StereoKitTest/Demos/DemoRecordMic.cs
@@ -18,6 +18,7 @@ class DemoRecordMic : ITest
 	/// and use that to create a sound for playback.
 	///
 	/// ![Audio recording window]({{site.screen_url}}/RecordAudioSnippet.jpg)
+	int         inputPreset;
 	Sound       recordedSound   = null;
 	List<float> recordedData    = new List<float>();
 	float[]     sampleBuffer    = null;
@@ -36,7 +37,7 @@ class DemoRecordMic : ITest
 			{
 				// Clear out our data, and start up the mic!
 				recordedData.Clear();
-				recording = Microphone.Start();
+				recording = Microphone.Start(inputPreset: inputPreset);
 				if (!recording)
 					Log.Warn("Recording failed to start!");
 			}
@@ -115,6 +116,19 @@ class DemoRecordMic : ITest
 				micDeviceActive = device;
 			}
 		}
+
+#if ANDROID
+		UI.HSeparator();
+		UI.Label("Input Preset");
+		// More info about each preset can be found below - note that miniaudio supports all non-system presets.
+		// https://developer.android.com/reference/android/media/MediaRecorder.AudioSource
+		string[] presetNames = ["Default", "Generic", "Camcorder", "Voice Recognition", "Voice Communication", "Unprocessed", "Voice Performance"];
+		for (int i = 0; i < presetNames.Length; i++)
+		{
+			if (UI.Radio(presetNames[i], inputPreset == i, size))
+				inputPreset = i;
+		}
+#endif
 
 		UI.WindowEnd();
 	}

--- a/StereoKit/Native/NativeAPI.cs
+++ b/StereoKit/Native/NativeAPI.cs
@@ -709,7 +709,7 @@ namespace StereoKit
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern int          mic_device_count();
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr       mic_device_name(int index);
 		[return: MarshalAs(UnmanagedType.Bool)]
-		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern bool         mic_start([MarshalAs(UnmanagedType.LPUTF8Str)] string device_name);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern bool         mic_start([MarshalAs(UnmanagedType.LPUTF8Str)] string device_name, int input_preset);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         mic_stop();
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr       mic_get_stream();
 		[return: MarshalAs(UnmanagedType.Bool)]

--- a/StereoKit/Native/NativeAPI.cs
+++ b/StereoKit/Native/NativeAPI.cs
@@ -709,7 +709,7 @@ namespace StereoKit
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern int          mic_device_count();
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr       mic_device_name(int index);
 		[return: MarshalAs(UnmanagedType.Bool)]
-		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern bool         mic_start([MarshalAs(UnmanagedType.LPUTF8Str)] string device_name, int input_preset);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern bool         mic_start([MarshalAs(UnmanagedType.LPUTF8Str)] string device_name, MicInputPreset input_preset);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         mic_stop();
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr       mic_get_stream();
 		[return: MarshalAs(UnmanagedType.Bool)]

--- a/StereoKit/Native/NativeEnums.cs
+++ b/StereoKit/Native/NativeEnums.cs
@@ -1079,6 +1079,37 @@ namespace StereoKit
 		Ignore,
 	}
 
+	/// <summary>Describes the input preset hint for microphone recording. These
+	/// presets tell the audio system how the microphone input should be
+	/// processed. Support varies by platform.</summary>
+	public enum MicInputPreset {
+		/// <summary>The default input preset, no specific processing is
+		/// requested.</summary>
+		Default      = 0,
+		/// <summary>A general purpose input preset with no specific tuning.</summary>
+		Generic,
+		/// <summary>Tuned for recording video with audio. Typically applies a
+		/// wider frequency range capture with some background noise
+		/// tolerance.</summary>
+		Camcorder,
+		/// <summary>Tuned for speech and voice recognition. Applies noise
+		/// suppression and gain control optimized for recognizing spoken
+		/// words.</summary>
+		VoiceRecognition,
+		/// <summary>Tuned for real-time voice communication such as VoIP. Applies
+		/// echo cancellation, noise suppression, and gain control for
+		/// two-way conversation.</summary>
+		VoiceCommunication,
+		/// <summary>Requests raw, unprocessed audio with minimal signal
+		/// processing. Useful when the application wants to apply its own
+		/// audio processing, or when recording for analysis.</summary>
+		Unprocessed,
+		/// <summary>Tuned for real-time voice performance such as karaoke or live
+		/// singing. Minimizes latency while keeping the voice sounding
+		/// natural.</summary>
+		VoicePerformance,
+	}
+
 	/// <summary>When opening the Platform.FilePicker, this enum describes
 	/// how the picker should look and behave.</summary>
 	public enum PickerMode {
@@ -1185,12 +1216,12 @@ namespace StereoKit
 		/// source. This provides aim, pinch, and poke interactors for hands, and
 		/// aim rays for controllers.</summary>
 		All,
-		/// <summary>Always use the hand interactors, using simulated hands when
+		/// <summary>Always use the default hand interactors, using simulated hands when
 		/// articulated hand tracking is not available.</summary>
 		Hands,
-		/// <summary>Always use the controller interactors.</summary>
+		/// <summary>Always use the default controller interactors.</summary>
 		Controllers,
-		/// <summary>Always use the mouse interactor.</summary>
+		/// <summary>Always use the default mouse interactor.</summary>
 		Mouse,
 	}
 

--- a/StereoKit/Systems/Microphone.cs
+++ b/StereoKit/Systems/Microphone.cs
@@ -63,14 +63,14 @@ namespace StereoKit
 		/// <param name="deviceName">The name of the microphone device to
 		/// use, as seen in the GetDevices list. null will use the system's
 		/// default device preference.</param>
-		/// <param name="inputPreset">AAudio input preset for Android.
-		/// Maps to ma_aaudio_input_preset values. Currently, this has
-		/// no effect on non-Android platforms.</param>
+		/// <param name="inputPreset">A hint to the audio system about how
+		/// the microphone input should be processed. Support varies by
+		/// platform.</param>
 		/// <returns>True if recording started successfully, false for
 		/// failure. This could fail if the app does not have mic permissions,
 		/// or if the deviceName is for a mic that has since been unplugged.
 		/// </returns>
-		public static bool Start(string deviceName = null, int inputPreset = 0)
+		public static bool Start(string deviceName = null, MicInputPreset inputPreset = MicInputPreset.Default)
 			=> NativeAPI.mic_start(deviceName, inputPreset);
 
 		/// <summary>If the Microphone is recording, this will stop it.

--- a/StereoKit/Systems/Microphone.cs
+++ b/StereoKit/Systems/Microphone.cs
@@ -63,12 +63,15 @@ namespace StereoKit
 		/// <param name="deviceName">The name of the microphone device to
 		/// use, as seen in the GetDevices list. null will use the system's
 		/// default device preference.</param>
-		/// <returns>True if recording started successfully, false for 
+		/// <param name="inputPreset">AAudio input preset for Android.
+		/// Maps to ma_aaudio_input_preset values. Currently, this has
+		/// no effect on non-Android platforms.</param>
+		/// <returns>True if recording started successfully, false for
 		/// failure. This could fail if the app does not have mic permissions,
 		/// or if the deviceName is for a mic that has since been unplugged.
 		/// </returns>
-		public static bool Start(string deviceName = null)
-			=> NativeAPI.mic_start(deviceName);
+		public static bool Start(string deviceName = null, int inputPreset = 0)
+			=> NativeAPI.mic_start(deviceName, inputPreset);
 
 		/// <summary>If the Microphone is recording, this will stop it.
 		/// </summary>

--- a/StereoKitC/stereokit.h
+++ b/StereoKitC/stereokit.h
@@ -2123,9 +2123,40 @@ SK_API float        sound_inst_get_intensity(sound_inst_t sound_inst);
 
 ///////////////////////////////////////////
 
+/*Describes the input preset hint for microphone recording. These
+  presets tell the audio system how the microphone input should be
+  processed. Support varies by platform.*/
+typedef enum mic_input_preset_ {
+	/*The default input preset, no specific processing is
+	  requested.*/
+	mic_input_preset_default              = 0,
+	/*A general purpose input preset with no specific tuning.*/
+	mic_input_preset_generic,
+	/*Tuned for recording video with audio. Typically applies a
+	  wider frequency range capture with some background noise
+	  tolerance.*/
+	mic_input_preset_camcorder,
+	/*Tuned for speech and voice recognition. Applies noise
+	  suppression and gain control optimized for recognizing spoken
+	  words.*/
+	mic_input_preset_voice_recognition,
+	/*Tuned for real-time voice communication such as VoIP. Applies
+	  echo cancellation, noise suppression, and gain control for
+	  two-way conversation.*/
+	mic_input_preset_voice_communication,
+	/*Requests raw, unprocessed audio with minimal signal
+	  processing. Useful when the application wants to apply its own
+	  audio processing, or when recording for analysis.*/
+	mic_input_preset_unprocessed,
+	/*Tuned for real-time voice performance such as karaoke or live
+	  singing. Minimizes latency while keeping the voice sounding
+	  natural.*/
+	mic_input_preset_voice_performance,
+} mic_input_preset_;
+
 SK_API int32_t      mic_device_count     (void);
 SK_API const char*  mic_device_name      (int32_t index);
-SK_API bool32_t     mic_start            (const char *device_name sk_default(nullptr), int32_t input_preset sk_default(0));
+SK_API bool32_t     mic_start            (const char *device_name sk_default(nullptr), mic_input_preset_ input_preset sk_default(mic_input_preset_default));
 SK_API void         mic_stop             (void);
 SK_API sound_t      mic_get_stream       (void);
 SK_API bool32_t     mic_is_recording     (void);

--- a/StereoKitC/stereokit.h
+++ b/StereoKitC/stereokit.h
@@ -2125,7 +2125,7 @@ SK_API float        sound_inst_get_intensity(sound_inst_t sound_inst);
 
 SK_API int32_t      mic_device_count     (void);
 SK_API const char*  mic_device_name      (int32_t index);
-SK_API bool32_t     mic_start            (const char *device_name sk_default(nullptr));
+SK_API bool32_t     mic_start            (const char *device_name sk_default(nullptr), int32_t input_preset sk_default(0));
 SK_API void         mic_stop             (void);
 SK_API sound_t      mic_get_stream       (void);
 SK_API bool32_t     mic_is_recording     (void);

--- a/StereoKitC/systems/audio.cpp
+++ b/StereoKitC/systems/audio.cpp
@@ -26,6 +26,7 @@ ma_device         au_device         = {};
 ma_device         au_mic_device     = {};
 sound_t           au_mic_sound      = {};
 char             *au_mic_name       = nullptr;
+int32_t           au_mic_preset     = 0;
 bool              au_recording      = false;
 bool              au_paused         = false;
 
@@ -320,7 +321,7 @@ void mic_callback(ma_device*, void*, const void* input, ma_uint32 frame_count) {
 
 ///////////////////////////////////////////
 
-bool32_t mic_start(const char *device_name) {
+bool32_t mic_start(const char *device_name, int32_t input_preset) {
 	permission_state_ state = permission_state(permission_type_microphone);
 	if (state == permission_state_capable) {
 		// We can record, but we need to ask permission first!
@@ -337,14 +338,15 @@ bool32_t mic_start(const char *device_name) {
 	// Make sure we're not starting up an already recording mic
 	if (au_recording) {
 		if (device_name == nullptr) {
-			if (au_mic_name == nullptr)
+			if (au_mic_name == nullptr && au_mic_preset == input_preset)
 				return true;
-		} else if (au_mic_name != nullptr && strcmp(device_name, au_mic_name) == 0) {
+		} else if (au_mic_name != nullptr && strcmp(device_name, au_mic_name) == 0 && au_mic_preset == input_preset) {
 			return true;
 		}
 		mic_stop();
 	}
-	au_mic_name = device_name == nullptr 
+	au_mic_preset = input_preset;
+	au_mic_name = device_name == nullptr
 		? nullptr
 		: string_copy(device_name);
 
@@ -377,6 +379,7 @@ bool32_t mic_start(const char *device_name) {
 	config.sampleRate         = AU_SAMPLE_RATE;
 	config.dataCallback       = mic_callback;
 	config.pUserData          = nullptr;
+	config.aaudio.inputPreset = (ma_aaudio_input_preset)input_preset;
 	ma_result result = ma_device_init(&au_context, &config, &au_mic_device);
 	if (result != MA_SUCCESS) {
 		log_warnf("Mic start failed, '%s'", ma_result_description(result));

--- a/StereoKitC/systems/audio.cpp
+++ b/StereoKitC/systems/audio.cpp
@@ -26,7 +26,7 @@ ma_device         au_device         = {};
 ma_device         au_mic_device     = {};
 sound_t           au_mic_sound      = {};
 char             *au_mic_name       = nullptr;
-int32_t           au_mic_preset     = 0;
+mic_input_preset_ au_mic_preset     = mic_input_preset_default;
 bool              au_recording      = false;
 bool              au_paused         = false;
 
@@ -321,7 +321,7 @@ void mic_callback(ma_device*, void*, const void* input, ma_uint32 frame_count) {
 
 ///////////////////////////////////////////
 
-bool32_t mic_start(const char *device_name, int32_t input_preset) {
+bool32_t mic_start(const char *device_name, mic_input_preset_ input_preset) {
 	permission_state_ state = permission_state(permission_type_microphone);
 	if (state == permission_state_capable) {
 		// We can record, but we need to ask permission first!
@@ -379,7 +379,8 @@ bool32_t mic_start(const char *device_name, int32_t input_preset) {
 	config.sampleRate         = AU_SAMPLE_RATE;
 	config.dataCallback       = mic_callback;
 	config.pUserData          = nullptr;
-	config.aaudio.inputPreset = (ma_aaudio_input_preset)input_preset;
+	config.aaudio.inputPreset     = (ma_aaudio_input_preset)input_preset;
+	config.opensl.recordingPreset = (ma_opensl_recording_preset)input_preset;
 	ma_result result = ma_device_init(&au_context, &config, &au_mic_device);
 	if (result != MA_SUCCESS) {
 		log_warnf("Mic start failed, '%s'", ma_result_description(result));


### PR DESCRIPTION
More info about each preset can be found [here](https://developer.android.com/reference/android/media/MediaRecorder.AudioSource) and an example of recording/playback disparities in the Mic Recording demo. There should be no effect on non-Android platforms.