### PR TITLE
Compute shaders

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -276,7 +276,7 @@ if (NOT SK_LOCAL_SK_RENDERER)
   CPMAddPackage(
     NAME sk_renderer
     GITHUB_REPOSITORY StereoKit/sk_renderer
-    GIT_TAG v2026.3.17
+    GIT_TAG v2026.3.18
   )
 else()
   # For building directly with in-progress sk_renderer changes, point this to your
@@ -340,6 +340,10 @@ set(SK_SRC_ASSET_TYPES
   StereoKitC/asset_types/assets.cpp
   StereoKitC/asset_types/animation.h
   StereoKitC/asset_types/animation.cpp
+  StereoKitC/asset_types/compute.h
+  StereoKitC/asset_types/compute.cpp
+  StereoKitC/asset_types/compute_buffer.h
+  StereoKitC/asset_types/compute_buffer.cpp
   StereoKitC/asset_types/font.h
   StereoKitC/asset_types/font.cpp
   StereoKitC/asset_types/material.h

--- a/Examples/Assets/Shaders/compute_reaction.hlsl
+++ b/Examples/Assets/Shaders/compute_reaction.hlsl
@@ -1,0 +1,91 @@
+//--name = app/compute_reaction
+// Reaction-diffusion simulation (Gray-Scott model).
+// Reference: http://mrob.com/pub/comp/xmorphia/
+
+float feed;
+float kill;
+float diffuseA;
+float diffuseB;
+float timestep;
+uint  size;
+
+StructuredBuffer  <float2> input  : register(t1);
+RWStructuredBuffer<float2> output : register(u2);
+RWTexture2D       <float4> out_tex: register(u3);
+
+float2 GetLaplacian(int2 pos) {
+	int2 offsets[9] = {
+		int2(-1, 1), int2( 0, 1), int2(1, 1),
+		int2(-1, 0), int2( 0, 0), int2(1, 0),
+		int2(-1,-1), int2( 0,-1), int2(1,-1) };
+	float weights[9] = {
+		0,  1, 0,
+		1, -4, 1,
+		0,  1, 0 };
+
+	float2 result = float2(0,0);
+	for (int i = 0; i < 9; i++) {
+		int2 p = pos + offsets[i];
+		if (p.x < 0)          p.x = size - 1;
+		if (p.y < 0)          p.y = size - 1;
+		if (p.x >= (int)size) p.x = 0;
+		if (p.y >= (int)size) p.y = 0;
+
+		result += input[p.x+p.y*size] * weights[i];
+	}
+	return result;
+}
+
+[numthreads(8, 8, 1)]
+void cs(uint3 dispatchThreadID : SV_DispatchThreadID) {
+	uint   id  = dispatchThreadID.x + dispatchThreadID.y*size;
+	float2 lap = GetLaplacian(dispatchThreadID.xy);
+
+	float A = input[id].x;
+	float B = input[id].y;
+	float reactionTerm = A * B * B;
+
+	// Vary kill spatially (distance from center) so different
+	// regions settle into different reaction regimes, producing
+	// more interesting patterns across the image.
+	float dist   = abs(dispatchThreadID.x / (float)size - 0.5) * 2;
+	float kill_v = lerp(kill * 0.8, kill * 1.2, dist);
+
+	output[id] = float2(
+		A + ((diffuseA * lap.x - reactionTerm + feed * (1.0 - A))    * timestep),
+		B + ((diffuseB * lap.y + reactionTerm - (kill_v + feed) * B) * timestep)
+	);
+
+	// Color mapping
+	float  value  = output[id].x*0.9-0.1;
+	float4 color1 = float4(1.00, 0.83, 0.00,  0  );
+	float4 color2 = float4(1.00, 0.35, 0.03, 0.1 );
+	float4 color3 = float4(1.00, 0.17, 0.10, 0.2 );
+	float4 color4 = float4(0.53, 0.05, 0.24, 0.3 );
+	float4 color5 = float4(0.22, 0.05, 0.26, 0.4 );
+	float4 color6 = float4(0.00, 0.04, 0.18, 1.0 );
+
+	float3 col;
+	float  a;
+	if (value <= color1.a) {
+		col = color1.rgb;
+	} else if (value <= color2.a) {
+		a = (value - color1.a)/(color2.a - color1.a);
+		col = lerp(color1.rgb, color2.rgb, a);
+	} else if (value <= color3.a) {
+		a = (value - color2.a)/(color3.a - color2.a);
+		col = lerp(color2.rgb, color3.rgb, a);
+	} else if (value <= color4.a) {
+		a = (value - color3.a)/(color4.a - color3.a);
+		col = lerp(color3.rgb, color4.rgb, a);
+	} else if (value <= color5.a) {
+		a = (value - color4.a)/(color5.a - color4.a);
+		col = lerp(color4.rgb, color5.rgb, a);
+	} else if (value <= color6.a) {
+		a = (value - color5.a)/(color6.a - color5.a);
+		col = lerp(color5.rgb, color6.rgb, a);
+	} else {
+		col = color6.rgb;
+	}
+	out_tex[dispatchThreadID.xy] = float4(col, 1);
+}

--- a/Examples/StereoKitTest/Demos/DemoCompute.cs
+++ b/Examples/StereoKitTest/Demos/DemoCompute.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Runtime.InteropServices;
+using StereoKit;
+
+class DemoCompute : ITest
+{
+	string title       = "Compute Shader";
+	string description = "A reaction-diffusion simulation running entirely on the GPU via compute shaders, displayed on a quad.";
+
+	[StructLayout(LayoutKind.Sequential)]
+	struct Cell { public float A, B; }
+
+	const int SimSize = 512;
+	const int Groups  = SimSize / 8;
+
+	Compute             computePing;
+	Compute             computePong;
+	ComputeBuffer<Cell> bufferA;
+	ComputeBuffer<Cell> bufferB;
+	Tex                 output;
+	Material            quadMat;
+	Pose                windowPose;
+	int                 iteration;
+
+	float simFeed     = 0.02f;
+	float simKill     = 0.055f;
+	float simDiffuseA = 0.2097f;
+	float simDiffuseB = 0.105f;
+	float simTimestep = 0.8f;
+	int   stepsPerFrame = 2;
+
+	public void Initialize()
+	{
+		Shader computeShader = Shader.FromFile("Shaders/compute_reaction.hlsl");
+		computePing = new Compute(computeShader);
+		computePong = new Compute(computeShader);
+
+		bufferA = new ComputeBuffer<Cell>(ComputeBufferType.ReadWrite, SimSize * SimSize);
+		bufferB = new ComputeBuffer<Cell>(ComputeBufferType.ReadWrite, SimSize * SimSize);
+		ResetSim();
+
+		output = new Tex(TexType.ImageNomips | TexType.Compute, TexFormat.Rgba128);
+		output.SetSize(SimSize, SimSize);
+
+		// Ping: read A -> write B
+		computePing.SetBuffer ("input",   bufferA);
+		computePing.SetBuffer ("output",  bufferB);
+		computePing.SetTexture("out_tex", output);
+
+		// Pong: read B -> write A
+		computePong.SetBuffer ("input",   bufferB);
+		computePong.SetBuffer ("output",  bufferA);
+		computePong.SetTexture("out_tex", output);
+
+		UpdateSimParams();
+
+		quadMat = new Material(Shader.Unlit);
+		quadMat[MatParamName.DiffuseTex] = output;
+
+		windowPose = (Demo.contentPose * Matrix.T(0.16f, 0.15f, 0)).Pose;
+	}
+
+	public void Step()
+	{
+		for (int i = 0; i < stepsPerFrame; i++)
+		{
+			Compute current = (iteration % 2 == 0) ? computePing : computePong;
+			current.Dispatch((uint)Groups, (uint)Groups, 1);
+			iteration++;
+		}
+
+		Vec3 at = Demo.contentPose.Transform(V.XYZ(0.16f, 0, 0));
+		Mesh.Quad.Draw(quadMat, Matrix.TRS(at, Quat.FromAngles(0, 180, 0), 0.3f));
+
+		UI.WindowBegin("Compute Settings", ref windowPose, new Vec2(0.3f, 0));
+		bool changed = false;
+		Vec2 size = new Vec2(0.08f, UI.LineHeight);
+		UI.Label("Feed", size); UI.SameLine();
+		changed |= UI.HSlider("Feed",     ref simFeed,     0.01f, 0.08f, 0.001f);
+		UI.Label("Kill", size); UI.SameLine();
+		changed |= UI.HSlider("Kill",     ref simKill,     0.03f, 0.08f, 0.001f);
+		UI.Label("DiffuseA", size); UI.SameLine();
+		changed |= UI.HSlider("DiffuseA", ref simDiffuseA, 0.05f, 0.40f, 0.001f);
+		UI.Label("DiffuseB", size); UI.SameLine();
+		changed |= UI.HSlider("DiffuseB", ref simDiffuseB, 0.02f, 0.20f, 0.001f);
+		UI.Label("Timestep", size); UI.SameLine();
+		changed |= UI.HSlider("Timestep", ref simTimestep, 0.1f,  2.0f,  0.1f);
+		if (changed) UpdateSimParams();
+		if (UI.Button("Reset")) ResetSim();
+		UI.WindowEnd();
+
+		Demo.ShowSummary(title, description, new Bounds(0.4f, 0.4f, 0.1f));
+	}
+
+	public void Shutdown() { }
+
+	void ResetSim()
+	{
+		// Seed with block-based random patches. The reaction-diffusion
+		// model is sensitive to initial conditions: A~random, B~(1-A)
+		// in coherent 16x16 blocks.
+		Cell[] initialData = new Cell[SimSize * SimSize];
+		for (int y = 0; y < SimSize; y++)
+		for (int x = 0; x < SimSize; x++)
+		{
+			float r = HashFloat(1, (uint)((x / 16) * 13 + (y / 16) * 127));
+			initialData[x + y * SimSize] = new Cell { A = r, B = 1.0f - r };
+		}
+		bufferA.SetData(initialData);
+		bufferB.SetData(initialData);
+		iteration = 0;
+	}
+
+	void UpdateSimParams()
+	{
+		foreach (var c in new[] { computePing, computePong })
+		{
+			c["feed"]     = simFeed;
+			c["kill"]     = simKill;
+			c["diffuseA"] = simDiffuseA;
+			c["diffuseB"] = simDiffuseB;
+			c["timestep"] = simTimestep;
+			c["size"]     = (uint)SimSize;
+		}
+	}
+
+	static float HashFloat(int position, uint seed)
+	{
+		const uint BIT_NOISE1 = 0x68E31DA4;
+		const uint BIT_NOISE2 = 0xB5297A4D;
+		const uint BIT_NOISE3 = 0x1B56C4E9;
+
+		uint mangled = (uint)position;
+		mangled *= BIT_NOISE1;
+		mangled += seed;
+		mangled ^= (mangled >> 8);
+		mangled += BIT_NOISE2;
+		mangled ^= (mangled << 8);
+		mangled *= BIT_NOISE3;
+		mangled ^= (mangled >> 8);
+		return (float)mangled / 4294967295.0f;
+	}
+}

--- a/StereoKit/Assets/Compute.cs
+++ b/StereoKit/Assets/Compute.cs
@@ -1,0 +1,253 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+namespace StereoKit
+{
+	/// <summary>Compute shaders allow you to run code on the GPU in a
+	/// massively parallel way! This is great for accelerating complex work, or
+	/// simply for working inline with the graphics pipeline with easy access
+	/// to GPU memory.
+	/// 
+	/// This behaves very much like Materials do! You can set parameters, and
+	/// attach buffers or textures! Unlike Materials, you need to dispatch the
+	/// compute shader to make it run. You may need to be a bit cautious about
+	/// compute data, since the GPU can be picky about what and when it reads
+	/// and writes to!</summary>
+	public class Compute : IAsset
+	{
+		internal IntPtr _inst;
+
+		/// <summary>Gets or sets the unique identifier of this asset resource!
+		/// This can be helpful for debugging, managing your assets, or finding
+		/// them later on!</summary>
+		public string Id
+		{
+			get => Marshal.PtrToStringAnsi(NativeAPI.compute_get_id(_inst));
+			set => NativeAPI.compute_set_id(_inst, value);
+		}
+
+		/// <summary>The shader associated with this compute object. Each
+		/// access here creates a new reference!</summary>
+		public Shader Shader => new Shader(NativeAPI.compute_get_shader(_inst));
+
+		/// <summary>Create a Compute dispatch from a shader that has a
+		/// compute stage! If the shader doesn't have a compute stage,
+		/// this will fail.</summary>
+		/// <param name="computeShader">A shader containing a compute
+		/// stage.</param>
+		public Compute(Shader computeShader)
+		{
+			_inst = NativeAPI.compute_create(computeShader == null ? IntPtr.Zero : computeShader._inst);
+			if (_inst == IntPtr.Zero)
+				Log.Err("Failed to create Compute!");
+		}
+
+		/// <summary>Create a Compute dispatch from a shader file! The
+		/// file should be a compiled .sks shader with a compute stage.
+		/// </summary>
+		/// <param name="shaderFilename">The filename of a compiled
+		/// shader asset containing a compute stage.</param>
+		public Compute(string shaderFilename)
+		{
+			Shader shader = Shader.FromFile(shaderFilename);
+			_inst = NativeAPI.compute_create(shader == null ? IntPtr.Zero : shader._inst);
+			if (_inst == IntPtr.Zero)
+				Log.Err("Failed to create Compute!");
+		}
+
+		internal Compute(IntPtr inst)
+		{
+			_inst = inst;
+			if (_inst == IntPtr.Zero)
+				Log.Err("Received an empty compute!");
+		}
+
+		/// <summary>Release reference to the StereoKit asset.</summary>
+		~Compute()
+		{
+			if (_inst != IntPtr.Zero)
+				NativeAPI.assets_releaseref_threadsafe(_inst);
+		}
+
+		/// <summary>This is the same as calling the type-specific Set
+		/// method, but the type is inferred from the value! This is
+		/// set-only, and works with float, int, uint, Color, Color32,
+		/// Vec2, Vec3, Vec4, bool, Matrix, and Tex.</summary>
+		/// <param name="parameterName">Name of the parameter in HLSL,
+		/// must match exactly!</param>
+		/// <returns>This is set only.</returns>
+		public object this[string parameterName] { set {
+			switch (value)
+			{
+				case float   f:   SetFloat  (parameterName, f); break;
+				case int     i:   SetInt    (parameterName, i); break;
+				case uint    u:   SetUInt   (parameterName, u); break;
+				case Color32 c32: SetColor  (parameterName, c32); break;
+				case Color   c:   SetColor  (parameterName, c); break;
+				case Vec4    v:   SetVector (parameterName, v); break;
+				case Vec3    v:   SetVector (parameterName, v); break;
+				case Vec2    v:   SetVector (parameterName, v); break;
+				case bool    b:   SetBool   (parameterName, b); break;
+				case Matrix  m:   SetMatrix (parameterName, m); break;
+				case Tex     t:   SetTexture(parameterName, t); break;
+				default: Log.Err($"Invalid compute parameter type: {value.GetType()}"); break;
+			}
+		} }
+
+		/// <summary>Set a shader parameter by name! The name must match
+		/// a variable in the HLSL compute shader exactly, and if no
+		/// match is found, nothing happens. Same as Material!</summary>
+		public void SetFloat(string name, float value)
+			=> NativeAPI.compute_set_float(_inst, name, value);
+		/// <inheritdoc cref="SetFloat"/>
+		public void SetInt(string name, int value)
+			=> NativeAPI.compute_set_int(_inst, name, value);
+		/// <inheritdoc cref="SetFloat"/>
+		public void SetUInt(string name, uint value)
+			=> NativeAPI.compute_set_uint(_inst, name, value);
+		/// <inheritdoc cref="SetFloat"/>
+		public void SetVector(string name, Vec2 value)
+			=> NativeAPI.compute_set_vector2(_inst, name, value);
+		/// <inheritdoc cref="SetFloat"/>
+		public void SetVector(string name, Vec3 value)
+			=> NativeAPI.compute_set_vector3(_inst, name, value);
+		/// <inheritdoc cref="SetFloat"/>
+		public void SetVector(string name, Vec4 value)
+			=> NativeAPI.compute_set_vector4(_inst, name, value);
+		/// <summary>Set a color parameter by name! Color is converted
+		/// from gamma to linear space, so what the shader receives will
+		/// be in linear. If you're working in linear already, use
+		/// SetVector with a Vec4 instead!</summary>
+		public void SetColor(string name, Color colorGamma)
+			=> NativeAPI.compute_set_color(_inst, name, colorGamma);
+		/// <inheritdoc cref="SetColor(string, Color)"/>
+		public void SetColor(string name, Color32 colorGamma)
+			=> NativeAPI.compute_set_color(_inst, name, new Color(colorGamma.r/255f, colorGamma.g/255f, colorGamma.b/255f, colorGamma.a/255f));
+		/// <inheritdoc cref="SetFloat"/>
+		public void SetBool(string name, bool value)
+			=> NativeAPI.compute_set_bool(_inst, name, value);
+		/// <inheritdoc cref="SetFloat"/>
+		public void SetMatrix(string name, Matrix value)
+			=> NativeAPI.compute_set_matrix(_inst, name, value);
+
+		/// <summary>Gets the value of a shader parameter by name! If
+		/// the name isn't found, you'll get a default value back.
+		/// </summary>
+		public float GetFloat(string name)
+			=> NativeAPI.compute_get_float(_inst, name);
+		/// <inheritdoc cref="GetFloat"/>
+		public int GetInt(string name)
+			=> NativeAPI.compute_get_int(_inst, name);
+		/// <inheritdoc cref="GetFloat"/>
+		public uint GetUInt(string name)
+			=> NativeAPI.compute_get_uint(_inst, name);
+		/// <inheritdoc cref="GetFloat"/>
+		public Vec2 GetVector2(string name)
+			=> NativeAPI.compute_get_vector2(_inst, name);
+		/// <inheritdoc cref="GetFloat"/>
+		public Vec3 GetVector3(string name)
+			=> NativeAPI.compute_get_vector3(_inst, name);
+		/// <inheritdoc cref="GetFloat"/>
+		public Vec4 GetVector4(string name)
+			=> NativeAPI.compute_get_vector4(_inst, name);
+		/// <inheritdoc cref="GetFloat"/>
+		public bool GetBool(string name)
+			=> NativeAPI.compute_get_bool(_inst, name);
+		/// <summary>Gets a color parameter by name! Note that SetColor
+		/// converts gamma to linear, so this returns the _linear_ value
+		/// the shader is actually using.</summary>
+		public Color GetColor(string name)
+			=> NativeAPI.compute_get_color(_inst, name);
+		/// <inheritdoc cref="GetFloat"/>
+		public Matrix GetMatrix(string name)
+			=> NativeAPI.compute_get_matrix(_inst, name);
+
+		/// <summary>Bind a texture to a named resource in the shader!
+		/// If you're writing to it (RWTexture2D), the texture _must_
+		/// have TexType.Compute set, and use a format like
+		/// TexFormat.Rgba128. Read-only Texture2D bindings work with
+		/// any texture. Fallbacks are resolved at Dispatch time, so
+		/// textures that are still loading will Just Work.</summary>
+		/// <param name="name">The texture name in the HLSL shader.
+		/// Must match exactly!</param>
+		/// <param name="texture">The texture to bind.</param>
+		/// <returns>True if a matching resource was found in the
+		/// shader, false if the name didn't match anything.</returns>
+		public bool SetTexture(string name, Tex texture)
+			=> NativeAPI.compute_set_texture(_inst, name, texture?._inst ?? IntPtr.Zero);
+
+		/// <summary>Bind a ComputeBuffer to a named resource in the
+		/// shader! The name must match a StructuredBuffer&lt;T&gt; or
+		/// RWStructuredBuffer&lt;T&gt; declaration in your HLSL.
+		/// </summary>
+		/// <typeparam name="T">The element type of the buffer.
+		/// </typeparam>
+		/// <param name="name">The buffer name in the HLSL shader.
+		/// Must match exactly!</param>
+		/// <param name="buffer">The buffer to bind.</param>
+		/// <returns>True if a matching resource was found in the
+		/// shader, false if the name didn't match anything.</returns>
+		public bool SetBuffer<T>(string name, ComputeBuffer<T> buffer) where T : unmanaged
+			=> NativeAPI.compute_set_buffer(_inst, name, buffer?._inst ?? IntPtr.Zero);
+
+		/// <summary>Fire off the compute shader on the GPU! The
+		/// parameters here are the number of thread _groups_, not
+		/// individual threads. The total thread count will be
+		/// groupCount * numthreads (as defined in your HLSL). So if
+		/// your shader says [numthreads(8,8,1)] and you dispatch
+		/// (64,64,1), you'll get 512*512 threads!</summary>
+		/// <param name="groupCountX">Thread groups in X.</param>
+		/// <param name="groupCountY">Thread groups in Y.</param>
+		/// <param name="groupCountZ">Thread groups in Z.</param>
+		public void Dispatch(uint groupCountX, uint groupCountY = 1, uint groupCountZ = 1)
+			=> NativeAPI.compute_dispatch(_inst, groupCountX, groupCountY, groupCountZ);
+
+		/// <summary>The number of shader parameters available on this
+		/// Compute! This includes both variables and textures/buffers,
+		/// great for building a GUI that can inspect any shader.
+		/// </summary>
+		public int ParamCount => NativeAPI.compute_get_param_count(_inst);
+
+		/// <summary>Gets an enumerable list of all parameter info on
+		/// this Compute! Handy for building auto-generated shader
+		/// GUIs or inspectors.</summary>
+		/// <returns>An IEnumerable of MatParamInfo, usable with
+		/// foreach.</returns>
+		public IEnumerable<MatParamInfo> GetAllParamInfo()
+		{
+			int count = ParamCount;
+			for (int i = 0; i < count; i++)
+			{
+				NativeAPI.compute_get_param_info(_inst, i, out IntPtr name, out MaterialParam type);
+				yield return new MatParamInfo(Marshal.PtrToStringAnsi(name), type);
+			}
+		}
+
+		/// <summary>Gets parameter info at a specific index! Parameters
+		/// are listed as variables first, then textures and buffers.
+		/// </summary>
+		/// <param name="index">Index of the parameter, bounded by
+		/// ParamCount.</param>
+		/// <returns>Name and type info for this parameter.</returns>
+		public MatParamInfo GetParamInfo(int index)
+		{
+			if (index < 0 || index >= ParamCount)
+				throw new IndexOutOfRangeException();
+
+			NativeAPI.compute_get_param_info(_inst, index, out IntPtr name, out MaterialParam type);
+			return new MatParamInfo(Marshal.PtrToStringAnsi(name), type);
+		}
+
+		/// <summary>Looks for a Compute object that has already been
+		/// created with a matching id!</summary>
+		/// <param name="computeId">The id to search for.</param>
+		/// <returns>A Compute with a matching id, or null if none
+		/// exists.</returns>
+		public static Compute Find(string computeId)
+		{
+			IntPtr inst = NativeAPI.compute_find(computeId);
+			return inst == IntPtr.Zero ? null : new Compute(inst);
+		}
+	}
+}

--- a/StereoKit/Assets/ComputeBuffer.cs
+++ b/StereoKit/Assets/ComputeBuffer.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace StereoKit
+{
+	/// <summary>A GPU storage buffer for shuttling data to and from
+	/// compute shaders! In HLSL, this maps to StructuredBuffer&lt;T&gt;
+	/// or RWStructuredBuffer&lt;T&gt; depending on the
+	/// ComputeBufferType.
+	///
+	/// Your struct T needs to be unmanaged (no reference types!) and
+	/// its layout _must_ match the HLSL struct. Watch out for
+	/// padding differences between C# and HLSL!</summary>
+	/// <typeparam name="T">An unmanaged struct matching the HLSL
+	/// buffer element layout.</typeparam>
+	public class ComputeBuffer<T> : IAsset where T : unmanaged
+	{
+		internal IntPtr _inst;
+
+		/// <summary>Gets or sets the unique identifier of this asset
+		/// resource! This can be helpful for debugging, managing your
+		/// assets, or finding them later on!</summary>
+		public string Id
+		{
+			get => Marshal.PtrToStringAnsi(NativeAPI.compute_buffer_get_id(_inst));
+			set => NativeAPI.compute_buffer_set_id(_inst, value);
+		}
+
+		/// <summary>The capacity of the buffer, in number of T elements.
+		/// This is the max you can Set or Get without clamping.
+		/// </summary>
+		public int Count => NativeAPI.compute_buffer_get_count(_inst);
+
+		/// <summary>Size of a single element in bytes, derived from
+		/// your T struct. Handy for sanity-checking that your C# struct
+		/// matches the HLSL side!</summary>
+		public int Stride => NativeAPI.compute_buffer_get_stride(_inst);
+
+		/// <summary>Creates a GPU storage buffer with room for
+		/// elementCount elements, initially uninitialized! The contents
+		/// will be whatever was in GPU memory before, so make sure to
+		/// write before you read.</summary>
+		/// <param name="type">Read or ReadWrite access from compute
+		/// shaders.</param>
+		/// <param name="elementCount">Number of T elements to
+		/// allocate.</param>
+		public ComputeBuffer(ComputeBufferType type, int elementCount)
+		{
+			int stride = Marshal.SizeOf<T>();
+			_inst = NativeAPI.compute_buffer_create(type, elementCount, stride, IntPtr.Zero);
+			if (_inst == IntPtr.Zero)
+				Log.Err("Failed to create ComputeBuffer!");
+		}
+
+		/// <summary>Creates a GPU storage buffer and immediately uploads
+		/// initialData to it! The buffer capacity is set to the array
+		/// length.</summary>
+		/// <param name="type">Read or ReadWrite access from compute
+		/// shaders.</param>
+		/// <param name="initialData">Array of data to upload to the
+		/// GPU.</param>
+		public ComputeBuffer(ComputeBufferType type, T[] initialData)
+		{
+			int stride = Marshal.SizeOf<T>();
+			GCHandle handle = GCHandle.Alloc(initialData, GCHandleType.Pinned);
+			try
+			{
+				_inst = NativeAPI.compute_buffer_create(type, initialData.Length, stride, handle.AddrOfPinnedObject());
+			}
+			finally
+			{
+				handle.Free();
+			}
+			if (_inst == IntPtr.Zero)
+				Log.Err("Failed to create ComputeBuffer!");
+		}
+
+		/// <summary>Release reference to the StereoKit asset.</summary>
+		~ComputeBuffer()
+		{
+			if (_inst != IntPtr.Zero)
+				NativeAPI.assets_releaseref_threadsafe(_inst);
+		}
+
+		/// <summary>Upload data from the CPU to the GPU! If data.Length
+		/// exceeds the buffer's capacity, it will be clamped with a
+		/// warning.</summary>
+		/// <param name="data">The data to upload.</param>
+		public void SetData(T[] data)
+		{
+			GCHandle handle = GCHandle.Alloc(data, GCHandleType.Pinned);
+			try
+			{
+				NativeAPI.compute_buffer_set_data(_inst, handle.AddrOfPinnedObject(), data.Length);
+			}
+			finally
+			{
+				handle.Free();
+			}
+		}
+
+		/// <summary>Read the full buffer back from the GPU! This blocks
+		/// until the data is ready, and allocates a new array each
+		/// call. For per-frame readbacks, prefer the GetData(ref T[])
+		/// overload to avoid GC pressure!</summary>
+		/// <returns>A new array containing the full buffer contents.
+		/// </returns>
+		public T[] GetData()
+		{
+			int      count  = Count;
+			T[]      data   = new T[count];
+			GCHandle handle = GCHandle.Alloc(data, GCHandleType.Pinned);
+			try
+			{
+				NativeAPI.compute_buffer_get_data(_inst, handle.AddrOfPinnedObject(), count);
+			}
+			finally
+			{
+				handle.Free();
+			}
+			return data;
+		}
+
+		/// <summary>Read GPU data into a pre-allocated array! This is
+		/// the allocation-free version of GetData, great for calling
+		/// every frame without creating GC garbage. Reads
+		/// Math.Min(data.Length, Count) elements.</summary>
+		/// <param name="data">A pre-allocated array to fill. If it's
+		/// smaller than the buffer, only data.Length elements are
+		/// read.</param>
+		public void GetData(ref T[] data)
+		{
+			int count = Math.Min(data.Length, Count);
+			GCHandle handle = GCHandle.Alloc(data, GCHandleType.Pinned);
+			try
+			{
+				NativeAPI.compute_buffer_get_data(_inst, handle.AddrOfPinnedObject(), count);
+			}
+			finally
+			{
+				handle.Free();
+			}
+		}
+	}
+}

--- a/StereoKit/Native/NativeAPI.cs
+++ b/StereoKit/Native/NativeAPI.cs
@@ -408,6 +408,54 @@ namespace StereoKit
 
 		///////////////////////////////////////////
 
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr       compute_buffer_create(ComputeBufferType type, int element_count, int element_size, IntPtr opt_initial_data);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         compute_buffer_set_id(IntPtr buffer, [MarshalAs(UnmanagedType.LPUTF8Str)] string id);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr       compute_buffer_get_id(IntPtr buffer);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         compute_buffer_set_data(IntPtr buffer, IntPtr data, int element_count);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         compute_buffer_get_data(IntPtr buffer, IntPtr out_data, int element_count);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern int          compute_buffer_get_count(IntPtr buffer);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern int          compute_buffer_get_stride(IntPtr buffer);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         compute_buffer_addref(IntPtr buffer);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         compute_buffer_release(IntPtr buffer);
+
+		///////////////////////////////////////////
+
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr       compute_create(IntPtr shader);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr       compute_find([MarshalAs(UnmanagedType.LPUTF8Str)] string id);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         compute_set_id(IntPtr compute, [MarshalAs(UnmanagedType.LPUTF8Str)] string id);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr       compute_get_id(IntPtr compute);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr       compute_get_shader(IntPtr compute);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         compute_set_float(IntPtr compute, [MarshalAs(UnmanagedType.LPUTF8Str)] string name, float value);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         compute_set_int(IntPtr compute, [MarshalAs(UnmanagedType.LPUTF8Str)] string name, int value);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         compute_set_uint(IntPtr compute, [MarshalAs(UnmanagedType.LPUTF8Str)] string name, uint value);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         compute_set_vector2(IntPtr compute, [MarshalAs(UnmanagedType.LPUTF8Str)] string name, Vec2 value);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         compute_set_vector3(IntPtr compute, [MarshalAs(UnmanagedType.LPUTF8Str)] string name, Vec3 value);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         compute_set_vector4(IntPtr compute, [MarshalAs(UnmanagedType.LPUTF8Str)] string name, Vec4 value);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         compute_set_color(IntPtr compute, [MarshalAs(UnmanagedType.LPUTF8Str)] string name, Color color_gamma);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         compute_set_bool(IntPtr compute, [MarshalAs(UnmanagedType.LPUTF8Str)] string name, [MarshalAs(UnmanagedType.Bool)] bool value);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         compute_set_matrix(IntPtr compute, [MarshalAs(UnmanagedType.LPUTF8Str)] string name, Matrix value);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern float        compute_get_float(IntPtr compute, [MarshalAs(UnmanagedType.LPUTF8Str)] string name);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern int          compute_get_int(IntPtr compute, [MarshalAs(UnmanagedType.LPUTF8Str)] string name);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern uint         compute_get_uint(IntPtr compute, [MarshalAs(UnmanagedType.LPUTF8Str)] string name);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern Vec2         compute_get_vector2(IntPtr compute, [MarshalAs(UnmanagedType.LPUTF8Str)] string name);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern Vec3         compute_get_vector3(IntPtr compute, [MarshalAs(UnmanagedType.LPUTF8Str)] string name);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern Vec4         compute_get_vector4(IntPtr compute, [MarshalAs(UnmanagedType.LPUTF8Str)] string name);
+		[return: MarshalAs(UnmanagedType.Bool)]
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern bool         compute_get_bool(IntPtr compute, [MarshalAs(UnmanagedType.LPUTF8Str)] string name);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern Color        compute_get_color(IntPtr compute, [MarshalAs(UnmanagedType.LPUTF8Str)] string name);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern Matrix       compute_get_matrix(IntPtr compute, [MarshalAs(UnmanagedType.LPUTF8Str)] string name);
+		[return: MarshalAs(UnmanagedType.Bool)]
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern bool         compute_set_texture(IntPtr compute, [MarshalAs(UnmanagedType.LPUTF8Str)] string name, IntPtr texture);
+		[return: MarshalAs(UnmanagedType.Bool)]
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern bool         compute_set_buffer(IntPtr compute, [MarshalAs(UnmanagedType.LPUTF8Str)] string name, IntPtr buffer);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         compute_dispatch(IntPtr compute, uint group_count_x, uint group_count_y, uint group_count_z);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern int          compute_get_param_count(IntPtr compute);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         compute_get_param_info(IntPtr compute, int index, out IntPtr out_name, out MaterialParam out_type);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         compute_addref(IntPtr compute);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         compute_release(IntPtr compute);
+
+		///////////////////////////////////////////
+
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern TextStyle    text_make_style(IntPtr font, float layout_height, Color color_gamma);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern TextStyle    text_make_style_shader(IntPtr font, float layout_height, IntPtr shader, Color color_gamma);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern TextStyle    text_make_style_mat(IntPtr font, float layout_height, IntPtr material, Color color_gamma);

--- a/StereoKit/Native/NativeEnums.cs
+++ b/StereoKit/Native/NativeEnums.cs
@@ -664,6 +664,10 @@ namespace StereoKit
 		/// readable. This makes it great for shadowmaps or other textures that need to
 		/// be read from later on.</summary>
 		Depthtarget  = 1 << 6,
+		/// <summary>This texture can be used as a RWTexture in compute shaders.
+		/// Create it with a format that supports storage images, such as
+		/// tex_format_rgba128.</summary>
+		Compute      = 1 << 7,
 		/// <summary>A standard color image that also generates mip-maps
 		/// automatically.</summary>
 		Image        = ImageNomips | Mips,
@@ -738,6 +742,17 @@ namespace StereoKit
 		/// this? I'm not sure!! But the graphics card can do it, so now you
 		/// can too!</summary>
 		Mirror,
+	}
+
+	/// <summary>Describes the access mode of a ComputeBuffer for use in compute
+	/// shaders.</summary>
+	public enum ComputeBufferType {
+		/// <summary>Read-only from compute shaders. Maps to StructuredBuffer&lt;T&gt;
+		/// in HLSL.</summary>
+		Read         = 1,
+		/// <summary>Read-write from compute shaders. Maps to
+		/// RWStructuredBuffer&lt;T&gt; in HLSL.</summary>
+		ReadWrite    = 2,
 	}
 
 	/// <summary>Also known as 'alpha' for those in the know. But there's
