### PR TITLE
fix: add CMAKE_TOOLCHAIN_FILE pointing to the NDK's android.toolchain

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -322,6 +322,7 @@
       "generator":   "Ninja",
       "cacheVariables": {
         "CMAKE_SYSTEM_NAME":    "Android",
+        "CMAKE_TOOLCHAIN_FILE": "$env{NDK}/build/cmake/android.toolchain.cmake",
         "CMAKE_ANDROID_NDK":    "$env{NDK}",
         "ANDROID_PLATFORM":     "android-32",
         "CMAKE_SYSTEM_VERSION": "32",


### PR DESCRIPTION
When building `develop`, I've been running into an error with CMake's built-in Android support because the `platforms/` directory was removed:

```
 Android: The system root directory needed for the selected Android version and architecture does not exist:
      .../ndk/29.x.x/platforms/android-32/arch-arm64
```

Using the NDK's toolchain file fixes this and is recommended [here](https://developer.android.com/ndk/guides/cmake#toolchain_file)