### PR TITLE
Merge metal/rough with AO into the same texture

### DIFF
--- a/StereoKit/Assets/Tex.cs
+++ b/StereoKit/Assets/Tex.cs
@@ -628,6 +628,67 @@ namespace StereoKit
 			return inst == IntPtr.Zero ? null : new Tex(inst);
 		}
 
+		/// <summary>Creates a texture by loading multiple source images
+		/// and packing their channels into a single output texture.
+		/// Each source specifies which channels to contribute via its
+		/// channel map. This is useful for creating packed textures
+		/// like ORM (Occlusion/Roughness/Metallic) from separate
+		/// source images.</summary>
+		/// <param name="sources">Array of source descriptors, each
+		/// providing image data (file or memory) and a channel
+		/// map.</param>
+		/// <param name="defaultColor">Default color for unmapped
+		/// channels.</param>
+		/// <param name="sRGBData">Is the source image data in sRGB
+		/// color space? Color images like photos and albedo maps are
+		/// sRGB, while data textures like normals, roughness, metallic,
+		/// and AO are linear. Image formats like PNG and JPEG don't
+		/// reliably communicate this on their own. Most packed data
+		/// textures are linear.</param>
+		/// <param name="priority">Async loading priority.</param>
+		/// <returns>A Tex asset, or null on failure.</returns>
+		public static Tex FromPacked(TexPackSource[] sources, Color defaultColor = default, bool sRGBData = false, int priority = 10)
+		{
+			int count = sources.Length;
+			List<GCHandle>        pins   = new List<GCHandle>(count);
+			TexPackSourceNative[] native = new TexPackSourceNative[count];
+			try
+			{
+				for (int i = 0; i < count; i++)
+				{
+					if (sources[i].data != null)
+					{
+						GCHandle h = GCHandle.Alloc(sources[i].data, GCHandleType.Pinned);
+						pins.Add(h);
+						native[i].data     = h.AddrOfPinnedObject();
+						native[i].dataSize = (UIntPtr)sources[i].data.Length;
+					}
+					if (sources[i].filename != null)
+					{
+						byte[]   utf8 = NativeHelper.ToUtf8(sources[i].filename);
+						GCHandle h    = GCHandle.Alloc(utf8, GCHandleType.Pinned);
+						pins.Add(h);
+						native[i].filename = h.AddrOfPinnedObject();
+					}
+					string map = sources[i].channelMap;
+					if (map != null)
+					{
+						native[i].channelR = map.Length > 0 ? (byte)map[0] : (byte)0;
+						native[i].channelG = map.Length > 1 ? (byte)map[1] : (byte)0;
+						native[i].channelB = map.Length > 2 ? (byte)map[2] : (byte)0;
+						native[i].channelA = map.Length > 3 ? (byte)map[3] : (byte)0;
+					}
+				}
+				IntPtr inst = NativeAPI.tex_create_packed(native, count, defaultColor, sRGBData, priority);
+				return inst == IntPtr.Zero ? null : new Tex(inst);
+			}
+			finally
+			{
+				for (int i = 0; i < pins.Count; i++)
+					pins[i].Free();
+			}
+		}
+
 		/// <summary>Creates a texture and sets the texture's pixels using a
 		/// color array! This will be an image of type `TexType.Image`, and
 		/// a format of `TexFormat.Rgba32` or `TexFormat.Rgba32Linear`

--- a/StereoKit/Native/NativeAPI.Custom.cs
+++ b/StereoKit/Native/NativeAPI.Custom.cs
@@ -66,6 +66,10 @@ namespace StereoKit
 		// tex_create_mem with byte array
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)]
 		public static extern IntPtr tex_create_mem([In] byte[] data, UIntPtr data_size, [MarshalAs(UnmanagedType.Bool)] bool srgb_data, int priority);
+
+		// tex_create_packed with internal native struct
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)]
+		public static extern IntPtr tex_create_packed([In] TexPackSourceNative[] in_arr_sources, int source_count, Color default_color, [MarshalAs(UnmanagedType.Bool)] bool srgb_data, int priority);
 		// tex_set_mem overload with byte[] data
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)]
 		public static extern void tex_set_mem(IntPtr texture, [In] byte[] data, UIntPtr data_size, [MarshalAs(UnmanagedType.Bool)] bool srgb_data, [MarshalAs(UnmanagedType.Bool)] bool blocking, int priority);

--- a/StereoKit/Native/NativeAPI.cs
+++ b/StereoKit/Native/NativeAPI.cs
@@ -261,6 +261,7 @@ namespace StereoKit
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr       tex_create_file_arr([In] string[] in_arr_files, int file_count, [MarshalAs(UnmanagedType.Bool)] bool srgb_data, int priority);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr       tex_create_cubemap_file([MarshalAs(UnmanagedType.LPUTF8Str)] string cubemap_file_utf8, [MarshalAs(UnmanagedType.Bool)] bool srgb_data, int priority);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr       tex_create_cubemap_files([In] string[] in_arr_cube_face_file_xxyyzz, [MarshalAs(UnmanagedType.Bool)] bool srgb_data, int priority);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr       tex_create_packed([In] TexPackSource[] in_arr_sources, int source_count, Color default_color, [MarshalAs(UnmanagedType.Bool)] bool srgb_data, int priority);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr       tex_copy(IntPtr texture, TexType type, TexFormat format);
 		[return: MarshalAs(UnmanagedType.Bool)]
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern bool         tex_gen_mips(IntPtr texture);

