### PR TITLE
Depth format fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -276,7 +276,7 @@ if (NOT SK_LOCAL_SK_RENDERER)
   CPMAddPackage(
     NAME sk_renderer
     GITHUB_REPOSITORY StereoKit/sk_renderer
-    GIT_TAG v2026.3.19
+    GIT_TAG v2026.3.26
   )
 else()
   # For building directly with in-progress sk_renderer changes, point this to your

--- a/Examples/StereoKitCTest/demo_envmap.cpp
+++ b/Examples/StereoKitCTest/demo_envmap.cpp
@@ -11,6 +11,7 @@ tex_t envmap_tex = {};
 
 tex_t                 envmap_oldtex   = {};
 spherical_harmonics_t envmap_oldlight = {};
+model_t               model           = {};
 
 ///////////////////////////////////////////
 
@@ -23,11 +24,14 @@ void demo_envmap_init() {
 		render_set_skylight(tex_get_cubemap_lighting(t));
 		render_set_skytex  (t);
 	}, nullptr);
+
+	model = model_create_file("DamagedHelmet.gltf");
 }
 
 ///////////////////////////////////////////
 
 void demo_envmap_update() {
+	model_draw(model, matrix_trs({0,0,-0.5f}, quat_lookat(vec3_zero, -vec3_forward), {0.1f, 0.1f,0.1f}));
 }
 
 ///////////////////////////////////////////