@@ -856,6 +871,9 @@ namespace StereoKit
 		UInt3        = 14,
 		/// <summary>A 4 component vector composed of unsigned integers.</summary>
 		UInt4        = 15,
+		/// <summary>A structured buffer resource, such as StructuredBuffer&lt;T&gt; or
+		/// RWStructuredBuffer&lt;T&gt; in HLSL.</summary>
+		Buffer       = 16,
 	}
 
 	/// <summary>This enum describes how text layout behaves within the space
@@ -1606,6 +1624,8 @@ namespace StereoKit
 		Android,
 		/// <summary>This is running in a browser.</summary>
 		Web,
+		/// <summary>This is running as a macOS app.</summary>
+		Macos,
 	}
 
 	/// <summary>This describes the graphics API that StereoKit is using for rendering.</summary>
@@ -1670,6 +1690,10 @@ namespace StereoKit
 		Anchor,
 		/// <summary>A RenderList</summary>
 		RenderList,
+		/// <summary>A Compute dispatch object</summary>
+		Compute,
+		/// <summary>A ComputeBuffer</summary>
+		ComputeBuffer,
 	}
 
 	/// <summary>This describes how a UI element moves when being dragged around by a user!</summary>

--- a/StereoKitC/asset_types/assets.cpp
+++ b/StereoKitC/asset_types/assets.cpp
@@ -17,6 +17,8 @@
 #include "sprite.h"
 #include "sound.h"
 #include "anchor.h"
