### PR TITLE
Upgrade builtin shaders to use newer default system

### DIFF
--- a/StereoKitC/shaders_builtin/shader_builtin_depth_prepass.hlsl
+++ b/StereoKitC/shaders_builtin/shader_builtin_depth_prepass.hlsl
@@ -4,15 +4,10 @@
 Texture2DArray depth_tex   : register(t1);
 SamplerState   depth_tex_s : register(s1);
 
-//--depth_view_proj_l = 1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1
-float4x4 depth_view_proj_l;
-//--depth_view_proj_r = 1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1
-float4x4 depth_view_proj_r;
-
-//--depth_view_proj_inv_l = 1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1
-float4x4 depth_view_proj_inv_l;
-//--depth_view_proj_inv_r = 1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1
-float4x4 depth_view_proj_inv_r;
+float4x4 depth_view_proj_l      = {1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1};
+float4x4 depth_view_proj_r      = {1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1};
+float4x4 depth_view_proj_inv_l  = {1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1};
+float4x4 depth_view_proj_inv_r  = {1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1};
 
 struct vsIn {
 	float4 pos  : SV_Position;

--- a/StereoKitC/shaders_builtin/shader_builtin_font.hlsl
+++ b/StereoKitC/shaders_builtin/shader_builtin_font.hlsl
@@ -1,9 +1,10 @@
 #include "stereokit.hlsli"
 
 //--name = sk/font
-//--color:color = 1,1,1,1
-//--diffuse     = white
-float4       color;
+
+float4 color = {1,1,1,1};
+
+//--diffuse = white
 Texture2D    diffuse   : register(t0);
 SamplerState diffuse_s : register(s0);
 

--- a/StereoKitC/shaders_builtin/shader_builtin_lightmap.hlsl
+++ b/StereoKitC/shaders_builtin/shader_builtin_lightmap.hlsl
@@ -1,13 +1,13 @@
 #include "stereokit.hlsli"
+
 //--name = sk/lightmap
 
-//--tex_trans = 0,0,1,1
-//--diffuse   = white
-//--lightmap  = white
+float4 tex_trans = {0,0,1,1};
 
-float4       tex_trans;
+//--diffuse = white
 Texture2D    diffuse    : register(t0);
 SamplerState diffuse_s  : register(s0);
+//--lightmap = white
 Texture2D    lightmap   : register(t1);
 SamplerState lightmap_s : register(s1);
 

--- a/StereoKitC/shaders_builtin/shader_builtin_lines.hlsl
+++ b/StereoKitC/shaders_builtin/shader_builtin_lines.hlsl
@@ -1,8 +1,8 @@
 #include "stereokit.hlsli"
 
-//--name        = sk/lines
-//--color:color = 1,1,1,1
-float4 color;
+//--name = sk/lines
+
+float4 color = {1,1,1,1};
 
 struct vsIn {
 	float4 pos    : SV_Position;

--- a/StereoKitC/shaders_builtin/shader_builtin_pbr.hlsl
+++ b/StereoKitC/shaders_builtin/shader_builtin_pbr.hlsl
@@ -3,16 +3,11 @@
 
 //--name = sk/pbr
 
-//--color:color           = 1,1,1,1
-//--emission_factor:color = 0,0,0,0
-//--metallic              = 0
-//--roughness             = 1
-//--tex_trans             = 0,0,1,1
-float4 color;
-float4 emission_factor;
-float4 tex_trans;
-float  metallic;
-float  roughness;
+float4 color           = {1,1,1,1};
+float4 emission_factor = {0,0,0,0};
+float4 tex_trans       = {0,0,1,1};
+float  metallic        = 0;
+float  roughness       = 1;
 
 //--diffuse   = white
 //--emission  = white

--- a/StereoKitC/shaders_builtin/shader_builtin_pbr_clip.hlsl
+++ b/StereoKitC/shaders_builtin/shader_builtin_pbr_clip.hlsl
@@ -3,18 +3,12 @@
 
 //--name = sk/pbr_clip
 
-//--color:color           = 1,1,1,1
-//--emission_factor:color = 0,0,0,0
-//--tex_trans             = 0,0,1,1
-//--metallic              = 0
-//--roughness             = 1
-//--cutoff                = 0.5
-float4 color;
-float4 emission_factor;
-float4 tex_trans;
-float  metallic;
-float  roughness;
-float  cutoff;
+float4 color           = {1,1,1,1};
+float4 emission_factor = {0,0,0,0};
+float4 tex_trans       = {0,0,1,1};
+float  metallic        = 0;
+float  roughness       = 1;
+float  cutoff          = 0.5;
 
 //--diffuse   = white
 //--emission  = white

--- a/StereoKitC/shaders_builtin/shader_builtin_ui.hlsl
+++ b/StereoKitC/shaders_builtin/shader_builtin_ui.hlsl
@@ -2,9 +2,9 @@
 
 //--name = sk/default_ui
 
-//--color:color = 1, 1, 1, 1
-//--diffuse     = white
-float4       color = float4(1,1,1,1);
+float4 color = {1,1,1,1};
+
+//--diffuse = white
 Texture2D    diffuse   : register(t0);
 SamplerState diffuse_s : register(s0);
 

--- a/StereoKitC/shaders_builtin/shader_builtin_ui_aura.hlsl
+++ b/StereoKitC/shaders_builtin/shader_builtin_ui_aura.hlsl
@@ -1,9 +1,8 @@
 #include "stereokit.hlsli"
 
 //--name = sk/default_ui_quadrant_aura
-//--color:color = 1, 1, 1, 1
 
-float4 color;
+float4 color = {1,1,1,1};
 
 struct vsIn {
 	float4 pos      : SV_Position;

--- a/StereoKitC/shaders_builtin/shader_builtin_ui_box.hlsl
+++ b/StereoKitC/shaders_builtin/shader_builtin_ui_box.hlsl
@@ -1,14 +1,11 @@
 #include "stereokit.hlsli"
 
 //--name = sk/default_ui_box
-//--color:color = .6, .6, .6, 1
-//--border_size = 0.005
-//--border_size_grow = 0.01
-//--border_affect_radius = 0.2
-float4       color;
-float        border_size;
-float        border_size_grow;
-float        border_affect_radius;
+
+float4 color                = {.6, .6, .6, 1};
+float  border_size          = 0.005;
+float  border_size_grow     = 0.01;
+float  border_affect_radius = 0.2;
 
 struct vsIn {
 	float4 pos  : SV_Position;

--- a/StereoKitC/shaders_builtin/shader_builtin_unlit.hlsl
+++ b/StereoKitC/shaders_builtin/shader_builtin_unlit.hlsl
@@ -2,13 +2,10 @@
 
 //--name = sk/unlit
 
-//--color:color = 1, 1, 1, 1
-//--tex_trans   = 0,0,1,1
-//--diffuse     = white
+float4 color     = {1,1,1,1};
+float4 tex_trans = {0,0,1,1};
 
-float4       color;
-float4       tex_trans;
-
+//--diffuse = white
 Texture2D    diffuse   : register(t0);
 SamplerState diffuse_s : register(s0);
 
@@ -26,7 +23,7 @@ struct psIn {
 
 psIn vs(vsIn input, sk_ids_t ids) {
 	psIn o;
-	float4 world = mul(float4(input.pos.xyz, 1), sk_inst[ids.inst].world);
+	float4 world = mul(float4(input.pos.xyz, 1), sk_inst    [ids.inst].world);
 	o.pos        = mul(world,                    sk_viewproj[ids.view]);
 
 	o.uv    = (input.uv * tex_trans.zw) + tex_trans.xy;

--- a/StereoKitC/shaders_builtin/shader_builtin_unlit_clip.hlsl
+++ b/StereoKitC/shaders_builtin/shader_builtin_unlit_clip.hlsl
@@ -2,14 +2,11 @@
 
 //--name = sk/unlit_clip
 
-//--color:color = 1, 1, 1, 1
-//--tex_trans   = 0,0,1,1
-//--diffuse     = white
-//--cutoff      = 0.01
+float4 color     = {1,1,1,1};
+float4 tex_trans = {0,0,1,1};
+float  cutoff    = 0.01;
 
-float4       color;
-float4       tex_trans;
-float        cutoff;
+//--diffuse = white
 Texture2D    diffuse   : register(t0);
 SamplerState diffuse_s : register(s0);
 


### PR DESCRIPTION
skshaderc added support for `= {}` and `= float4()` syntax for assigning defaults to global uniforms. `//--` syntax will still do just fine, and is still required for texture defaults.