--- a/StereoKit/Native/NativeTypes.Custom.cs
+++ b/StereoKit/Native/NativeTypes.Custom.cs
@@ -569,4 +569,42 @@ namespace StereoKit
 		[Obsolete("Use Pivot instead")]
 		public static implicit operator Pivot(TextAlign a) => (Pivot)a;
 	}
+
+	/// <summary>Describes a source image for channel packing. This is
+	/// the internal marshaling struct matching the native
+	/// tex_pack_source_t layout.</summary>
+	[StructLayout(LayoutKind.Sequential)]
+	internal struct TexPackSourceNative
+	{
+		public IntPtr  filename;
+		public IntPtr  data;
+		public UIntPtr dataSize;
+		public byte    channelR;
+		public byte    channelG;
+		public byte    channelB;
+		public byte    channelA;
+	}
+
+	/// <summary>Describes a source image for channel packing via
+	/// `Tex.FromPacked`. Provide either a Filename or in-memory Data.
+	/// The ChannelMap is a 4-byte array where each position represents
+	/// an output channel (RGBA), and the value selects which source
+	/// channel to read: (byte)'R', (byte)'G', (byte)'B', (byte)'A',
+	/// or 0 to skip.</summary>
+	public struct TexPackSource
+	{
+		/// <summary>File path for the source image, or null if
+		/// providing in-memory data instead.</summary>
+		public string filename;
+		/// <summary>Encoded image file data (PNG, JPEG, etc.), or
+		/// null if using a filename instead.</summary>
+		public byte[] data;
+		/// <summary>A 4-character string mapping source channels to
+		/// output channels. Each position is an output channel (RGBA).
+		/// The character selects which source channel to read: 'R',
+		/// 'G', 'B', 'A', or '_' to skip. For example, "R___" copies
+		/// source R to output R. "_GB_" copies source G and B to
+		/// output G and B.</summary>
+		public string channelMap;
+	}
 }