+#include "compute.h"
+#include "compute_buffer.h"
 #include "../platforms/platform.h"
 #include "../libraries/stref.h"
 #include "../libraries/array.h"
@@ -146,16 +148,18 @@ asset_header_t* assets_allocate_no_add(asset_type_ type, const char** out_type_s
 	size_t      size      = sizeof(asset_header_t);
 	const char* type_name = "asset";
 	switch(type) {
-	case asset_type_mesh:        size = sizeof(_mesh_t );       type_name = "mesh";        break;
-	case asset_type_tex:         size = sizeof(_tex_t);         type_name = "tex";         break;
-	case asset_type_shader:      size = sizeof(_shader_t);      type_name = "shader";      break;
-	case asset_type_material:    size = sizeof(_material_t);    type_name = "material";    break;
-	case asset_type_model:       size = sizeof(_model_t);       type_name = "model";       break;
-	case asset_type_font:        size = sizeof(_font_t);        type_name = "font";        break;
-	case asset_type_sprite:      size = sizeof(_sprite_t);      type_name = "sprite";      break;
-	case asset_type_sound:       size = sizeof(_sound_t);       type_name = "sound";       break;
-	case asset_type_anchor:      size = sizeof(_anchor_t);      type_name = "anchor";      break;
-	case asset_type_render_list: size = sizeof(_render_list_t); type_name = "render_list"; break;
+	case asset_type_mesh:           size = sizeof(_mesh_t );          type_name = "mesh";           break;
+	case asset_type_tex:            size = sizeof(_tex_t);            type_name = "tex";            break;
+	case asset_type_shader:         size = sizeof(_shader_t);         type_name = "shader";         break;
+	case asset_type_material:       size = sizeof(_material_t);       type_name = "material";       break;
+	case asset_type_model:          size = sizeof(_model_t);          type_name = "model";          break;
+	case asset_type_font:           size = sizeof(_font_t);           type_name = "font";           break;
+	case asset_type_sprite:         size = sizeof(_sprite_t);         type_name = "sprite";         break;
+	case asset_type_sound:          size = sizeof(_sound_t);          type_name = "sound";          break;
+	case asset_type_anchor:         size = sizeof(_anchor_t);         type_name = "anchor";         break;
+	case asset_type_render_list:    size = sizeof(_render_list_t);    type_name = "render_list";    break;
+	case asset_type_compute:        size = sizeof(_compute_t);        type_name = "compute";        break;
+	case asset_type_compute_buffer: size = sizeof(_compute_buffer_t); type_name = "compute_buffer"; break;
 	default: log_err("Unimplemented asset type!"); abort();
 	}
 
@@ -294,7 +298,9 @@ void assets_destroy(asset_header_t *asset) {
 	case asset_type_sprite:      sprite_destroy     ((sprite_t     )asset); break;
 	case asset_type_sound:       sound_destroy      ((sound_t      )asset); break;
 	case asset_type_anchor:      anchor_destroy     ((anchor_t     )asset); break;
-	case asset_type_render_list: render_list_destroy((render_list_t)asset); break;
+	case asset_type_render_list:    render_list_destroy   ((render_list_t   )asset); break;
+	case asset_type_compute:        compute_destroy       ((compute_t       )asset); break;
+	case asset_type_compute_buffer: compute_buffer_destroy((compute_buffer_t)asset); break;
 	default: log_err("Unimplemented asset type!"); abort();
 	}
 

--- a/StereoKitC/asset_types/compute.cpp
+++ b/StereoKitC/asset_types/compute.cpp
@@ -1,0 +1,381 @@
+#include "../stereokit.h"
+#include "../sk_memory.h"
+#include "../libraries/stref.h"
+#include "compute.h"
+#include "compute_buffer.h"
+#include "shader.h"
+#include "texture.h"
+#include "assets.h"
+
+namespace sk {
+
+///////////////////////////////////////////
+
+compute_t compute_create(shader_t shader) {
+	if (shader == nullptr) {
+		log_err("compute_create: shader is null");
+		return nullptr;
+	}
+
+	compute_t result = (compute_t)assets_allocate(asset_type_compute);
+	shader_addref(shader);
+	result->shader = shader;
+
+	if (skr_compute_create(&shader->gpu_shader, &result->gpu_compute) != skr_err_success) {
+		log_err("compute_create: failed to create GPU compute object");
+		shader_release(shader);
+		result->shader = nullptr;
+		assets_releaseref(&result->header);
+		return nullptr;
+	}
+
+	// Allocate tracking arrays for bound resources
+	const sksc_shader_meta_t *meta = shader->gpu_shader.meta;
+
+	result->texture_count = 0;
+	result->buffer_count  = 0;
+	for (uint32_t i = 0; i < meta->resource_count; i++) {
+		skr_register_ reg = (skr_register_)meta->resources[i].bind.register_type;
+		if      (reg == skr_register_texture   || reg == skr_register_readwrite_tex) result->texture_count++;
+		else if (reg == skr_register_readwrite || reg == skr_register_read_buffer)   result->buffer_count++;
+	}
+
+	if (result->texture_count > 0) result->textures = sk_malloc_zero_t(tex_t, result->texture_count);
+	if (result->buffer_count  > 0) result->buffers  = sk_malloc_zero_t(compute_buffer_t, result->buffer_count);
+
+	return result;
+}
+
+///////////////////////////////////////////
+
+compute_t compute_find(const char *id) {
+	compute_t result = (compute_t)assets_find(id, asset_type_compute);
+	if (result != nullptr) {
+		compute_addref(result);
+		return result;
+	}
+	return nullptr;
+}
+
+///////////////////////////////////////////
+
+void compute_set_id(compute_t compute, const char *id) {
+	assets_set_id(&compute->header, id);
+}
+
+///////////////////////////////////////////
+
+const char* compute_get_id(const compute_t compute) {
+	return compute->header.id_text;
+}
+
+///////////////////////////////////////////
+
+shader_t compute_get_shader(const compute_t compute) {
+	shader_addref(compute->shader);
+	return compute->shader;
+}
+
+///////////////////////////////////////////
+
+void compute_set_float(compute_t compute, const char *name, float value) {
+	skr_compute_set_param(&compute->gpu_compute, name, sksc_shader_var_float, 1, &value);
+}
+
+///////////////////////////////////////////
+
+void compute_set_int(compute_t compute, const char *name, int32_t value) {
+	skr_compute_set_param(&compute->gpu_compute, name, sksc_shader_var_int, 1, &value);
+}
+
+///////////////////////////////////////////
+
+void compute_set_uint(compute_t compute, const char *name, uint32_t value) {
+	skr_compute_set_param(&compute->gpu_compute, name, sksc_shader_var_uint, 1, &value);
+}
+
+///////////////////////////////////////////
+
+void compute_set_vector2(compute_t compute, const char *name, vec2 value) {
+	skr_compute_set_param(&compute->gpu_compute, name, sksc_shader_var_float, 2, &value);
+}
+
+///////////////////////////////////////////
+
+void compute_set_vector3(compute_t compute, const char *name, vec3 value) {
+	skr_compute_set_param(&compute->gpu_compute, name, sksc_shader_var_float, 3, &value);
+}
+
+///////////////////////////////////////////
+
+void compute_set_vector4(compute_t compute, const char *name, vec4 value) {
+	skr_compute_set_param(&compute->gpu_compute, name, sksc_shader_var_float, 4, &value);
+}
+
+///////////////////////////////////////////
+
+void compute_set_color(compute_t compute, const char *name, color128 color_gamma) {
+	color128 linear = color_to_linear(color_gamma);
+	skr_compute_set_param(&compute->gpu_compute, name, sksc_shader_var_float, 4, &linear);
+}
+
+///////////////////////////////////////////
+
+void compute_set_bool(compute_t compute, const char *name, bool32_t value) {
+	uint32_t val = value ? 1 : 0;
+	skr_compute_set_param(&compute->gpu_compute, name, sksc_shader_var_uint, 1, &val);
+}
+
+///////////////////////////////////////////
+
+void compute_set_matrix(compute_t compute, const char *name, matrix value) {
+	skr_compute_set_param(&compute->gpu_compute, name, sksc_shader_var_float, 16, &value);
+}
+
+///////////////////////////////////////////
+
+float compute_get_float(compute_t compute, const char *name) {
+	float result = 0.0f;
+	skr_compute_get_param(&compute->gpu_compute, name, sksc_shader_var_float, 1, &result);
+	return result;
+}
+
+///////////////////////////////////////////
+
+int32_t compute_get_int(compute_t compute, const char *name) {
+	int32_t result = 0;
+	skr_compute_get_param(&compute->gpu_compute, name, sksc_shader_var_int, 1, &result);
+	return result;
+}
+
+///////////////////////////////////////////
+
+uint32_t compute_get_uint(compute_t compute, const char *name) {
+	uint32_t result = 0;
+	skr_compute_get_param(&compute->gpu_compute, name, sksc_shader_var_uint, 1, &result);
+	return result;
+}
+
+///////////////////////////////////////////
+
+vec2 compute_get_vector2(compute_t compute, const char *name) {
+	vec2 result = {};
+	skr_compute_get_param(&compute->gpu_compute, name, sksc_shader_var_float, 2, &result);
+	return result;
+}
+
+///////////////////////////////////////////
+
+vec3 compute_get_vector3(compute_t compute, const char *name) {
+	vec3 result = {};
+	skr_compute_get_param(&compute->gpu_compute, name, sksc_shader_var_float, 3, &result);
+	return result;
+}
+
+///////////////////////////////////////////
+
+vec4 compute_get_vector4(compute_t compute, const char *name) {
+	vec4 result = {};
+	skr_compute_get_param(&compute->gpu_compute, name, sksc_shader_var_float, 4, &result);
+	return result;
+}
+
+///////////////////////////////////////////
+
+bool32_t compute_get_bool(compute_t compute, const char *name) {
+	uint32_t result = 0;
+	skr_compute_get_param(&compute->gpu_compute, name, sksc_shader_var_uint, 1, &result);
+	return result != 0;
+}
+
+///////////////////////////////////////////
+
+color128 compute_get_color(compute_t compute, const char *name) {
+	color128 result = {1,1,1,1};
+	skr_compute_get_param(&compute->gpu_compute, name, sksc_shader_var_float, 4, &result);
+	return result;
+}
+
+///////////////////////////////////////////
+
+matrix compute_get_matrix(compute_t compute, const char *name) {
+	matrix result = matrix_identity;
+	skr_compute_get_param(&compute->gpu_compute, name, sksc_shader_var_float, 16, &result);
+	return result;
+}
+
+///////////////////////////////////////////
+
+bool32_t compute_set_texture(compute_t compute, const char *name, tex_t texture) {
+	const sksc_shader_meta_t *meta = compute->shader->gpu_shader.meta;
+
+	// Find which texture tracking slot this resource maps to
+	int32_t  tex_idx = 0;
+	int32_t  found   = -1;
+	uint64_t hash    = hash_string(name);
+	for (uint32_t i = 0; i < meta->resource_count; i++) {
+		skr_register_ reg = (skr_register_)meta->resources[i].bind.register_type;
+		if (reg == skr_register_texture || reg == skr_register_readwrite_tex) {
+			if (meta->resources[i].name_hash == hash) {
+				found = tex_idx;
+				break;
+			}
+			tex_idx++;
+		}
+	}
+
+	if (found < 0 || found >= compute->texture_count)
+		return false;
+
+	if (texture) tex_addref(texture);
+	tex_release(compute->textures[found]);
+	compute->textures[found] = texture;
+		
+	return true;
+}
+
+///////////////////////////////////////////
+
+bool32_t compute_set_buffer(compute_t compute, const char *name, compute_buffer_t buffer) {
+	const sksc_shader_meta_t *meta = compute->shader->gpu_shader.meta;
+
+	// Find which buffer tracking slot this resource maps to
+	int32_t  buf_idx = 0;
+	int32_t  found   = -1;
+	uint64_t hash    = hash_string(name);
+	for (uint32_t i = 0; i < meta->resource_count; i++) {
+		skr_register_ reg = (skr_register_)meta->resources[i].bind.register_type;
+		if (reg == skr_register_readwrite || reg == skr_register_read_buffer) {
+			if (meta->resources[i].name_hash == hash) {
+				found = buf_idx;
+				break;
+			}
+			buf_idx++;
+		}
+	}
+
+	if (found < 0 || found >= compute->buffer_count)
+		return false;
+
+	if (buffer) compute_buffer_addref(buffer);
+	compute_buffer_release(compute->buffers[found]);
+	compute->buffers[found] = buffer;
+
+	// Always forward to sk_renderer
+	skr_compute_set_buffer(&compute->gpu_compute, name, buffer ? &buffer->gpu_buffer : nullptr);
+	return true;
+}
+
+///////////////////////////////////////////
+
+void compute_dispatch(compute_t compute, uint32_t group_count_x, uint32_t group_count_y, uint32_t group_count_z) {
+	// Resolve texture fallbacks at dispatch time so that textures
+	// that finish loading between set and dispatch use the correct
+	// data instead of a stale fallback.
+	const sksc_shader_meta_t *meta = compute->shader->gpu_shader.meta;
+	int32_t tex_idx = 0;
+	for (uint32_t i = 0; i < meta->resource_count; i++) {
+		skr_register_ reg = (skr_register_)meta->resources[i].bind.register_type;
+		if (reg == skr_register_texture || reg == skr_register_readwrite_tex) {
+			if (tex_idx < compute->texture_count) {
+				tex_t tex = compute->textures[tex_idx];
+				skr_compute_set_tex(&compute->gpu_compute, meta->resources[i].name, tex != nullptr
+					? tex->fallback != nullptr
+						? &tex->fallback->gpu_tex
+						: &tex->gpu_tex
+					: nullptr);
+			}
+			tex_idx++;
+		}
+	}
+
+	skr_compute_execute(&compute->gpu_compute, group_count_x, group_count_y, group_count_z);
+}
+
+///////////////////////////////////////////
+
+int32_t compute_get_param_count(compute_t compute) {
+	int32_t buffer_id = compute->shader->gpu_shader.meta->global_buffer_id;
+	if (buffer_id == -1)
+		return compute->shader->gpu_shader.meta->resource_count;
+
+	return
+		compute->shader->gpu_shader.meta->buffers[buffer_id].var_count +
+		compute->shader->gpu_shader.meta->resource_count;
+}
+
+///////////////////////////////////////////
+
+void compute_get_param_info(compute_t compute, int32_t index, char **out_name, material_param_ *out_type) {
+	const sksc_shader_meta_t *meta = compute->shader->gpu_shader.meta;
+
+	int32_t buffer_id = meta->global_buffer_id;
+	int32_t buffer_ct = buffer_id >= 0
+		? meta->buffers[buffer_id].var_count
+		: 0;
+
+	if (index < buffer_ct) {
+		sksc_shader_var_t *info = &meta->buffers[buffer_id].vars[index];
+		if (out_type != nullptr) {
+			*out_type = material_param_unknown;
+			if (info->type == sksc_shader_var_float) {
+				if      (info->type_count == 16) *out_type = material_param_matrix;
+				else if (info->type_count == 1 ) *out_type = material_param_float;
+				else if (info->type_count == 2 ) *out_type = material_param_vector2;
+				else if (info->type_count == 3 ) *out_type = material_param_vector3;
+				else if (info->type_count == 4 ) *out_type = string_eq_nocase(info->extra, "color") ? material_param_color128 : material_param_vector4;
+			} else if (info->type == sksc_shader_var_int) {
+				if      (info->type_count == 1 ) *out_type = material_param_int;
+				else if (info->type_count == 2 ) *out_type = material_param_int2;
+				else if (info->type_count == 3 ) *out_type = material_param_int3;
+				else if (info->type_count == 4 ) *out_type = material_param_int4;
+			} else if (info->type == sksc_shader_var_uint) {
+				if      (info->type_count == 1 ) *out_type = material_param_uint;
+				else if (info->type_count == 2 ) *out_type = material_param_uint2;
+				else if (info->type_count == 3 ) *out_type = material_param_uint3;
+				else if (info->type_count == 4 ) *out_type = material_param_uint4;
+			}
+		}
+		if (out_name != nullptr) *out_name = info->name;
+	} else {
+		int32_t res_idx = index - buffer_ct;
+		if (out_type != nullptr) {
+			skr_register_ reg = (skr_register_)meta->resources[res_idx].bind.register_type;
+			*out_type = (reg == skr_register_readwrite || reg == skr_register_read_buffer)
+				? material_param_buffer
+				: material_param_texture;
+		}
+		if (out_name != nullptr) *out_name = meta->resources[res_idx].name;
+	}
+}
+
+///////////////////////////////////////////
+
+void compute_addref(compute_t compute) {
+	assets_addref(&compute->header);
+}
+
+///////////////////////////////////////////
+
+void compute_release(compute_t compute) {
+	if (compute == nullptr)
+		return;
+	assets_releaseref(&compute->header);
+}
+
+///////////////////////////////////////////
+
+void compute_destroy(compute_t compute) {
+	// Release tracked data
+	for (int32_t i = 0; i < compute->texture_count; i++) tex_release(compute->textures[i]);
+	for (int32_t i = 0; i < compute->buffer_count; i++) compute_buffer_release(compute->buffers[i]);
+	sk_free(compute->textures);
+	sk_free(compute->buffers);
+
+	shader_release(compute->shader);
+	skr_compute_destroy(&compute->gpu_compute);
+
+	*compute = {};
+}
+
+} // namespace sk

--- a/StereoKitC/asset_types/compute.h
+++ b/StereoKitC/asset_types/compute.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <sk_renderer.h>
+#include "../stereokit.h"
+#include "assets.h"
+
+namespace sk {
+
+struct _compute_t {
+	asset_header_t    header;
+	shader_t          shader;
+	skr_compute_t     gpu_compute;
+
+	tex_t*            textures;
+	int32_t           texture_count;
+	compute_buffer_t* buffers;
+	int32_t           buffer_count;
+};
+
+void compute_destroy(compute_t compute);
+
+} // namespace sk

--- a/StereoKitC/asset_types/compute_buffer.cpp
+++ b/StereoKitC/asset_types/compute_buffer.cpp
@@ -1,0 +1,100 @@
+#include "../stereokit.h"
+#include "../sk_memory.h"
+#include "../libraries/stref.h"
+#include "compute_buffer.h"
+#include "assets.h"
+
+namespace sk {
+
+///////////////////////////////////////////
+
+compute_buffer_t compute_buffer_create(compute_buffer_type_ type, int32_t element_count, int32_t element_size, const void *initial_data) {
+	skr_use_ use;
+	switch (type) {
+		case compute_buffer_type_read:      use = (skr_use_)(skr_use_dynamic | skr_use_compute_read);      break;
+		case compute_buffer_type_readwrite: use = (skr_use_)(skr_use_dynamic | skr_use_compute_readwrite); break;
+		default:
+			log_err("compute_buffer_create: invalid buffer type");
+			return nullptr;
+	}
+
+	compute_buffer_t result = (compute_buffer_t)assets_allocate(asset_type_compute_buffer);
+	result->type          = type;
+	result->element_count = element_count;
+	result->element_size  = element_size;
+
+	if (skr_buffer_create(initial_data, (uint32_t)element_count, (uint32_t)element_size, skr_buffer_type_storage, use, &result->gpu_buffer) != skr_err_success) {
+		log_err("compute_buffer_create: failed to create GPU buffer");
+		assets_releaseref(&result->header);
+		return nullptr;
+	}
+
+	return result;
+}
+
+///////////////////////////////////////////
+
+void compute_buffer_set_id(compute_buffer_t buffer, const char *id) {
+	assets_set_id(&buffer->header, id);
+}
+
+///////////////////////////////////////////
+
+const char* compute_buffer_get_id(const compute_buffer_t buffer) {
+	return buffer->header.id_text;
+}
+
+///////////////////////////////////////////
+
+void compute_buffer_set_data(compute_buffer_t buffer, const void *data, int32_t element_count) {
+	if (element_count > buffer->element_count) {
+		log_warnf("compute_buffer_set_data: element_count %d exceeds buffer capacity %d, clamping", element_count, buffer->element_count);
+		element_count = buffer->element_count;
+	}
+	skr_buffer_set(&buffer->gpu_buffer, data, (uint32_t)(element_count * buffer->element_size));
+}
+
+///////////////////////////////////////////
+
+void compute_buffer_get_data(compute_buffer_t buffer, void *out_data, int32_t element_count) {
+	if (element_count > buffer->element_count) {
+		log_warnf("compute_buffer_get_data: element_count %d exceeds buffer capacity %d, clamping", element_count, buffer->element_count);
+		element_count = buffer->element_count;
+	}
+	skr_buffer_get(&buffer->gpu_buffer, out_data, (uint32_t)(element_count * buffer->element_size));
+}
+
+///////////////////////////////////////////
+
+int32_t compute_buffer_get_count(const compute_buffer_t buffer) {
+	return buffer->element_count;
+}
+
+///////////////////////////////////////////
+
+int32_t compute_buffer_get_stride(const compute_buffer_t buffer) {
+	return buffer->element_size;
+}
+
+///////////////////////////////////////////
+
+void compute_buffer_addref(compute_buffer_t buffer) {
+	assets_addref(&buffer->header);
+}
+
+///////////////////////////////////////////
+
+void compute_buffer_release(compute_buffer_t buffer) {
+	if (buffer == nullptr)
+		return;
+	assets_releaseref(&buffer->header);
+}
+
+///////////////////////////////////////////
+
+void compute_buffer_destroy(compute_buffer_t buffer) {
+	skr_buffer_destroy(&buffer->gpu_buffer);
+	*buffer = {};
+}
+
+} // namespace sk

--- a/StereoKitC/asset_types/compute_buffer.h
+++ b/StereoKitC/asset_types/compute_buffer.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <sk_renderer.h>
+#include "../stereokit.h"
+#include "assets.h"
+
+namespace sk {
+
+struct _compute_buffer_t {
+	asset_header_t       header;
+	skr_buffer_t         gpu_buffer;
+	compute_buffer_type_ type;
+	int32_t              element_count;
+	int32_t              element_size;
+};
+
+void compute_buffer_destroy(compute_buffer_t buffer);
+
+} // namespace sk

--- a/StereoKitC/asset_types/texture.cpp
+++ b/StereoKitC/asset_types/texture.cpp
@@ -90,6 +90,7 @@ skr_tex_flags_ tex_type_to_skr_flags(tex_type_ type) {
 	if (type & tex_type_mips)         flags = (skr_tex_flags_)(flags | skr_tex_flags_gen_mips);
 	if (type & tex_type_rendertarget) flags = (skr_tex_flags_)(flags | skr_tex_flags_writeable);
 	if (type & tex_type_depthtarget)  flags = (skr_tex_flags_)(flags | skr_tex_flags_writeable); // Readable depth (shadow maps)
+	if (type & tex_type_compute)      flags = (skr_tex_flags_)(flags | skr_tex_flags_compute);
 	return flags;
 }
 

--- a/StereoKitC/stereokit.h
+++ b/StereoKitC/stereokit.h
@@ -1082,6 +1082,8 @@ SK_DeclarePrivateType(sprite_t);
 SK_DeclarePrivateType(sound_t);
 SK_DeclarePrivateType(anchor_t);
 SK_DeclarePrivateType(render_list_t);
+SK_DeclarePrivateType(compute_t);
+SK_DeclarePrivateType(compute_buffer_t);
 
 ///////////////////////////////////////////
 
@@ -1233,6 +1235,10 @@ typedef enum tex_type_ {
 	  readable. This makes it great for shadowmaps or other textures that need to
 	  be read from later on.*/
 	tex_type_depthtarget   = 1 << 6,
+	/*This texture can be used as a RWTexture in compute shaders.
+	  Create it with a format that supports storage images, such as
+	  tex_format_rgba128.*/
+	tex_type_compute       = 1 << 7,
 	/*A standard color image that also generates mip-maps
 	  automatically.*/
 	tex_type_image         = tex_type_image_nomips | tex_type_mips,
@@ -1386,6 +1392,19 @@ SK_API void         shader_release          (shader_t shader);
 
 ///////////////////////////////////////////
 
+/*Describes the access mode of a ComputeBuffer for use in compute
+  shaders.*/
+typedef enum compute_buffer_type_ {
+	/*Read-only from compute shaders. Maps to StructuredBuffer<T>
+	  in HLSL.*/
+	compute_buffer_type_read      = 1,
+	/*Read-write from compute shaders. Maps to
+	  RWStructuredBuffer<T> in HLSL.*/
+	compute_buffer_type_readwrite = 2,
+} compute_buffer_type_;
+
+///////////////////////////////////////////
+
 /*Also known as 'alpha' for those in the know. But there's
   actually more than one type of transparency in rendering! The
   horrors. We're keepin' it fairly simple for now, so you get three
@@ -1503,6 +1522,9 @@ typedef enum material_param_ {
 	material_param_uint3 = 14,
 	/*A 4 component vector composed of unsigned integers.*/
 	material_param_uint4 = 15,
+	/*A structured buffer resource, such as StructuredBuffer<T> or
+	  RWStructuredBuffer<T> in HLSL.*/
+	material_param_buffer = 16,
 } material_param_;
 
 SK_API material_t        material_find            (const char *id);
@@ -1572,6 +1594,51 @@ SK_API material_buffer_t material_buffer_create   (int32_t size);
 SK_API void              material_buffer_addref   (material_buffer_t buffer);
 SK_API void              material_buffer_release  (material_buffer_t buffer);
 SK_API void              material_buffer_set_data (material_buffer_t buffer, const void *buffer_data);
+
+///////////////////////////////////////////
+
+SK_API compute_buffer_t compute_buffer_create    (compute_buffer_type_ type, int32_t element_count, int32_t element_size, const void *opt_initial_data);
+SK_API void             compute_buffer_set_id    (compute_buffer_t buffer, const char *id);
+SK_API const char*      compute_buffer_get_id    (const compute_buffer_t buffer);
+SK_API void             compute_buffer_set_data  (compute_buffer_t buffer, const void *data, int32_t element_count);
+SK_API void             compute_buffer_get_data  (compute_buffer_t buffer, void *out_data, int32_t element_count);
+SK_API int32_t          compute_buffer_get_count (const compute_buffer_t buffer);
+SK_API int32_t          compute_buffer_get_stride(const compute_buffer_t buffer);
+SK_API void             compute_buffer_addref    (compute_buffer_t buffer);
+SK_API void             compute_buffer_release   (compute_buffer_t buffer);
+
+///////////////////////////////////////////
+
+SK_API compute_t        compute_create           (shader_t shader);
+SK_API compute_t        compute_find             (const char *id);
+SK_API void             compute_set_id           (compute_t compute, const char *id);
+SK_API const char*      compute_get_id           (const compute_t compute);
+SK_API shader_t         compute_get_shader       (const compute_t compute);
+SK_API void             compute_set_float        (compute_t compute, const char *name, float value);
+SK_API void             compute_set_int          (compute_t compute, const char *name, int32_t value);
+SK_API void             compute_set_uint         (compute_t compute, const char *name, uint32_t value);
+SK_API void             compute_set_vector2      (compute_t compute, const char *name, vec2 value);
+SK_API void             compute_set_vector3      (compute_t compute, const char *name, vec3 value);
+SK_API void             compute_set_vector4      (compute_t compute, const char *name, vec4 value);
+SK_API void             compute_set_color        (compute_t compute, const char *name, color128 color_gamma);
+SK_API void             compute_set_bool         (compute_t compute, const char *name, bool32_t value);
+SK_API void             compute_set_matrix       (compute_t compute, const char *name, matrix value);
+SK_API float            compute_get_float        (compute_t compute, const char *name);
+SK_API int32_t          compute_get_int          (compute_t compute, const char *name);
+SK_API uint32_t         compute_get_uint         (compute_t compute, const char *name);
+SK_API vec2             compute_get_vector2      (compute_t compute, const char *name);
+SK_API vec3             compute_get_vector3      (compute_t compute, const char *name);
+SK_API vec4             compute_get_vector4      (compute_t compute, const char *name);
+SK_API bool32_t         compute_get_bool         (compute_t compute, const char *name);
+SK_API color128         compute_get_color        (compute_t compute, const char *name);
+SK_API matrix           compute_get_matrix       (compute_t compute, const char *name);
+SK_API bool32_t         compute_set_texture      (compute_t compute, const char *name, tex_t texture);
+SK_API bool32_t         compute_set_buffer       (compute_t compute, const char *name, compute_buffer_t buffer);
+SK_API void             compute_dispatch         (compute_t compute, uint32_t group_count_x, uint32_t group_count_y, uint32_t group_count_z);
+SK_API int32_t          compute_get_param_count  (compute_t compute);
+SK_API void             compute_get_param_info   (compute_t compute, int32_t index, char **out_name, material_param_ *out_type);
+SK_API void             compute_addref           (compute_t compute);
+SK_API void             compute_release          (compute_t compute);
 
 ///////////////////////////////////////////
 
@@ -3018,6 +3085,10 @@ typedef enum asset_type_ {
 	asset_type_anchor,
 	/*A RenderList*/
 	asset_type_render_list,
+	/*A Compute dispatch object*/
+	asset_type_compute,
+	/*A ComputeBuffer*/
+	asset_type_compute_buffer,
 } asset_type_;
 
 typedef void* asset_t;

--- a/tools/StereoKitAPIGen/SKModules.txt
+++ b/tools/StereoKitAPIGen/SKModules.txt
@@ -10,3 +10,4 @@ backend_d3d11 backend_d3d11_
 backend_opengl backend_opengl_
 render_list render_list_
 material_buffer material_buffer_
+compute_buffer compute_buffer_

--- a/tools/StereoKitAPIGen/SKOverridesCSharp.txt
+++ b/tools/StereoKitAPIGen/SKOverridesCSharp.txt
@@ -42,6 +42,8 @@ render_layer_7 Layer7
 render_layer_8 Layer8
 render_layer_9 Layer9
 
+compute_buffer_type_readwrite ReadWrite
+
 material_param_uint UInt
 material_param_uint2 UInt2
 material_param_uint3 UInt3


### PR DESCRIPTION
Initial compute shader implementation! This adds `Compute` and `ComputeBuffer` classes which look a lot like `Material` and `MaterialBuffer`.

A reaction diffusion demo has also been ported from sk_renderer, to DemoCompute.cs.

More features and changes may come to this one yet, as it gets tested!