### PR TITLE
fix: remove SKAssetDestination from AndroidAsset Link

### DIFF
--- a/StereoKit/SKAssets.targets
+++ b/StereoKit/SKAssets.targets
@@ -19,7 +19,7 @@
 		</ItemGroup>
 		<ItemGroup Condition="'$(SKBuildPlatform)'=='Android'">
 			<AndroidAsset Include="%(SKContent.Identity)">
-				<Link>$(SKAssetDestination)/%(SKContent.RecursiveDir)%(SKContent.Filename)%(SKContent.Extension)</Link>
+				<Link>%(SKContent.RecursiveDir)%(SKContent.Filename)%(SKContent.Extension)</Link>
 			</AndroidAsset>
 		</ItemGroup>
 	</Target>


### PR DESCRIPTION
https://github.com/StereoKit/StereoKit/commit/f3ad4f3896ad4c206509cdccfedde5adc9614176#diff-4d9545e822b9f870f3c6897acbcdbf4b51093945cac0fe315ad88facc45e9d73 re-added the AndroidAsset block from https://github.com/StereoKit/StereoKit/commit/84835939fb102dbe60992e24ff9d9c21234b8ee9#diff-4d9545e822b9f870f3c6897acbcdbf4b51093945cac0fe315ad88facc45e9d73 but included `$(SKAssetDestination)` in the Link. This caused Android assets to be placed at `assets/Assets/` in the APK instead of `assets/`, resulting in null refs.

I noticed `assets.cpp` also skips the `assetsFolder` prefix on Android ([ref](https://github.com/StereoKit/StereoKit/blob/7ee84b4fb44511fb2b2424cc68affb666a07efe7/StereoKitC/asset_types/assets.cpp#L418)) - would you rather support `$(SKAssetDestination)` on Android, or is this fix the right approach?