--- a/StereoKitC/asset_types/model_gltf.cpp
+++ b/StereoKitC/asset_types/model_gltf.cpp
@@ -519,6 +519,61 @@ void gltf_apply_sampler(tex_t to_tex, cgltf_sampler *sampler) {
 
 ///////////////////////////////////////////
 
+// Decodes a base64 data URI into a newly allocated buffer. Returns
+// true on success. The caller must free the returned buffer with
+// sk_free.
+bool gltf_decode_data_uri(const char *uri, void **out_data, size_t *out_size) {
+	if (uri == nullptr || strncmp(uri, "data:", 5) != 0)
+		return false;
+
+	const char *comma = strchr(uri, ',');
+	if (!comma || comma - uri < 7 || strncmp(comma - 7, ";base64", 7) != 0)
+		return false;
+
+	const char *base64      = comma + 1;
+	size_t      base64_len  = strlen(base64);
+	size_t      decoded_size = base64_len - base64_len / 4;
+	if (base64_len >= 2) {
+		decoded_size -= base64[base64_len - 2] == '=';
+		decoded_size -= base64[base64_len - 1] == '=';
+	}
+
+	cgltf_options options = {};
+	options.memory.alloc_func = [](void *, cgltf_size size) { return sk_malloc(size); };
+	options.memory.free_func  = [](void *, void*      data) { sk_free(data); };
+	if (cgltf_load_buffer_base64(&options, decoded_size, base64, out_data) != cgltf_result_success)
+		return false;
+
+	*out_size = decoded_size;
+	return true;
+}
+
+///////////////////////////////////////////
+
+// Resolves image data from a cgltf_image into a pointer+size or
+// filename. Returns false if the image can't be resolved. When
+// out_data is non-null, the data either points into the glTF buffer
+// (buffer_view case, not owned) or is a new allocation (base64 case,
+// caller must free). Check image->buffer_view to distinguish.
+bool gltf_resolve_image(cgltf_data *data, cgltf_image *image, const char *filename, void **out_data, size_t *out_size, char *out_filename, int32_t out_filename_size) {
+	*out_data = nullptr;
+	*out_size = 0;
+
+	if (image->buffer_view != nullptr && image->buffer_view->buffer->data != nullptr) {
+		*out_data = (void*)((uint8_t*)image->buffer_view->buffer->data + image->buffer_view->offset);
+		*out_size = image->buffer_view->size;
+		return true;
+	} else if (gltf_decode_data_uri(image->uri, out_data, out_size)) {
+		return true;
+	} else if (image->uri != nullptr && strstr(image->uri, "://") == nullptr) {
+		gltf_imagename(data, image, filename, out_filename, out_filename_size);
+		return true;
+	}
+	return false;
+}
+
+///////////////////////////////////////////
+
 tex_t gltf_parsetexture(cgltf_data* data, cgltf_texture *tex, const char *filename, bool srgb_data, int32_t priority, array_t<const char*>* warnings) {
 	cgltf_image *image = tex->has_basisu
 		? tex->basisu_image
@@ -535,38 +590,21 @@ tex_t gltf_parsetexture(cgltf_data* data, cgltf_texture *tex, const char *filena
 		return result;
 	}
 
-	if (image->buffer_view != nullptr) {
-		// If it's already a loaded buffer, like in a .glb
-		result = tex_create_mem((void*)((uint8_t*)image->buffer_view->buffer->data + image->buffer_view->offset), image->buffer_view->size, srgb_data, priority);
-		if (result == nullptr) 
+	void   *img_data = nullptr;
+	size_t  img_size = 0;
+	if (!gltf_resolve_image(data, image, filename, &img_data, &img_size, id, 512))
+		return nullptr;
+
+	if (img_data != nullptr) {
+		result = tex_create_mem(img_data, img_size, srgb_data, priority);
+		// Free base64-decoded data (tex_create_mem copies it).
+		// Buffer view pointers are into the cgltf buffer, not ours.
+		if (image->buffer_view == nullptr)
+			sk_free(img_data);
+		if (result == nullptr)
 			log_warnf("[%s] Couldn't load texture: %s", filename, image->name);
 		else
 			tex_set_id(result, id);
-	} else if (image->uri != nullptr && strncmp(image->uri, "data:", 5) == 0) {
-		// If it's an image file encoded in a base64 string
-		char* start = strchr(image->uri, ',');
-		if (start != nullptr && start - image->uri >= 7 && strncmp(start - 7, ";base64", 7) == 0) {
-			void*         buffer  = nullptr;
-			cgltf_options options = {};
-
-			char*  base64_start = start + 1;
-			size_t base64_len   = strlen(base64_start);
-
-			// A base64 string may end with 0, 1 or 2 '=' padding characters,
-			// padding is present to ensure data is a multiple of 3.
-			size_t base64_size = 3 * (base64_len / 4);
-			if (base64_len >= 1 && base64_start[base64_len-1] == '=') { base64_size -= 1; }
-			if (base64_len >= 2 && base64_start[base64_len-2] == '=') { base64_size -= 1; }
-
-			 // find the size of the data in bytes, there's 6 bits of data encoded in 8 bits of base64
-			cgltf_load_buffer_base64(&options, base64_size, base64_start, &buffer);
-
-			if (buffer != nullptr) {
-				result = tex_create_mem(buffer, base64_size, srgb_data, priority);
-				tex_set_id(result, id);
-				sk_free(buffer);
-			}
-		}
 	} else if (image->uri != nullptr && strstr(image->uri, "://") == nullptr) {
 		// If it's a file path to an external image file
 		result = tex_create_file(id, srgb_data, priority);
@@ -617,15 +655,13 @@ material_t gltf_parsematerial(cgltf_data *data, cgltf_material *material, const 
 		} else if (is_lightmap) {
 			result = material_create(shader_find(default_id_shader_lightmap));
 		} else if (material->unlit) {
-			if (material->alpha_mode == cgltf_alpha_mode_mask)
-				result = material_copy_id(default_id_material_unlit_clip);
-			else
-				result = material_copy_id(default_id_material_unlit);
+			result = material->alpha_mode == cgltf_alpha_mode_mask
+				? material_copy_id(default_id_material_unlit_clip)
+				: material_copy_id(default_id_material_unlit);
 		} else if (material->has_pbr_metallic_roughness) {
-			if (material->alpha_mode == cgltf_alpha_mode_mask)
-				result = material_copy_id(default_id_material_pbr_clip);
-			else
-				result = material_copy_id(default_id_material_pbr);
+			result = material->alpha_mode == cgltf_alpha_mode_mask
+				? material_copy_id(default_id_material_pbr_clip)
+				: material_copy_id(default_id_material_pbr);
 		} else {
 			result = material_copy_id(default_id_material);
 		}
@@ -643,6 +679,7 @@ material_t gltf_parsematerial(cgltf_data *data, cgltf_material *material, const 
 		return result;
 
 	cgltf_texture *tex = nullptr;
+	bool ao_handled = false;
 	if (material->has_pbr_metallic_roughness) {
 		tex = material->pbr_metallic_roughness.base_color_texture.texture;
 		if (tex != nullptr && material_has_param(result, "diffuse", material_param_texture)) {
@@ -656,7 +693,77 @@ material_t gltf_parsematerial(cgltf_data *data, cgltf_material *material, const 
 		}
 
 		tex = material->pbr_metallic_roughness.metallic_roughness_texture.texture;
-		if (tex != nullptr && material_has_param(result, "metal", material_param_texture)) {
+		cgltf_texture *ao_tex = material->occlusion_texture.texture;
+
+		// When both metallic/roughness and occlusion textures are present,
+		// pack them into a single ORM texture to save memory.
+		if (tex != nullptr && ao_tex != nullptr && !is_lightmap && material_has_param(result, "metal", material_param_texture)) {
+			cgltf_image *metal_img = tex   ->has_basisu ? tex   ->basisu_image : tex   ->image;
+			cgltf_image *ao_img    = ao_tex->has_basisu ? ao_tex->basisu_image : ao_tex->image;
+
+			if (metal_img == ao_img && metal_img != nullptr) {
+				// Same underlying image - already ORM packed
+				tex_t parse_tex = gltf_parsetexture(data, tex, filename, false, 13, warnings);
+				if (parse_tex != nullptr) {
+					tex_set_fallback(parse_tex, sk_default_tex_rough);
+					material_set_texture(result, "metal", parse_tex);
+					tex_release(parse_tex);
+					ao_handled = true;
+				}
+			} else if (metal_img != nullptr && ao_img != nullptr) {
+				// Different images - pack AO(R) + metal/rough(GB) into
+				// one texture via tex_create_packed
+
+				// Check for a cached packed texture first
+				char metal_id[512], ao_id[512], packed_id[512];
+				gltf_imagename(data, metal_img, filename, metal_id, 512);
+				gltf_imagename(data, ao_img,    filename, ao_id,    512);
+				snprintf(packed_id, sizeof(packed_id), "packed:%s+%s", metal_id, ao_id);
+
+				tex_t packed = tex_find(packed_id);
+				if (packed == nullptr) {
+					// Resolve raw image data for both sources
+					void   *metal_data = nullptr, *ao_data = nullptr;
+					size_t  metal_size = 0,        ao_size = 0;
+					char    metal_file[512],       ao_file[512];
+
+					bool metal_ok = gltf_resolve_image(data, metal_img, filename, &metal_data, &metal_size, metal_file, 512);
+					bool ao_ok    = gltf_resolve_image(data, ao_img,    filename, &ao_data,    &ao_size,    ao_file,    512);
+
+					if (metal_ok && ao_ok) {
+						tex_pack_source_t sources[2] = {};
+						sources[0].data           = ao_data;
+						sources[0].data_size      = ao_size;
+						sources[0].filename       = ao_data    == nullptr ? ao_file    : nullptr;
+						sources[0].channel_map[0] = 'R'; // AO.R -> output.R
+						sources[1].data           = metal_data;
+						sources[1].data_size      = metal_size;
+						sources[1].filename       = metal_data == nullptr ? metal_file : nullptr;
+						sources[1].channel_map[1] = 'G'; // metal.G -> output.G (roughness)
+						sources[1].channel_map[2] = 'B'; // metal.B -> output.B (metallic)
+
+						packed = tex_create_packed(sources, 2, { 1,1,0,1 }, false, 13);
+						if (packed != nullptr)
+							tex_set_id(packed, packed_id);
+					}
+
+					// Free any base64-decoded allocations
+					if (metal_img->buffer_view == nullptr) sk_free(metal_data);
+					if (ao_img   ->buffer_view == nullptr) sk_free(ao_data);
+				}
+
+				if (packed != nullptr) {
+					tex_set_fallback(packed, sk_default_tex_rough);
+					gltf_apply_sampler(packed, tex->sampler);
+					material_set_texture(result, "metal", packed);
+					tex_release(packed);
+					ao_handled = true;
+				}
+			}
+		}
+
+		// Fallback: load metal/rough separately if packing didn't happen
+		if (!ao_handled && tex != nullptr && material_has_param(result, "metal", material_param_texture)) {
 			if (material->pbr_metallic_roughness.metallic_roughness_texture.texcoord != 0) gltf_add_warning(warnings, "StereoKit doesn't support loading multiple texture coordinate channels yet.");
 			tex_t parse_tex = gltf_parsetexture(data, tex, filename, false, 13, warnings);
 			if (parse_tex != nullptr) {
@@ -712,20 +819,22 @@ material_t gltf_parsematerial(cgltf_data *data, cgltf_material *material, const 
 		}
 	}
 
-	tex = material->occlusion_texture.texture;
-	const char* param = is_lightmap ? "lightmap" : "occlusion";
-	if (tex != nullptr && material_has_param(result, param, material_param_texture)) {
-		if (material->occlusion_texture.texcoord != 0 && is_lightmap == false) gltf_add_warning(warnings, "StereoKit doesn't support multiple texture coordinate channels yet.");
-		tex_t parse_tex = gltf_parsetexture(data, tex, filename, is_lightmap ? true : false, 11, warnings);
-		if (parse_tex != nullptr) {
-			tex_set_fallback(parse_tex, sk_default_tex);
-			material_set_texture(result, param, parse_tex);
-			tex_release(parse_tex);
+	// Lightmap materials use the occlusion texture as a lightmap via a
+	// separate shader that still has a "lightmap" texture slot.
+	if (is_lightmap) {
+		tex = material->occlusion_texture.texture;
+		if (tex != nullptr && material_has_param(result, "lightmap", material_param_texture)) {
+			tex_t parse_tex = gltf_parsetexture(data, tex, filename, true, 11, warnings);
+			if (parse_tex != nullptr) {
+				tex_set_fallback(parse_tex, sk_default_tex);
+				material_set_texture(result, "lightmap", parse_tex);
+				tex_release(parse_tex);
+			}
 		}
 	}
 
 	tex = material->emissive_texture.texture;
-	param = is_lightmap ? "diffuse" : "emission";
+	const char *param = is_lightmap ? "diffuse" : "emission";
 	if (tex != nullptr && material_has_param(result, param, material_param_texture)) {
 		if (material->emissive_texture.texcoord != 0) gltf_add_warning(warnings, "StereoKit doesn't support multiple texture coordinate channels yet.");
 		gltf_set_material_transform(result, &material->emissive_texture);

--- a/StereoKitC/asset_types/texture.cpp
+++ b/StereoKitC/asset_types/texture.cpp
@@ -333,6 +333,236 @@ void tex_load_on_failure(asset_header_t *asset, void *) {
 }
 
 ///////////////////////////////////////////
+// Packed texture loading stages         //
+///////////////////////////////////////////
+
+struct tex_pack_load_t {
+	int32_t       source_count;
+	bool32_t      is_srgb;
+	char        **source_filenames; // NULL entries = memory source
+	void        **source_data;     // Encoded bytes (copied or loaded from file)
+	size_t       *source_sizes;
+	uint8_t     (*source_maps)[4]; // Per-source channel maps
+	color32       default_color;
+	int32_t       out_width;
+	int32_t       out_height;
+	tex_format_   out_format;
+	color32      *packed_data;     // Final output after packing
+};
+
+///////////////////////////////////////////
+
+void tex_pack_load_free(asset_header_t *, void *job_data) {
+	tex_pack_load_t *data = (tex_pack_load_t *)job_data;
+
+	for (int32_t i = 0; i < data->source_count; i++) {
+		if (data->source_filenames != nullptr) sk_free(data->source_filenames[i]);
+		if (data->source_data      != nullptr) sk_free(data->source_data     [i]);
+	}
+	sk_free(data->source_filenames);
+	sk_free(data->source_data);
+	sk_free(data->source_sizes);
+	sk_free(data->source_maps);
+	sk_free(data->packed_data);
+	sk_free(data);
+}
+
+///////////////////////////////////////////
+
+void tex_pack_load_on_failure(asset_header_t *asset, void *) {
+	tex_t tex = (tex_t)asset;
+	tex_set_fallback(tex, _tex_get_error_fallback(tex));
+}
+
+///////////////////////////////////////////
+
+bool32_t tex_pack_load_and_merge(asset_task_t *task, asset_header_t *asset, void *job_data) {
+	profiler_zone();
+
+	tex_pack_load_t *data = (tex_pack_load_t *)job_data;
+	tex_t            tex  = (tex_t)asset;
+
+	// Arrays for decoded source pixel data
+	void   **decoded       = sk_malloc_zero_t(void *, data->source_count);
+	int32_t *decoded_w     = sk_malloc_t(int32_t, data->source_count);
+	int32_t *decoded_h     = sk_malloc_t(int32_t, data->source_count);
+	int32_t  max_w         = 0;
+	int32_t  max_h         = 0;
+	int32_t  pixel_count   = 0;
+
+	struct pack_info_t {
+		int32_t  ch_map[4];   // source channel index per output channel, -1 = skip
+		uint32_t write_mask;  // bitmask of output bytes to write
+		bool     identity;    // true if all active channels map to same position
+		bool     same_size;   // true if source matches output dimensions
+	};
+	pack_info_t *pinfo = nullptr;
+
+	// Load and decode each source
+	for (int32_t i = 0; i < data->source_count; i++) {
+		// Load file if this is a file-based source
+		if (data->source_filenames[i] != nullptr && data->source_data[i] == nullptr) {
+			if (!platform_read_file(data->source_filenames[i], &data->source_data[i], &data->source_sizes[i])) {
+				log_warnf("tex_create_packed: failed to load file '%s'", data->source_filenames[i]);
+				tex->header.state = asset_state_error_not_found;
+				goto fail;
+			}
+		}
+
+		// Decode the image
+		int32_t     w, h, arr, mip;
+		tex_format_ fmt;
+		tex_type_   type = tex_type_image;
+		if (!tex_load_image_data(data->source_data[i], data->source_sizes[i],
+				data->is_srgb, &type, &fmt, &w, &h, &arr, &mip,
+				&decoded[i])) {
+			log_warnf("tex_create_packed: source %d failed to decode", i);
+			tex->header.state = asset_state_error_unsupported;
+			goto fail;
+		}
+
+		// Only RGBA32 formats are supported for channel packing
+		if (fmt != tex_format_rgba32 && fmt != tex_format_rgba32_linear) {
+			log_warnf("tex_create_packed: source %d is not RGBA32 (format %d), HDR and compressed formats are unsupported", i, fmt);
+			tex->header.state = asset_state_error_unsupported;
+			goto fail;
+		}
+
+		decoded_w[i] = w;
+		decoded_h[i] = h;
+		if (w > max_w) max_w = w;
+		if (h > max_h) max_h = h;
+
+		// Free encoded source data now that we've decoded it
+		sk_free(data->source_data[i]);
+	}
+
+	// Update output dimensions (may differ from metadata estimate if
+	// file-based sources had unknown dimensions)
+	data->out_width  = max_w;
+	data->out_height = max_h;
+	tex_set_meta(tex, max_w, max_h, data->out_format);
+	assets_task_set_complexity(task, max_w * max_h);
+
+	// Pre-compute per-source channel mapping info
+	pixel_count = max_w * max_h;
+	uint32_t default_u32;
+	memcpy(&default_u32, &data->default_color, 4);
+
+	pinfo = (pack_info_t *)sk_malloc(sizeof(pack_info_t) * data->source_count);
+
+	for (int32_t s = 0; s < data->source_count; s++) {
+		uint8_t *map       = data->source_maps[s];
+		pinfo[s].write_mask = 0;
+		pinfo[s].identity   = true;
+		pinfo[s].same_size  = (decoded_w[s] == max_w && decoded_h[s] == max_h);
+
+		for (int32_t ch = 0; ch < 4; ch++) {
+			int32_t src_ch = -1;
+			switch (map[ch]) {
+			case 'R': case 'r': src_ch = 0; break;
+			case 'G': case 'g': src_ch = 1; break;
+			case 'B': case 'b': src_ch = 2; break;
+			case 'A': case 'a': src_ch = 3; break;
+			}
+			pinfo[s].ch_map[ch] = src_ch;
+			if (src_ch >= 0) {
+				pinfo[s].write_mask |= 0xFFu << (ch * 8);
+				if (src_ch != ch)
+					pinfo[s].identity = false;
+			}
+		}
+	}
+
+	// Allocate output and fill with default color
+	data->packed_data = sk_malloc_t(color32, pixel_count);
+	{
+		uint32_t *dp = (uint32_t *)data->packed_data;
+		for (int32_t i = 0; i < pixel_count; i++)
+			dp[i] = default_u32;
+	}
+
+	// Pack channels from each source into the output
+	for (int32_t s = 0; s < data->source_count; s++) {
+		if (pinfo[s].write_mask == 0) {
+			sk_free(decoded[s]);
+			decoded[s] = nullptr;
+			continue;
+		}
+
+		uint32_t *src = (uint32_t *)decoded[s];
+		uint32_t *dst = (uint32_t *)data->packed_data;
+
+		if (pinfo[s].same_size && pinfo[s].identity) {
+			// Fast path: same size, channels map to same position.
+			// Masked 32-bit merge — compiler can auto-vectorize this.
+			uint32_t mask = pinfo[s].write_mask;
+			uint32_t keep = ~mask;
+			for (int32_t i = 0; i < pixel_count; i++)
+				dst[i] = (dst[i] & keep) | (src[i] & mask);
+		} else if (pinfo[s].same_size) {
+			// Same size but channels are remapped
+			int32_t *ch_map = pinfo[s].ch_map;
+			for (int32_t i = 0; i < pixel_count; i++) {
+				uint8_t *sp = (uint8_t *)&src[i];
+				uint8_t *dp = (uint8_t *)&dst[i];
+				for (int32_t ch = 0; ch < 4; ch++)
+					if (ch_map[ch] >= 0)
+						dp[ch] = sp[ch_map[ch]];
+			}
+		} else {
+			// Different sizes — nearest-neighbor resampling
+			int32_t  src_w  = decoded_w[s];
+			int32_t  src_h  = decoded_h[s];
+			int32_t *ch_map = pinfo[s].ch_map;
+			for (int32_t y = 0; y < max_h; y++) {
+				int32_t sy = (y * src_h) / max_h;
+				for (int32_t x = 0; x < max_w; x++) {
+					int32_t  sx = (x * src_w) / max_w;
+					uint8_t *sp = (uint8_t *)&src[sy * src_w + sx];
+					uint8_t *dp = (uint8_t *)&dst[y * max_w + x];
+					for (int32_t ch = 0; ch < 4; ch++)
+						if (ch_map[ch] >= 0)
+							dp[ch] = sp[ch_map[ch]];
+				}
+			}
+		}
+
+		sk_free(decoded[s]);
+		decoded[s] = nullptr;
+	}
+	sk_free(pinfo);
+
+	sk_free(decoded);
+	sk_free(decoded_w);
+	sk_free(decoded_h);
+
+	tex->header.state = asset_state_loaded_meta;
+	return true;
+
+fail:
+	for (int32_t i = 0; i < data->source_count; i++)
+		sk_free(decoded[i]);
+	sk_free(decoded);
+	sk_free(decoded_w);
+	sk_free(decoded_h);
+	sk_free(pinfo);
+	tex_set_fallback(tex, _tex_get_error_fallback(tex));
+	return false;
+}
+
+///////////////////////////////////////////
+
+bool32_t tex_pack_upload(asset_task_t *, asset_header_t *asset, void *job_data) {
+	tex_pack_load_t *data = (tex_pack_load_t *)job_data;
+	tex_t            tex  = (tex_t)asset;
+
+	void *arr[] = { data->packed_data };
+	tex_set_color_arr_mips(tex, data->out_width, data->out_height, arr, 1, 1);
+	return true;
+}
+
+///////////////////////////////////////////
 
 bool tex_load_image_info(void *data, size_t data_size, bool32_t srgb_data, tex_type_* ref_image_type, tex_format_* out_format, int32_t *out_width, int32_t *out_height, int32_t* out_array_count, int32_t* out_mip_count) {
 
@@ -545,6 +775,85 @@ tex_t tex_create_mem_type(tex_type_ type, void *data, size_t data_size, bool32_t
 
 tex_t tex_create_mem(void *data, size_t data_size, bool32_t srgb_data, int32_t priority) {
 	return tex_create_mem_type(tex_type_image, data, data_size, srgb_data, priority);
+}
+
+///////////////////////////////////////////
+
+tex_t tex_create_packed(const tex_pack_source_t *in_arr_sources, int32_t source_count, color128 default_color, bool32_t srgb_data, int32_t priority) {
+	if (source_count < 1 || in_arr_sources == nullptr) {
+		log_warn("tex_create_packed: source_count must be >= 1 and sources must not be null");
+		return nullptr;
+	}
+
+	tex_t result = tex_create(tex_type_image);
+	result->header.state = asset_state_loading;
+
+	tex_pack_load_t *load = sk_malloc_zero_t(tex_pack_load_t, 1);
+	load->source_count    = source_count;
+	load->is_srgb         = srgb_data;
+	load->default_color   = color_to_32(default_color);
+	load->out_format      = srgb_data ? tex_format_rgba32 : tex_format_rgba32_linear;
+	load->source_filenames = sk_malloc_zero_t(char *,       source_count);
+	load->source_data      = sk_malloc_zero_t(void *,       source_count);
+	load->source_sizes     = sk_malloc_zero_t(size_t,       source_count);
+	load->source_maps      = (uint8_t(*)[4])sk_calloc(source_count * 4);
+
+	// Copy source data and extract metadata where possible
+	int32_t max_w = 0, max_h = 0;
+	bool    has_file_sources = false;
+	for (int32_t i = 0; i < source_count; i++) {
+		const tex_pack_source_t *src = &in_arr_sources[i];
+
+		memcpy(load->source_maps[i], src->channel_map, 4);
+
+		if (src->filename != nullptr) {
+			load->source_filenames[i] = string_copy(src->filename);
+			has_file_sources = true;
+		} else if (src->data != nullptr && src->data_size > 0) {
+			load->source_data [i] = sk_malloc(src->data_size);
+			memcpy(load->source_data[i], src->data, src->data_size);
+			load->source_sizes[i] = src->data_size;
+
+			// Extract metadata from memory sources for early
+			// dimension info
+			int32_t     w, h, arr, mip;
+			tex_format_ fmt;
+			tex_type_   type = tex_type_image;
+			if (tex_load_image_info(load->source_data[i], load->source_sizes[i], srgb_data, &type, &fmt, &w, &h, &arr, &mip)) {
+				if (w > max_w) max_w = w;
+				if (h > max_h) max_h = h;
+			}
+		} else {
+			log_warnf("tex_create_packed: source %d has no filename or data", i);
+			tex_pack_load_free(&result->header, load);
+			result->header.state = asset_state_error_unsupported;
+			return result;
+		}
+	}
+
+	// Set metadata early if we know the dimensions (all memory sources)
+	load->out_width  = max_w;
+	load->out_height = max_h;
+	if (!has_file_sources && max_w > 0 && max_h > 0)
+		tex_set_meta(result, max_w, max_h, load->out_format);
+
+	static const asset_load_action_t actions[] = {
+		asset_load_action_t { tex_pack_load_and_merge, asset_thread_asset },
+		asset_load_action_t { tex_pack_upload,         asset_thread_asset },
+	};
+
+	asset_task_t task = {};
+	task.asset        = (asset_header_t *)result;
+	task.free_data    = tex_pack_load_free;
+	task.on_failure   = tex_pack_load_on_failure;
+	task.load_data    = load;
+	task.actions      = (asset_load_action_t *)actions;
+	task.action_count = _countof(actions);
+	task.priority     = priority;
+	task.sort         = asset_sort(priority, max_w * max_h);
+	assets_add_task(task);
+
+	return result;
 }
 
 ///////////////////////////////////////////

--- a/StereoKitC/shaders_builtin/shader_builtin_pbr.hlsl
+++ b/StereoKitC/shaders_builtin/shader_builtin_pbr.hlsl
@@ -9,18 +9,15 @@ float4 tex_trans       = {0,0,1,1};
 float  metallic        = 0;
 float  roughness       = 1;
 
-//--diffuse   = white
-//--emission  = white
-//--metal     = white
-//--occlusion = white
-Texture2D    diffuse     : register(t0);
-SamplerState diffuse_s   : register(s0);
-Texture2D    emission    : register(t1);
-SamplerState emission_s  : register(s1);
-Texture2D    metal       : register(t2);
-SamplerState metal_s     : register(s2);
-Texture2D    occlusion   : register(t3);
-SamplerState occlusion_s : register(s3);
+//--diffuse  = white
+//--emission = white
+//--metal    = white
+Texture2D    diffuse   : register(t0);
+SamplerState diffuse_s : register(s0);
+Texture2D    emission  : register(t1);
+SamplerState emission_s: register(s1);
+Texture2D    metal     : register(t2);
+SamplerState metal_s   : register(s2);
 
 struct vsIn {
 	float4 pos       : SV_Position;
@@ -53,15 +50,11 @@ psIn vs(vsIn input, sk_ids_t ids) {
 }
 
 float4 ps(psIn input) : SV_TARGET {
-	half2 metal_rough = (half2)metal    .Sample(metal_s,     input.uv).gb; // rough is g, b is metallic
-	half  ao          = (half )occlusion.Sample(occlusion_s, input.uv).r;  // occlusion is sometimes part of the metal tex, uses r channel
-	half4 albedo      = (half4)diffuse  .Sample(diffuse_s,   input.uv)     * input.color;
-	half3 emissive    = (half3)emission .Sample(emission_s,  input.uv).rgb * (half3)emission_factor.rgb;
+	half4 albedo   = (half4)diffuse .Sample(diffuse_s,  input.uv) * input.color;
+	half3 orm      = (half3)metal   .Sample(metal_s,    input.uv).rgb; // r=occlusion, g=roughness, b=metallic
+	half3 emissive = (half3)emission.Sample(emission_s, input.uv).rgb;
 
-	half metallic_final = metal_rough.y * (half)metallic;
-	half rough_final    = metal_rough.x * (half)roughness;
-
-	float4 color = sk_pbr_shade(albedo, input.irradiance, ao, metallic_final, rough_final, input.view_dir, input.normal);
-	color.rgb += (float3)emissive;
+	float4 color = sk_pbr_shade(albedo, input.irradiance, orm.r, orm.b * (half)metallic, orm.g * (half)roughness, input.view_dir, input.normal);
+	color.rgb += (float3)(emissive * (half3)emission_factor.rgb);
 	return color;
 }

--- a/StereoKitC/shaders_builtin/shader_builtin_pbr_clip.hlsl
+++ b/StereoKitC/shaders_builtin/shader_builtin_pbr_clip.hlsl
@@ -10,18 +10,15 @@ float  metallic        = 0;
 float  roughness       = 1;
 float  cutoff          = 0.5;
 
-//--diffuse   = white
-//--emission  = white
-//--metal     = white
-//--occlusion = white
-Texture2D    diffuse     : register(t0);
-SamplerState diffuse_s   : register(s0);
-Texture2D    emission    : register(t1);
-SamplerState emission_s  : register(s1);
-Texture2D    metal       : register(t2);
-SamplerState metal_s     : register(s2);
-Texture2D    occlusion   : register(t3);
-SamplerState occlusion_s : register(s3);
+//--diffuse  = white
+//--emission = white
+//--metal    = white
+Texture2D    diffuse   : register(t0);
+SamplerState diffuse_s : register(s0);
+Texture2D    emission  : register(t1);
+SamplerState emission_s: register(s1);
+Texture2D    metal     : register(t2);
+SamplerState metal_s   : register(s2);
 
 struct vsIn {
 	float4 pos       : SV_Position;
@@ -58,14 +55,10 @@ float4 ps(psIn input) : SV_TARGET {
 	if (albedo.a < (half)cutoff) discard;
 	albedo *= input.color;
 
-	half2 metal_rough = (half2)metal    .Sample(metal_s,     input.uv).gb; // rough is g, b is metallic
-	half  ao          = (half )occlusion.Sample(occlusion_s, input.uv).r;  // occlusion is sometimes part of the metal tex, uses r channel
-	half3 emissive    = (half3)emission .Sample(emission_s,  input.uv).rgb * (half3)emission_factor.rgb;
+	half3 orm      = (half3)metal   .Sample(metal_s,    input.uv).rgb; // r=occlusion, g=roughness, b=metallic
+	half3 emissive = (half3)emission.Sample(emission_s, input.uv).rgb;
 
-	half metallic_final = metal_rough.y * (half)metallic;
-	half rough_final    = metal_rough.x * (half)roughness;
-
-	float4 color = sk_pbr_shade(albedo, input.irradiance, ao, metallic_final, rough_final, input.view_dir, input.normal);
-	color.rgb += (float3)emissive;
+	float4 color = sk_pbr_shade(albedo, input.irradiance, orm.r, orm.b * (half)metallic, orm.g * (half)roughness, input.view_dir, input.normal);
+	color.rgb += (float3)(emissive * (half3)emission_factor.rgb);
 	return color;
 }

--- a/StereoKitC/stereokit.h
+++ b/StereoKitC/stereokit.h
@@ -1245,6 +1245,32 @@ typedef enum tex_type_ {
 } tex_type_;
 SK_MakeFlag(tex_type_);
 
+/*Describes a source image for channel packing via
+  `tex_create_packed`. Provide either a filename or in-memory data.
+  The channel_map is a fixed 4-byte array where each position
+  represents an output channel (RGBA), and the value selects which
+  source channel to read: 'R', 'G', 'B', 'A', or 0 to skip. For
+  example, {0,'G','B',0} copies source green to output green and
+  source blue to output blue.*/
+typedef struct tex_pack_source_t {
+	/*File path for the source image, or NULL if providing
+	  in-memory data instead.*/
+	const char  *filename;
+	/*Pointer to encoded image file data (PNG, JPEG, etc.), or
+	  NULL if using a filename instead.*/
+	const void  *data;
+	/*Size of the data buffer in bytes, ignored when using a
+	  filename.*/
+	size_t       data_size;
+	/*A 4-byte channel map. Each position is an output channel
+	  (0=R, 1=G, 2=B, 3=A). The value selects which source
+	  channel to read: 'R', 'G', 'B', 'A', or 0 to skip.
+	  Examples: {'R',0,0,0} copies source R to output R.
+	  {0,0,0,'R'} copies source R to output A. {0,'B','G',0}
+	  swaps green and blue.*/
+	uint8_t      channel_map[4];
+} tex_pack_source_t;
+
 /*How does the shader grab pixels from the texture? Or more
   specifically, how does the shader grab colors between the provided
   pixels? If you'd like an in-depth explanation of these topics, check
@@ -1326,6 +1352,7 @@ SK_API tex_t        tex_create_file         (const char *file_utf8,             
 SK_API tex_t        tex_create_file_arr     (const char **in_arr_files, int32_t file_count, bool32_t srgb_data sk_default(true), int32_t priority sk_default(10));
 SK_API tex_t        tex_create_cubemap_file (const char *cubemap_file_utf8,                 bool32_t srgb_data sk_default(true), int32_t priority sk_default(10));
 SK_API tex_t        tex_create_cubemap_files(const char **in_arr_cube_face_file_xxyyzz,     bool32_t srgb_data sk_default(true), int32_t priority sk_default(10));
+SK_API tex_t        tex_create_packed       (const tex_pack_source_t *in_arr_sources, int32_t source_count, color128 default_color sk_default({}), bool32_t srgb_data sk_default(false), int32_t priority sk_default(10));
 SK_API tex_t        tex_copy                (const tex_t texture, tex_type_ type sk_default(tex_type_image), tex_format_ format sk_default(tex_format_none));
 SK_API bool32_t     tex_gen_mips            (tex_t texture);
 SK_API void         tex_set_id              (tex_t texture, const char *id);


### PR DESCRIPTION
PBR shaders previously used separate texture slots for AO and metal/rough, as GLTF textures for each can and will be separate assets. This change will merge both textures automatically when both are provided, meaning one less texture lookup in the shader, and one less rgba texture in memory for PBR surfaces.

This also adds Tex.FromPacked, allowing textures to be packed together during loading.