--- a/StereoKitC/asset_types/model_gltf.cpp
+++ b/StereoKitC/asset_types/model_gltf.cpp
@@ -695,13 +695,19 @@ material_t gltf_parsematerial(cgltf_data *data, cgltf_material *material, const 
 		tex = material->pbr_metallic_roughness.metallic_roughness_texture.texture;
 		cgltf_texture *ao_tex = material->occlusion_texture.texture;
 
-		// When both metallic/roughness and occlusion textures are present,
-		// pack them into a single ORM texture to save memory.
-		if (tex != nullptr && ao_tex != nullptr && !is_lightmap && material_has_param(result, "metal", material_param_texture)) {
-			cgltf_image *metal_img = tex   ->has_basisu ? tex   ->basisu_image : tex   ->image;
-			cgltf_image *ao_img    = ao_tex->has_basisu ? ao_tex->basisu_image : ao_tex->image;
+		// Always pack metallic/roughness through the packer to ensure
+		// the R channel has valid AO data. Standard glTF metal/rough
+		// textures have R=0 (unused), which reads as zero occlusion if
+		// loaded directly. The packer's default color fills R=1 (full
+		// occlusion) when no AO source is present.
+		if (tex != nullptr && !is_lightmap && material_has_param(result, "metal", material_param_texture)) {
+			if (material->pbr_metallic_roughness.metallic_roughness_texture.texcoord != 0) gltf_add_warning(warnings, "StereoKit doesn't support loading multiple texture coordinate channels yet.");
+			cgltf_image *metal_img = tex->has_basisu ? tex->basisu_image : tex->image;
+			cgltf_image *ao_img    = ao_tex != nullptr
+				? (ao_tex->has_basisu ? ao_tex->basisu_image : ao_tex->image)
+				: nullptr;
 
-			if (metal_img == ao_img && metal_img != nullptr) {
+			if (ao_img != nullptr && metal_img == ao_img) {
 				// Same underlying image - already ORM packed
 				tex_t parse_tex = gltf_parsetexture(data, tex, filename, false, 13, warnings);
 				if (parse_tex != nullptr) {
@@ -710,46 +716,66 @@ material_t gltf_parsematerial(cgltf_data *data, cgltf_material *material, const 
 					tex_release(parse_tex);
 					ao_handled = true;
 				}
-			} else if (metal_img != nullptr && ao_img != nullptr) {
-				// Different images - pack AO(R) + metal/rough(GB) into
-				// one texture via tex_create_packed
-
-				// Check for a cached packed texture first
-				char metal_id[512], ao_id[512], packed_id[512];
+			} else if (metal_img != nullptr) {
+				// Pack metal/rough (GB) with AO (R) if present,
+				// otherwise default fills R=1 for full occlusion.
+				char packed_id[512];
+				char metal_id[512];
 				gltf_imagename(data, metal_img, filename, metal_id, 512);
-				gltf_imagename(data, ao_img,    filename, ao_id,    512);
-				snprintf(packed_id, sizeof(packed_id), "packed:%s+%s", metal_id, ao_id);
+
+				if (ao_img != nullptr) {
+					char ao_id[512];
+					gltf_imagename(data, ao_img, filename, ao_id, 512);
+					snprintf(packed_id, sizeof(packed_id), "packed:%s+%s", metal_id, ao_id);
+				} else {
+					snprintf(packed_id, sizeof(packed_id), "packed:%s", metal_id);
+				}
 
 				tex_t packed = tex_find(packed_id);
 				if (packed == nullptr) {
-					// Resolve raw image data for both sources
-					void   *metal_data = nullptr, *ao_data = nullptr;
-					size_t  metal_size = 0,        ao_size = 0;
-					char    metal_file[512],       ao_file[512];
+					void  *metal_data = nullptr;
+					size_t metal_size = 0;
+					char   metal_file[512];
+					bool   metal_ok = gltf_resolve_image(data, metal_img, filename, &metal_data, &metal_size, metal_file, 512);
 
-					bool metal_ok = gltf_resolve_image(data, metal_img, filename, &metal_data, &metal_size, metal_file, 512);
-					bool ao_ok    = gltf_resolve_image(data, ao_img,    filename, &ao_data,    &ao_size,    ao_file,    512);
+					int32_t           source_count = 0;
+					tex_pack_source_t sources[2]   = {};
 
-					if (metal_ok && ao_ok) {
-						tex_pack_source_t sources[2] = {};
-						sources[0].data           = ao_data;
-						sources[0].data_size      = ao_size;
-						sources[0].filename       = ao_data    == nullptr ? ao_file    : nullptr;
-						sources[0].channel_map[0] = 'R'; // AO.R -> output.R
-						sources[1].data           = metal_data;
-						sources[1].data_size      = metal_size;
-						sources[1].filename       = metal_data == nullptr ? metal_file : nullptr;
-						sources[1].channel_map[1] = 'G'; // metal.G -> output.G (roughness)
-						sources[1].channel_map[2] = 'B'; // metal.B -> output.B (metallic)
+					// AO source (optional)
+					void  *ao_data = nullptr;
+					size_t ao_size = 0;
+					char   ao_file[512] = {};
+					bool   ao_ok = false;
+					if (ao_img != nullptr) {
+						ao_ok = gltf_resolve_image(data, ao_img, filename, &ao_data, &ao_size, ao_file, 512);
+						if (ao_ok) {
+							sources[source_count].data           = ao_data;
+							sources[source_count].data_size      = ao_size;
+							sources[source_count].filename       = ao_data == nullptr ? ao_file : nullptr;
+							sources[source_count].channel_map[0] = 'R'; // AO.R -> output.R
+							source_count++;
+						}
+					}
 
-						packed = tex_create_packed(sources, 2, { 1,1,0,1 }, false, 13);
+					// Metal/rough source
+					if (metal_ok) {
+						sources[source_count].data           = metal_data;
+						sources[source_count].data_size      = metal_size;
+						sources[source_count].filename       = metal_data == nullptr ? metal_file : nullptr;
+						sources[source_count].channel_map[1] = 'G'; // metal.G -> output.G (roughness)
+						sources[source_count].channel_map[2] = 'B'; // metal.B -> output.B (metallic)
+						source_count++;
+					}
+
+					if (source_count > 0) {
+						packed = tex_create_packed(sources, source_count, { 1,0,0,1 }, false, 13);
 						if (packed != nullptr)
 							tex_set_id(packed, packed_id);
 					}
 
 					// Free any base64-decoded allocations
 					if (metal_img->buffer_view == nullptr) sk_free(metal_data);
-					if (ao_img   ->buffer_view == nullptr) sk_free(ao_data);
+					if (ao_img != nullptr && ao_img->buffer_view == nullptr) sk_free(ao_data);
 				}
 
 				if (packed != nullptr) {
@@ -759,17 +785,6 @@ material_t gltf_parsematerial(cgltf_data *data, cgltf_material *material, const 
 					tex_release(packed);
 					ao_handled = true;
 				}
-			}
-		}
-
-		// Fallback: load metal/rough separately if packing didn't happen
-		if (!ao_handled && tex != nullptr && material_has_param(result, "metal", material_param_texture)) {
-			if (material->pbr_metallic_roughness.metallic_roughness_texture.texcoord != 0) gltf_add_warning(warnings, "StereoKit doesn't support loading multiple texture coordinate channels yet.");
-			tex_t parse_tex = gltf_parsetexture(data, tex, filename, false, 13, warnings);
-			if (parse_tex != nullptr) {
-				tex_set_fallback(parse_tex, sk_default_tex_rough);
-				material_set_texture(result, "metal", parse_tex);
-				tex_release(parse_tex);
 			}
 		}
 

--- a/StereoKitC/asset_types/texture.cpp
+++ b/StereoKitC/asset_types/texture.cpp
@@ -855,7 +855,7 @@ void tex_add_zbuffer(tex_t texture, tex_format_ format) {
 
 	char id[64];
 	assets_unique_name(asset_type_tex, "sk/tex/zbuffer/", id, sizeof(id));
-	texture->depth_buffer = tex_create(tex_type_depth, format);
+	texture->depth_buffer = tex_create(tex_type_zbuffer, format);
 	tex_set_id       (texture->depth_buffer, id);
 	tex_set_color_arr(texture->depth_buffer, texture->width, texture->height, nullptr, texture->gpu_tex.layer_count, skr_tex_get_multisample(&texture->gpu_tex), nullptr);
 	texture->depth_buffer->header.state = asset_state_loaded;
@@ -905,6 +905,7 @@ void tex_set_surface(tex_t texture, void *native_surface, tex_type_ type, int64_
 		skr_tex_external_info_t info = {};
 		info.image         = (VkImage)native_surface;
 		info.format        = skr_tex_fmt_from_native((uint32_t)native_fmt);
+		info.flags         = tex_type_to_skr_flags(type);
 		info.size          = { width, height, 1 };
 		info.sampler       = tex_get_skr_sampler(texture);
 		info.multisample   = multisample;

--- a/StereoKitC/systems/render_pipeline.cpp
+++ b/StereoKitC/systems/render_pipeline.cpp
@@ -64,15 +64,16 @@ void render_pipeline_draw() {
 		render_draw_queue(list, s->view_matrices, s->proj_matrices, 0, s->array_count, s->layer, 0);
 
 		skr_pass_t pass = {};
-		pass.color       = &s->tex->gpu_tex;
-		pass.depth       = depth_tex;
-		pass.resolve     = s->resolve_target;
-		pass.clear       = clear_flags;
-		pass.clear_color = clear_color;
-		pass.clear_depth = 1.0f;
-		pass.viewport    = { 0, 0, (float)width, (float)height };
-		pass.scissor     = { 0, 0, width, height };
-		pass.view_count  = s->array_count;
+		pass.color            = &s->tex->gpu_tex;
+		pass.depth            = depth_tex;
+		pass.resolve          = s->resolve_target;
+		pass.clear            = clear_flags;
+		pass.clear_color      = clear_color;
+		pass.clear_depth      = 1.0f;
+		pass.viewport         = { 0, 0, (float)width, (float)height };
+		pass.scissor          = { 0, 0, width, height };
+		pass.view_count       = s->array_count;
+		pass.views_correlated = s->array_count > 1;
 		render_pass_add_draw(&pass);
 		skr_pass_submit(&pass);
 	}

--- a/StereoKitC/xr_backends/openxr_view.cpp
+++ b/StereoKitC/xr_backends/openxr_view.cpp
@@ -465,7 +465,11 @@ bool openxr_display_swapchain_update(device_display_t *display) {
 
 			for (uint32_t i = 0; i < sc_color->backbuffer_count; i++) {
 				sc_color->textures[i] = tex_create(tex_type_rendertarget, tex_get_tex_format(xr_preferred_color_format));
-				sc_depth->textures[i] = tex_create(tex_type_depth,        tex_get_tex_format(xr_preferred_depth_format));
+				// Use readable depth (tex_type_depth) only when depth composition
+				// is active — the runtime needs to read it. Otherwise use write-only
+				// (tex_type_zbuffer) to avoid storing depth to main memory on tilers.
+				tex_type_ depth_type = xr_ext_composition_depth_available() ? tex_type_depth : tex_type_zbuffer;
+				sc_depth->textures[i] = tex_create(depth_type, tex_get_tex_format(xr_preferred_depth_format));
 
 				char           name[64];
 				static int32_t target_index = 0;
@@ -484,8 +488,9 @@ bool openxr_display_swapchain_update(device_display_t *display) {
 			// called, so we pass owned=false here.
 			void *native_surface_col   = (void*)sc_color->backbuffers[back].image;
 			void *native_surface_depth = (void*)sc_depth->backbuffers[back].image;
+			tex_type_ depth_type = xr_ext_composition_depth_available() ? tex_type_depth : tex_type_zbuffer;
 			tex_set_surface(sc_color->textures[back], native_surface_col,   tex_type_rendertarget, xr_preferred_color_format, sc_color->width, sc_color->height, array_count, 1, false);
-			tex_set_surface(sc_depth->textures[back], native_surface_depth, tex_type_depth,        xr_preferred_depth_format, sc_depth->width, sc_depth->height, array_count, 1, false);
+			tex_set_surface(sc_depth->textures[back], native_surface_depth, depth_type,            xr_preferred_depth_format, sc_depth->width, sc_depth->height, array_count, 1, false);
 			tex_set_zbuffer(sc_color->textures[back], sc_depth->textures[back]);
 		}
 


### PR DESCRIPTION
- Wrong depth texture hint was being used for swapchains
- Newer sk_renderer with barrier and transition optimizations
- Fix for GLTFs with only metal/rough textures
- Update C++ demo with a shiny gltf in the cubemap scene