### PR TITLE
Renderer work

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -276,7 +276,7 @@ if (NOT SK_LOCAL_SK_RENDERER)
   CPMAddPackage(
     NAME sk_renderer
     GITHUB_REPOSITORY StereoKit/sk_renderer
-    GIT_TAG v2026.4.21
+    GIT_TAG v2026.5.11
   )
 else()
   # For building directly with in-progress sk_renderer changes, point this to your

--- a/Examples/Assets/texture3d.hlsl
+++ b/Examples/Assets/texture3d.hlsl
@@ -1,0 +1,76 @@
+#include <stereokit.hlsli>
+
+//--name = app/texture3d
+// Raymarches a Texture3D through a unit cube. Used by Test3DTex to
+// validate StereoKit's 3D texture support.
+
+//--world_inv = 1,0,0,0,  0,1,0,0,  0,0,1,0,  0,0,0,1
+float4x4 world_inv;
+
+Texture3D    volume   : register(t0);
+SamplerState volume_s : register(s0);
+
+struct vsIn {
+	float4 pos  : SV_Position;
+	float3 norm : NORMAL0;
+	float2 uv   : TEXCOORD0;
+	float4 col  : COLOR0;
+};
+struct psIn {
+	float4 pos       : SV_POSITION;
+	float3 local_pos : TEXCOORD0;
+	float3 cam_local : TEXCOORD1;
+};
+
+psIn vs(vsIn input, sk_ids_t ids) {
+	psIn o;
+
+	float4 world = mul(input.pos, sk_inst[ids.inst].world);
+	o.pos        = mul(world,     sk_viewproj[ids.view]);
+
+	o.local_pos  = input.pos.xyz;
+	o.cam_local  = mul(float4(sk_camera_pos[ids.view].xyz, 1), world_inv).xyz;
+	return o;
+}
+
+// Ray-AABB slab test. Returns (tmin, tmax) along the ray.
+float2 ray_box_intersect(float3 ray_origin, float3 ray_dir, float3 box_min, float3 box_max) {
+	float3 inv_dir = 1.0 / ray_dir;
+	float3 t0      = (box_min - ray_origin) * inv_dir;
+	float3 t1      = (box_max - ray_origin) * inv_dir;
+	float3 tmin3   = min(t0, t1);
+	float3 tmax3   = max(t0, t1);
+	float  tmin    = max(max(tmin3.x, tmin3.y), tmin3.z);
+	float  tmax    = min(min(tmax3.x, tmax3.y), tmax3.z);
+	return float2(tmin, tmax);
+}
+
+float4 ps(psIn input) : SV_TARGET {
+	// Mesh.Cube is a unit cube spanning ±0.5 in local space.
+	float3 ray_dir = normalize(input.local_pos - input.cam_local);
+	float2 t       = ray_box_intersect(input.cam_local, ray_dir, float3(-0.5,-0.5,-0.5), float3(0.5,0.5,0.5));
+
+	float t_start = max(t.x, 0.0);
+	float t_end   = t.y;
+	if (t_end <= t_start) discard;
+
+	const int   STEPS     = 64;
+	const float step_size = (t_end - t_start) / float(STEPS);
+
+	float4 accum   = float4(0,0,0,0);
+	float3 ray_pos = input.cam_local + ray_dir * t_start;
+
+	for (int i = 0; i < STEPS && accum.a < 0.95; i++) {
+		float3 uvw          = ray_pos + 0.5;
+		float4 sample_color = volume.SampleLevel(volume_s, uvw, 0);
+
+		float  alpha = sample_color.a * step_size * 4.0;
+		accum.rgb   += (1.0 - accum.a) * alpha * sample_color.rgb;
+		accum.a     += (1.0 - accum.a) * alpha;
+
+		ray_pos += ray_dir * step_size;
+	}
+
+	if (accum.a < 0.01) discard;
+	return float4(accum.rgb, accum.a);
+}

--- a/Examples/StereoKitCTest/demo_shadows.cpp
+++ b/Examples/StereoKitCTest/demo_shadows.cpp
@@ -153,7 +153,7 @@ static void setup_shadow_map(vec3 light_direction) {
 
 	// Render to shadow map (filter out VFX layer)
 	render_layer_ layer_filter = (render_layer_)(render_layer_all & ~render_layer_vfx);
-	render_to(shadow_map, 0, view, proj, layer_filter, shadow_map_variant, render_clear_all, rect_t{});
+	render_to(shadow_map, 0, &view, &proj, 1, layer_filter, shadow_map_variant, render_clear_all, rect_t{});
 
 	// Rebind the shadow map for reading
 	render_global_texture(shadow_buffer_slot, shadow_map);

--- a/Examples/StereoKitTest/Tests/Test3DTex.cs
+++ b/Examples/StereoKitTest/Tests/Test3DTex.cs
@@ -1,0 +1,70 @@
+using StereoKit;
+using System.Runtime.InteropServices;
+
+class Test3DTex : ITest
+{
+	const  int     Size = 32;
+	static Vec3    Pos  = V.XYZ(0, 0, -0.5f);
+	static float   Sz   = 0.4f;
+
+	Tex      _volume;
+	Material _material;
+
+	public void Initialize()
+	{
+		_volume = new Tex(TexType.ImageNomips | TexType.Volume, TexFormat.Rgba32);
+
+		// Three colored spheres packed into a 32^3 RGBA8 volume. Solid
+		// inside the radius, fully transparent outside, so the raymarch
+		// has clear opaque blobs to render.
+		Color32[] data = BuildSphereVolume(Size);
+		var handle = GCHandle.Alloc(data, GCHandleType.Pinned);
+		try   { _volume.SetColors(Size, Size, Size, handle.AddrOfPinnedObject()); }
+		finally { handle.Free(); }
+		_volume.AddressMode = TexAddress.Clamp;
+
+		_material = new Material(Shader.FromFile("texture3d.hlsl"));
+		_material.SetTexture("volume", _volume);
+		_material.Transparency = Transparency.Blend;
+
+		// world_inv is the inverse of the cube's TRS, so the shader can
+		// transform the camera into cube-local space for raymarching.
+		// Transpose to match HLSL's column-major matrix packing (same as
+		// TestMatrixShaderParam.cs does for custom_transform).
+		Matrix world = Matrix.TS(Pos, Sz);
+		_material.SetMatrix("world_inv", world.Inverse.Transposed);
+	}
+	public void Shutdown() { }
+
+	public void Step()
+	{
+		Tests.Screenshot("Tests/Texture3D.jpg", 600, 600, 50, V.XYZ(0.4f, 0.3f, -0.05f), Pos);
+		Mesh.Cube.Draw(_material, Matrix.TS(Pos, Sz));
+	}
+
+	static Color32[] BuildSphereVolume(int size)
+	{
+		Color32[] data = new Color32[size*size*size];
+		Vec3[]    centers = { V.XYZ(0.3f, 0.55f, 0.5f), V.XYZ(0.5f, 0.3f, 0.5f), V.XYZ(0.7f, 0.3f, 0.7f) };
+		float[]   radii   = { 0.3f, 0.2f, 0.25f };
+		Color32[] colors  = {
+			new Color32(255,  64,  64, 255), // red
+			new Color32( 64, 255,  64, 255), // green
+			new Color32( 64,  64, 255, 255), // blue
+		};
+
+		for (int z = 0; z < size; z++)
+		for (int y = 0; y < size; y++)
+		for (int x = 0; x < size; x++)
+		{
+			Vec3 p = V.XYZ((x+0.5f)/size, (y+0.5f)/size, (z+0.5f)/size);
+			Color32 c = new Color32(0,0,0,0);
+			for (int i = 0; i < 3; i++)
+			{
+				if (Vec3.Distance(p, centers[i]) < radii[i]) { c = colors[i]; break; }
+			}
+			data[x + y*size + z*size*size] = c;
+		}
+		return data;
+	}
+}

--- a/StereoKit/Assets/Compute.cs
+++ b/StereoKit/Assets/Compute.cs
@@ -205,17 +205,49 @@ namespace StereoKit
 		public bool SetConstant<T>(string name, MaterialBuffer<T> buffer) where T : struct
 			=> NativeAPI.compute_set_constant(_inst, name, buffer?._inst ?? IntPtr.Zero);
 
-		/// <summary>Fire off the compute shader on the GPU! The
-		/// parameters here are the number of thread _groups_, not
-		/// individual threads. The total thread count will be
-		/// groupCount * numthreads (as defined in your HLSL). So if
-		/// your shader says [numthreads(8,8,1)] and you dispatch
-		/// (64,64,1), you'll get 512*512 threads!</summary>
+		/// <summary>Queue this compute dispatch into the render pipeline.
+		/// It will run during the next frame's render setup phase, in
+		/// source order with other queued render actions
+		/// (Renderer.RenderTo, Renderer.SetGlobal*). This is the
+		/// recommended path for compute work that participates in the
+		/// frame's rendering pipeline (e.g. populating a texture that a
+		/// later RenderTo or the main pass will sample), since
+		/// sk_renderer can manage the necessary GPU barriers between
+		/// queued items.
+		///
+		/// IMPORTANT: bindings (textures, buffers, constants, scalar
+		/// parameters) are NOT snapshotted when Dispatch is called —
+		/// they are read at execute time, which happens later in the
+		/// frame. If you change a binding between two queued Dispatch
+		/// calls on the same Compute, both dispatches will see the
+		/// final binding state, not the state at their respective
+		/// Dispatch times. To dispatch the same Compute with different
+		/// bindings, either issue each Dispatch with DispatchNow, or
+		/// use a separate Compute instance per binding set.
+		///
+		/// The parameters are the number of thread _groups_, not
+		/// individual threads. Total thread count = groupCount *
+		/// numthreads (as defined in your HLSL). So if your shader says
+		/// [numthreads(8,8,1)] and you dispatch (64,64,1), you'll get
+		/// 512*512 threads.</summary>
 		/// <param name="groupCountX">Thread groups in X.</param>
 		/// <param name="groupCountY">Thread groups in Y.</param>
 		/// <param name="groupCountZ">Thread groups in Z.</param>
 		public void Dispatch(uint groupCountX, uint groupCountY = 1, uint groupCountZ = 1)
 			=> NativeAPI.compute_dispatch(_inst, groupCountX, groupCountY, groupCountZ);
+
+		/// <summary>Run this compute dispatch synchronously, right now,
+		/// on the calling thread. Use this for ad-hoc work that doesn't
+		/// belong in the per-frame render pipeline (debugging, one-shot
+		/// tasks, immediate readbacks). For compute work that feeds into
+		/// later render passes within the same frame, prefer Dispatch,
+		/// which queues into the pipeline and lets sk_renderer handle
+		/// ordering and barriers automatically.</summary>
+		/// <param name="groupCountX">Thread groups in X.</param>
+		/// <param name="groupCountY">Thread groups in Y.</param>
+		/// <param name="groupCountZ">Thread groups in Z.</param>
+		public void DispatchNow(uint groupCountX, uint groupCountY = 1, uint groupCountZ = 1)
+			=> NativeAPI.compute_dispatch_now(_inst, groupCountX, groupCountY, groupCountZ);
 
 		/// <summary>The number of shader parameters available on this
 		/// Compute! This includes both variables and textures/buffers,

--- a/StereoKit/Assets/RenderList.cs
+++ b/StereoKit/Assets/RenderList.cs
@@ -144,7 +144,7 @@ namespace StereoKit
 		/// across multiple views in a single pass, with one camera +
 		/// projection per view. Each view writes to its corresponding
 		/// layer of the (array) render target. The number of views is
-		/// capped by Renderer.MaxViews.</summary>
+		/// capped at 6.</summary>
 		/// <param name="toRenderTarget">An array or cubemap rendertarget
 		/// with at least `cameras.Length` layers.</param>
 		/// <param name="cameras">View transforms, one per view. Length

--- a/StereoKit/Assets/RenderList.cs
+++ b/StereoKit/Assets/RenderList.cs
@@ -138,7 +138,37 @@ namespace StereoKit
 		/// Material has no corresponding variant, it will not be drawn.
 		/// </param>
 		public void DrawNow(Tex toRenderTarget, Matrix camera, Matrix projection, Color clearColor = default, RenderClear clear = RenderClear.All, Rect viewportPct = default, RenderLayer layerFilter = RenderLayer.All, int materialVariant = 0)
-			=> NativeAPI.render_list_draw_now(_inst, toRenderTarget._inst, camera, projection, clearColor, clear, viewportPct, layerFilter, materialVariant);
+			=> NativeAPI.render_list_draw_now(_inst, toRenderTarget._inst, in camera, in projection, 1, clearColor, clear, viewportPct, layerFilter, materialVariant);
+
+		/// <summary>Multi-view variant of DrawNow. Renders the list once
+		/// across multiple views in a single pass, with one camera +
+		/// projection per view. Each view writes to its corresponding
+		/// layer of the (array) render target. The number of views is
+		/// capped by Renderer.MaxViews.</summary>
+		/// <param name="toRenderTarget">An array or cubemap rendertarget
+		/// with at least `cameras.Length` layers.</param>
+		/// <param name="cameras">View transforms, one per view. Length
+		/// must equal `projections.Length` and cannot exceed
+		/// Renderer.MaxViews.</param>
+		/// <param name="projections">Projection matrices, one per view.
+		/// Same length as `cameras`.</param>
+		/// <param name="clearColor">If `clear` clears color, this is the
+		/// color used. Default is transparent black.</param>
+		/// <param name="clear">Whether and how to clear the rendertarget
+		/// before rendering.</param>
+		/// <param name="viewportPct">Subregion of the rendertarget to draw
+		/// to, in normalized coordinates 0-1. Width of zero draws to the
+		/// entire target.</param>
+		/// <param name="layerFilter">Bit flag controlling which render
+		/// layers are drawn this pass.</param>
+		/// <param name="materialVariant">Which material variant to use.
+		/// 0 is the default; non-zero indexes into Material.Variants.</param>
+		public void DrawNow(Tex toRenderTarget, in Matrix[] cameras, in Matrix[] projections, Color clearColor = default, RenderClear clear = RenderClear.All, Rect viewportPct = default, RenderLayer layerFilter = RenderLayer.All, int materialVariant = 0)
+		{
+			if (cameras.Length != projections.Length)
+				throw new ArgumentException("cameras and projections must have the same length");
+			NativeAPI.render_list_draw_now(_inst, toRenderTarget._inst, cameras, projections, cameras.Length, clearColor, clear, viewportPct, layerFilter, materialVariant);
+		}
 
 		/// <summary>The default RenderList used by the Renderer for the
 		/// primary display surface.</summary>

--- a/StereoKit/Assets/RenderList.cs
+++ b/StereoKit/Assets/RenderList.cs
@@ -7,7 +7,7 @@ namespace StereoKit
 	/// submitted to various surfaces. RenderList.Primary is where all normal
 	/// Draw calls get added to, and this RenderList is renderer to primary
 	/// display surface.
-	/// 
+	///
 	/// Manually working with a RenderList can be useful for "baking down
 	/// matrices" or caching a scene of objects. Or for drawing a separate
 	/// scene to an offscreen surface, like for thumbnails of Models.</summary>
@@ -34,9 +34,14 @@ namespace StereoKit
 		public int PrevCount => NativeAPI.render_list_prev_count(_inst);
 
 		/// <summary>Creates a new empty RenderList.</summary>
-		public RenderList()
+		/// <param name="refs">Controls whether the list tracks asset
+		/// references for the Meshes and Materials added to it. The default,
+		/// `Tracked`, is safe across frames. `None` skips the addref/release
+		/// pair on each add and clear, but the caller must ensure the list
+		/// is cleared before any referenced asset could be released.</param>
+		public RenderList(RenderListRefs refs = RenderListRefs.Tracked)
 		{
-			_inst = NativeAPI.render_list_create();
+			_inst = NativeAPI.render_list_create(refs);
 		}
 		internal RenderList(IntPtr list)
 		{

--- a/StereoKit/Assets/Tex.cs
+++ b/StereoKit/Assets/Tex.cs
@@ -309,6 +309,89 @@ namespace StereoKit
 			}
 			NativeAPI.tex_set_colors(_inst, width, height, data);
 		}
+		/// <summary>Set the texture's pixels for a multi-layer and/or
+		/// mip-mapped texture, using an array of pointers. Each pointer in
+		/// `arrayData` represents one layer (face for cubemaps, slice for array
+		/// textures), and points to a tightly packed block containing all mip
+		/// levels for that layer in the order `[mip0][mip1][mip2]...`. The
+		/// memory layout per mip should match the texture's format. This is the
+		/// raw pointer variant for advanced use cases like uploading
+		/// pre-decoded image data from native code.</summary>
+		/// <param name="width">Width in pixels of mip 0. Powers of two are
+		/// generally best!</param>
+		/// <param name="height">Height in pixels of mip 0. Powers of two are
+		/// generally best!</param>
+		/// <param name="arrayData">An array of `arrayCount` pointers, one per
+		/// layer. Each layer points to packed mip data
+		/// `[mip0][mip1][mip2]...`.</param>
+		/// <param name="mipCount">The number of mip levels packed into each
+		/// layer's data. Use 1 if no mip data is provided beyond the base.
+		/// </param>
+		/// <param name="multisample">Multisample count, only relevant for
+		/// rendertarget textures.</param>
+		public void SetColors(int width, int height, IntPtr[] arrayData, int mipCount, int multisample = 1)
+			=> NativeAPI.tex_set_color_arr_mips(_inst, width, height, arrayData, arrayData.Length, mipCount, multisample, IntPtr.Zero);
+		/// <summary>Set the texture's pixels for a multi-layer and/or
+		/// mip-mapped texture using a jagged color array. Each entry in
+		/// `arrayData` is one layer (face for cubemaps, slice for array
+		/// textures), packed as `[mip0][mip1][mip2]...`. This function should
+		/// only be called on textures with a format of Rgba32 or Rgba32Linear.
+		/// </summary>
+		/// <param name="width">Width in pixels of mip 0. Powers of two are
+		/// generally best!</param>
+		/// <param name="height">Height in pixels of mip 0. Powers of two are
+		/// generally best!</param>
+		/// <param name="arrayData">A jagged array where each `arrayData[layer]`
+		/// contains all mip levels for that layer, packed as
+		/// `[mip0][mip1][mip2]...` with mip 0 sized `width*height`, mip 1
+		/// sized `(width/2)*(height/2)`, and so on.</param>
+		/// <param name="mipCount">The number of mip levels packed into each
+		/// layer's data. Use 1 if no mip data is provided beyond the base.
+		/// </param>
+		/// <param name="multisample">Multisample count, only relevant for
+		/// rendertarget textures.</param>
+		public void SetColors(int width, int height, in Color32[][] arrayData, int mipCount, int multisample = 1)
+		{
+			TexFormat format = Format;
+			if (format != TexFormat.Rgba32 && format != TexFormat.Rgba32Linear)
+			{
+				Log.Err($"Can't set a {format} format texture from Color32 data!");
+				return;
+			}
+			SetColorsPinned(width, height, arrayData, mipCount, multisample);
+		}
+		/// <summary>Set the texture's pixels for a multi-layer and/or
+		/// mip-mapped texture using a jagged byte array. Each entry in
+		/// `arrayData` is one layer (face for cubemaps, slice for array
+		/// textures), packed as `[mip0][mip1][mip2]...`. The byte layout per
+		/// mip should match the texture's format.</summary>
+		/// <param name="width">Width in pixels of mip 0. Powers of two are
+		/// generally best!</param>
+		/// <param name="height">Height in pixels of mip 0. Powers of two are
+		/// generally best!</param>
+		/// <param name="arrayData">A jagged array where each `arrayData[layer]`
+		/// contains all mip levels for that layer as bytes, packed as
+		/// `[mip0][mip1][mip2]...`.</param>
+		/// <param name="mipCount">The number of mip levels packed into each
+		/// layer's data. Use 1 if no mip data is provided beyond the base.
+		/// </param>
+		/// <param name="multisample">Multisample count, only relevant for
+		/// rendertarget textures.</param>
+		public void SetColors(int width, int height, in byte[][] arrayData, int mipCount, int multisample = 1)
+			=> SetColorsPinned(width, height, arrayData, mipCount, multisample);
+
+		void SetColorsPinned<T>(int width, int height, T[][] arrayData, int mipCount, int multisample) where T : struct
+		{
+			GCHandle[] handles = new GCHandle[arrayData.Length];
+			IntPtr  [] ptrs    = new IntPtr  [arrayData.Length];
+			for (int i = 0; i < arrayData.Length; i++)
+			{
+				handles[i] = GCHandle.Alloc(arrayData[i], GCHandleType.Pinned);
+				ptrs   [i] = handles[i].AddrOfPinnedObject();
+			}
+			NativeAPI.tex_set_color_arr_mips(_inst, width, height, ptrs, arrayData.Length, mipCount, multisample, IntPtr.Zero);
+			for (int i = 0; i < handles.Length; i++) handles[i].Free();
+		}
 
 		/// <summary>Loads an image file stored in memory directly into
 		/// the created texture! Supported formats are: jpg, png, tga,

--- a/StereoKit/Assets/Tex.cs
+++ b/StereoKit/Assets/Tex.cs
@@ -32,6 +32,11 @@ namespace StereoKit
 		/// <summary> The height of the texture, in pixels. This will be a
 		/// blocking call if AssetState is less than LoadedMeta. </summary>
 		public int Height => NativeAPI.tex_get_height(_inst);
+		/// <summary> The depth of the texture, in pixels. Only meaningful
+		/// for 3D (volume) textures created with TexType.Volume — for 2D,
+		/// array, and cubemap textures this is 1. This will be a blocking
+		/// call if AssetState is less than LoadedMeta. </summary>
+		public int Depth => NativeAPI.tex_get_depth(_inst);
 		/// <summary>The number of mip-map levels this texture has. This will
 		/// be 1 if the texture doesn't have mip mapping enabled. This will be
 		/// a blocking call if AssetState is less than LoadedMeta.</summary>
@@ -201,6 +206,31 @@ namespace StereoKit
 		/// constructing the texture!</param>
 		public void SetColors(int width, int height, IntPtr data)
 			=> NativeAPI.tex_set_colors(_inst, width, height, data);
+		/// <summary>Set the contents of a 3D (volume) texture from a
+		/// contiguous block of memory. The texture must be created with
+		/// TexType.Volume. Pass IntPtr.Zero to allocate an empty volume
+		/// (e.g. for use as a compute UAV). Slice-major layout: all of
+		/// slice 0, then slice 1, etc., each slice being width*height
+		/// pixels of the texture's format.</summary>
+		/// <param name="width">Width in pixels.</param>
+		/// <param name="height">Height in pixels.</param>
+		/// <param name="depth">Depth in pixels (number of slices).</param>
+		/// <param name="data">A pointer to width*height*depth pixels of
+		/// the texture's format, or IntPtr.Zero to allocate an empty
+		/// volume.</param>
+		public void SetColors(int width, int height, int depth, IntPtr data)
+			=> NativeAPI.tex_set_colors_3d(_inst, width, height, depth, data);
+		/// <summary>Set the contents of a 3D (volume) texture from a byte
+		/// array. The texture must be created with TexType.Volume and a
+		/// single-channel format such as R8. Slice-major layout: all of
+		/// slice 0, then slice 1, etc., each slice being width*height
+		/// bytes.</summary>
+		/// <param name="width">Width in pixels.</param>
+		/// <param name="height">Height in pixels.</param>
+		/// <param name="depth">Depth in pixels (number of slices).</param>
+		/// <param name="data">An array of width*height*depth bytes.</param>
+		public void SetColors(int width, int height, int depth, in byte[] data)
+			=> NativeAPI.tex_set_colors_3d(_inst, width, height, depth, data);
 		/// <summary>Set the texture's pixels using a color array! This
 		/// function should only be called on textures with a format of
 		/// Rgba32 or Rgba32Linear. You can call this as many times as you'd

--- a/StereoKit/Native/NativeAPI.Custom.cs
+++ b/StereoKit/Native/NativeAPI.Custom.cs
@@ -67,6 +67,13 @@ namespace StereoKit
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)]
 		public static extern void tex_set_colors_3d(IntPtr texture, int width, int height, int depth, [In] byte[] data);
 
+		// render_list_draw_now single-matrix overload — passes one camera +
+		// projection by reference (ABI-equivalent to a 1-element array
+		// pointer) so the common single-view call path doesn't have to
+		// allocate a temporary array.
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)]
+		public static extern void render_list_draw_now(IntPtr list, IntPtr to_rendertarget, in Matrix in_arr_cameras, in Matrix in_arr_projections, int view_count, Color clear_color, RenderClear clear, Rect viewport_pct, RenderLayer layer_filter, int material_variant);
+
 		// tex_create_mem with byte array
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)]
 		public static extern IntPtr tex_create_mem([In] byte[] data, UIntPtr data_size, [MarshalAs(UnmanagedType.Bool)] bool srgb_data, int priority);

--- a/StereoKit/Native/NativeAPI.Custom.cs
+++ b/StereoKit/Native/NativeAPI.Custom.cs
@@ -74,6 +74,12 @@ namespace StereoKit
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)]
 		public static extern void render_list_draw_now(IntPtr list, IntPtr to_rendertarget, in Matrix in_arr_cameras, in Matrix in_arr_projections, int view_count, Color clear_color, RenderClear clear, Rect viewport_pct, RenderLayer layer_filter, int material_variant);
 
+		// render_to single-matrix overload — same trick as
+		// render_list_draw_now above. Lets the single-view RenderTo
+		// path avoid a temporary array allocation.
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)]
+		public static extern void render_to(IntPtr to_rendertarget, int to_target_index, in Matrix in_arr_cameras, in Matrix in_arr_projections, int view_count, RenderLayer layer_filter, int material_variant, RenderClear clear, Rect viewport);
+
 		// tex_create_mem with byte array
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)]
 		public static extern IntPtr tex_create_mem([In] byte[] data, UIntPtr data_size, [MarshalAs(UnmanagedType.Bool)] bool srgb_data, int priority);

--- a/StereoKit/Native/NativeAPI.Custom.cs
+++ b/StereoKit/Native/NativeAPI.Custom.cs
@@ -83,6 +83,10 @@ namespace StereoKit
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)]
 		public static extern void tex_set_color_arr_mips(IntPtr texture, int width, int height, IntPtr array_data, int array_count, int mip_count, int multisample, IntPtr out_sh_lighting_info);
 
+		// tex_set_color_arr_mips overload accepting an array of per-layer pointers
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)]
+		public static extern void tex_set_color_arr_mips(IntPtr texture, int width, int height, [In] IntPtr[] array_data, int array_count, int mip_count, int multisample, IntPtr out_sh_lighting_info);
+
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)]
 		public static extern IntPtr tex_gen_cubemap(IntPtr gradient, Vec3 gradient_dir, int resolution, IntPtr out_sh_lighting_info);
 

--- a/StereoKit/Native/NativeAPI.Custom.cs
+++ b/StereoKit/Native/NativeAPI.Custom.cs
@@ -63,6 +63,10 @@ namespace StereoKit
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)]
 		public static extern void tex_set_colors(IntPtr texture, int width, int height, [In] float[] data);
 
+		// tex_set_colors_3d overload for byte[] (single-channel volumes, SDFs, etc.)
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)]
+		public static extern void tex_set_colors_3d(IntPtr texture, int width, int height, int depth, [In] byte[] data);
+
 		// tex_create_mem with byte array
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)]
 		public static extern IntPtr tex_create_mem([In] byte[] data, UIntPtr data_size, [MarshalAs(UnmanagedType.Bool)] bool srgb_data, int priority);

--- a/StereoKit/Native/NativeAPI.cs
+++ b/StereoKit/Native/NativeAPI.cs
@@ -651,7 +651,7 @@ namespace StereoKit
 		///////////////////////////////////////////
 
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr       render_list_find([MarshalAs(UnmanagedType.LPUTF8Str)] string id);
-		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr       render_list_create();
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr       render_list_create(RenderListRefs refs);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         render_list_set_id(IntPtr list, [MarshalAs(UnmanagedType.LPUTF8Str)] string id);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr       render_list_get_id(IntPtr list);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         render_list_addref(IntPtr list);

--- a/StereoKit/Native/NativeAPI.cs
+++ b/StereoKit/Native/NativeAPI.cs
@@ -460,6 +460,7 @@ namespace StereoKit
 		[return: MarshalAs(UnmanagedType.Bool)]
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern bool         compute_set_constant(IntPtr compute, [MarshalAs(UnmanagedType.LPUTF8Str)] string name, IntPtr buffer);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         compute_dispatch(IntPtr compute, uint group_count_x, uint group_count_y, uint group_count_z);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         compute_dispatch_now(IntPtr compute, uint group_count_x, uint group_count_y, uint group_count_z);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern int          compute_get_param_count(IntPtr compute);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         compute_get_param_info(IntPtr compute, int index, out IntPtr out_name, out MaterialParam out_type);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         compute_addref(IntPtr compute);
@@ -646,7 +647,7 @@ namespace StereoKit
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         render_screenshot([MarshalAs(UnmanagedType.LPUTF8Str)] string file_utf8, int file_quality_100, Pose viewpoint, int width, int height, float field_of_view_degrees);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         render_screenshot_capture([MarshalAs(UnmanagedType.FunctionPtr)] RenderOnScreenshotCallback render_on_screenshot_callback, Pose viewpoint, int width, int height, float field_of_view_degrees, TexFormat tex_format, IntPtr context);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         render_screenshot_viewpoint([MarshalAs(UnmanagedType.FunctionPtr)] RenderOnScreenshotCallback render_on_screenshot_callback, Matrix camera, Matrix projection, int width, int height, RenderLayer layer_filter, RenderClear clear, Rect viewport, TexFormat tex_format, IntPtr context);
-		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         render_to(IntPtr to_rendertarget, int to_target_index, in Matrix camera, in Matrix projection, RenderLayer layer_filter, int material_variant, RenderClear clear, Rect viewport);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         render_to(IntPtr to_rendertarget, int to_target_index, [In] Matrix[] in_arr_cameras, [In] Matrix[] in_arr_projections, int view_count, RenderLayer layer_filter, int material_variant, RenderClear clear, Rect viewport);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         render_get_device(IntPtr device, IntPtr context);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr       render_get_primary_list();
 

--- a/StereoKit/Native/NativeAPI.cs
+++ b/StereoKit/Native/NativeAPI.cs
@@ -280,6 +280,7 @@ namespace StereoKit
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         tex_set_colors(IntPtr texture, int width, int height, IntPtr data);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         tex_set_color_arr(IntPtr texture, int width, int height, IntPtr array_data, int array_count, int multisample, out SphericalHarmonics out_sh_lighting_info);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         tex_set_color_arr_mips(IntPtr texture, int width, int height, IntPtr array_data, int array_count, int mip_count, int multisample, out SphericalHarmonics out_sh_lighting_info);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         tex_set_colors_3d(IntPtr texture, int width, int height, int depth, IntPtr data);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         tex_set_mem(IntPtr texture, IntPtr data, UIntPtr data_size, [MarshalAs(UnmanagedType.Bool)] bool srgb_data, [MarshalAs(UnmanagedType.Bool)] bool blocking, int priority);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         tex_add_zbuffer(IntPtr texture, TexFormat format);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         tex_set_zbuffer(IntPtr texture, IntPtr depth_texture);
@@ -292,6 +293,7 @@ namespace StereoKit
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern TexFormat    tex_get_format(IntPtr texture);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern int          tex_get_width(IntPtr texture);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern int          tex_get_height(IntPtr texture);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern int          tex_get_depth(IntPtr texture);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         tex_set_sample(IntPtr texture, TexSample sample);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern TexSample    tex_get_sample(IntPtr texture);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         tex_set_sample_comp(IntPtr texture, TexSampleComp compare);

--- a/StereoKit/Native/NativeAPI.cs
+++ b/StereoKit/Native/NativeAPI.cs
@@ -664,7 +664,7 @@ namespace StereoKit
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         render_list_add_mesh(IntPtr list, IntPtr mesh, IntPtr material, Matrix world_transform, Color color_linear, RenderLayer layer);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         render_list_add_model(IntPtr list, IntPtr model, Matrix world_transform, Color color_linear, RenderLayer layer);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         render_list_add_model_mat(IntPtr list, IntPtr model, IntPtr material_override, Matrix world_transform, Color color_linear, RenderLayer layer);
-		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         render_list_draw_now(IntPtr list, IntPtr to_rendertarget, Matrix camera, Matrix projection, Color clear_color, RenderClear clear, Rect viewport_pct, RenderLayer layer_filter, int material_variant);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         render_list_draw_now(IntPtr list, IntPtr to_rendertarget, [In] Matrix[] in_arr_cameras, [In] Matrix[] in_arr_projections, int view_count, Color clear_color, RenderClear clear, Rect viewport_pct, RenderLayer layer_filter, int material_variant);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         render_list_push(IntPtr list);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         render_list_pop();
 

--- a/StereoKit/Native/NativeEnums.cs
+++ b/StereoKit/Native/NativeEnums.cs
@@ -681,6 +681,10 @@ namespace StereoKit
 		/// Create it with a format that supports storage images, such as
 		/// tex_format_rgba128.</summary>
 		Compute      = 1 << 7,
+		/// <summary>A volumetric (3D) texture, sized with width, height, and depth.
+		/// Volume textures are mutually exclusive with Cubemap and array
+		/// textures, and don't pair with a zbuffer.</summary>
+		Volume       = 1 << 8,
 		/// <summary>A standard color image that also generates mip-maps
 		/// automatically.</summary>
 		Image        = ImageNomips | Mips,

--- a/StereoKit/Native/NativeEnums.cs
+++ b/StereoKit/Native/NativeEnums.cs
@@ -1079,6 +1079,21 @@ namespace StereoKit
 		Ortho        = 1,
 	}
 
+	/// <summary>Controls whether a RenderList holds asset references for the items it
+	/// contains. Tracked lists are safe to keep around across frames at the cost
+	/// of an addref/releaseref pair per item.</summary>
+	public enum RenderListRefs {
+		/// <summary>The list calls addref on each item's mesh/material when added, and
+		/// releaseref when cleared. This keeps assets alive for as long as the
+		/// list holds them, and is the safe default.</summary>
+		Tracked      = 0,
+		/// <summary>The list does not addref or releaseref its items. The caller is
+		/// responsible for ensuring referenced assets remain valid until the
+		/// list is cleared. Useful for per-frame lists that are filled and
+		/// drained inside a single frame.</summary>
+		None         = 1,
+	}
+
 	/// <summary>When used with a hierarchy modifying function that will push/pop items onto a
 	/// stack, this can be used to change the behavior of how parent hierarchy items
 	/// will affect the item being added to the top of the stack.</summary>

--- a/StereoKit/Systems/Renderer.cs
+++ b/StereoKit/Systems/Renderer.cs
@@ -485,13 +485,36 @@ namespace StereoKit
 		/// If the width of this value is zero, then this will render to the
 		/// entire texture.</param>
 		public static void RenderTo(Tex toRendertarget, Matrix camera, Matrix projection, RenderLayer layerFilter = RenderLayer.All, int materialVariant = 0, RenderClear clear = RenderClear.All, Rect viewport = default(Rect))
-			=> NativeAPI.render_to(toRendertarget._inst, 0, camera, projection, layerFilter, materialVariant, clear, viewport);
+			=> NativeAPI.render_to(toRendertarget._inst, 0, in camera, in projection, 1, layerFilter, materialVariant, clear, viewport);
 
 		/// <inheritdoc cref="RenderTo(Tex, Matrix, Matrix, RenderLayer, int, RenderClear, Rect)"/>
 		/// <param name="toTargetIndex">Index of the render target's array
 		/// texture we want to draw to.</param>
 		public static void RenderTo(Tex toRendertarget, int toTargetIndex, Matrix camera, Matrix projection, RenderLayer layerFilter = RenderLayer.All, int materialVariant = 0, RenderClear clear = RenderClear.All, Rect viewport = default(Rect))
-			=> NativeAPI.render_to(toRendertarget._inst, toTargetIndex, camera, projection, layerFilter, materialVariant, clear, viewport);
+			=> NativeAPI.render_to(toRendertarget._inst, toTargetIndex, in camera, in projection, 1, layerFilter, materialVariant, clear, viewport);
+
+		/// <summary>Multi-view variant of RenderTo. Queues a single render
+		/// pass that draws the active list into N views at once, with one
+		/// camera + projection per view, writing into N consecutive layers
+		/// of an array rendertarget. The number of views is capped by the
+		/// engine's max-views constant. Like the single-view RenderTo,
+		/// this is queued for the next pipeline frame.</summary>
+		/// <param name="toRendertarget">An array or cubemap rendertarget
+		/// with at least `cameras.Length` layers.</param>
+		/// <param name="cameras">View transforms, one per view.</param>
+		/// <param name="projections">Projection matrices, one per view.
+		/// Length must match `cameras`.</param>
+		/// <param name="layerFilter">Bit flag for which render layers to
+		/// include this pass.</param>
+		/// <param name="materialVariant">Which material variant to use.</param>
+		/// <param name="clear">Whether and how to clear the rendertarget.</param>
+		/// <param name="viewport">Subregion in normalized 0-1 coordinates.</param>
+		public static void RenderTo(Tex toRendertarget, in Matrix[] cameras, in Matrix[] projections, RenderLayer layerFilter = RenderLayer.All, int materialVariant = 0, RenderClear clear = RenderClear.All, Rect viewport = default(Rect))
+		{
+			if (cameras.Length != projections.Length)
+				throw new ArgumentException("cameras and projections must have the same length");
+			NativeAPI.render_to(toRendertarget._inst, 0, cameras, projections, cameras.Length, layerFilter, materialVariant, clear, viewport);
+		}
 
 		/// <summary>This attaches a texture resource globally across all
 		/// shaders. StereoKit uses this to attach the sky cubemap for use in

--- a/StereoKitC/asset_types/compute.cpp
+++ b/StereoKitC/asset_types/compute.cpp
@@ -7,6 +7,7 @@
 #include "shader.h"
 #include "texture.h"
 #include "assets.h"
+#include "../systems/render.h"
 
 namespace sk {
 
@@ -291,6 +292,12 @@ bool32_t compute_set_constant(compute_t compute, const char *name, material_buff
 ///////////////////////////////////////////
 
 void compute_dispatch(compute_t compute, uint32_t group_count_x, uint32_t group_count_y, uint32_t group_count_z) {
+	render_queue_compute(compute, group_count_x, group_count_y, group_count_z);
+}
+
+///////////////////////////////////////////
+
+void compute_dispatch_now(compute_t compute, uint32_t group_count_x, uint32_t group_count_y, uint32_t group_count_z) {
 	// Resolve texture fallbacks at dispatch time so that textures
 	// that finish loading between set and dispatch use the correct
 	// data instead of a stale fallback.

--- a/StereoKitC/asset_types/material.cpp
+++ b/StereoKitC/asset_types/material.cpp
@@ -1066,9 +1066,12 @@ void material_check_dirty(material_t material) {
 			// Update sk_renderer texture binding
 			skr_material_set_tex(&material->gpu_mat, meta->resources[i].name, &physical_tex->gpu_tex);
 
-			// Update the _i info param with texture dimensions
+			// Update the _i info param with texture dimensions. The third
+			// component is the highest mip index — read it from the actual
+			// GPU texture, not log2(width), so partial mip chains don't lie
+			// to the shader.
 			id_hash_t tex_info_hash = hash_string_with("_i", meta->resources[i].name_hash);
-			vec4      info          = { (float)physical_tex->width, (float)physical_tex->height, (float)(uint32_t)log2(physical_tex->width), 0 };
+			vec4      info          = { (float)physical_tex->width, (float)physical_tex->height, physical_tex->gpu_tex.mip_levels > 0 ? (float)(physical_tex->gpu_tex.mip_levels - 1) : 0, 0 };
 			material_set_param_id(material, tex_info_hash, material_param_vector4, &info);
 		}
 	}

--- a/StereoKitC/asset_types/texture.cpp
+++ b/StereoKitC/asset_types/texture.cpp
@@ -807,17 +807,32 @@ tex_t tex_create_cubemap_files(const char **cube_face_file_xxyyzz, bool32_t srgb
 tex_t tex_copy(const tex_t texture, tex_type_ type, tex_format_ format) {
 	profiler_zone();
 
-	skr_vec3i_t tex_size = { texture->width, texture->height, 1 };
-	tex_t       result   = tex_create(type, format == tex_format_none ? texture->format : format);
-	tex_set_color_arr_mips(result, texture->width, texture->height, nullptr, 1, skr_tex_calc_mip_count(tex_size));
+	int32_t src_mip_count = (int32_t)texture->gpu_tex.mip_levels;
+	bool    wants_mips    = (type & tex_type_mips) > 0;
+	bool    has_mips      = src_mip_count > 1;
 
-	bool wants_mips    = (type          & tex_type_mips) > 0;
-	bool has_mips      = (texture->type & tex_type_mips) > 0;
-	bool generate_mips = has_mips == false && wants_mips == true;
+	// Destination mip count:
+	//  - dest doesn't want mips           → 1 mip
+	//  - dest wants mips, source has them → match the source (preserves a
+	//                                       partial chain instead of leaving
+	//                                       the tail uninitialized)
+	//  - dest wants mips, source has none → full chain (generated below)
+	int32_t dest_mip_count;
+	if      (!wants_mips) dest_mip_count = 1;
+	else if (has_mips)    dest_mip_count = src_mip_count;
+	else                  dest_mip_count = skr_tex_calc_mip_count({ texture->width, texture->height, 1 });
 
-	// Copy base mip (and generate remaining mips if needed)
-	skr_tex_copy(&texture->gpu_tex, &result->gpu_tex, 0, 0, 0, 0, texture->gpu_tex.layer_count);
-	if (generate_mips) {
+	tex_t result = tex_create(type, format == tex_format_none ? texture->format : format);
+	tex_set_color_arr_mips(result, texture->width, texture->height, nullptr, 1, dest_mip_count);
+
+	// skr_tex_copy is one-mip-per-call; copy each level the source actually
+	// has. If the source has no mips but the destination wants them, fall
+	// through to skr_tex_generate_mips after the base copy.
+	int32_t copy_count = (has_mips && wants_mips) ? src_mip_count : 1;
+	for (int32_t m = 0; m < copy_count; m++) {
+		skr_tex_copy(&texture->gpu_tex, &result->gpu_tex, m, 0, m, 0, texture->gpu_tex.layer_count);
+	}
+	if (wants_mips && !has_mips) {
 		skr_tex_generate_mips(&result->gpu_tex, nullptr);
 	}
 	return result;
@@ -1046,7 +1061,7 @@ void tex_compute_sh(tex_t texture, bool end_cmd) {
 	profiler_zone();
 
 	skr_vec3i_t base_size = { texture->width, texture->height, 1 };
-	int32_t     mip_count = skr_tex_calc_mip_count(base_size);
+	int32_t     mip_count = (int32_t)texture->gpu_tex.mip_levels;
 	int32_t     mip_level = maxi(0, mip_count - 6);
 	skr_vec3i_t mip_size  = skr_tex_calc_mip_dimensions(base_size, mip_level);
 
@@ -1141,8 +1156,12 @@ void _tex_set_color_arr(tex_t texture, int32_t width, int32_t height, void **arr
 		if (is_array) flags = (skr_tex_flags_)(flags | skr_tex_flags_array);
 		skr_vec3i_t size = { width, height, is_array ? array_count : 1 };
 
-		// Determine mip count for creation
-		int32_t create_mip_count = (texture->type & tex_type_mips) ? 0 : mip_count; // 0 = auto-calculate
+		// Determine mip count for creation. If the caller asked for mips but only
+		// supplied the base level, pass 0 to request a full auto-generated chain
+		// (filled in below by skr_tex_generate_mips). If the caller supplied
+		// multiple mips, cap the GPU texture at that count so we don't leave
+		// uninitialized levels above what was uploaded.
+		int32_t create_mip_count = ((texture->type & tex_type_mips) && mip_count <= 1) ? 0 : mip_count;
 
 		// Create new texture into a temporary first
 		skr_tex_t new_tex;
@@ -1433,8 +1452,12 @@ int32_t tex_get_anisotropy(tex_t texture) {
 ///////////////////////////////////////////
 
 int32_t tex_get_mips(tex_t texture) {
-	return (texture->type & tex_type_mips)
-		? skr_tex_calc_mip_count(texture->gpu_tex.size)
+	// Return the actual stored mip count rather than recomputing from
+	// dimensions. The two can differ: tex_type_mips just signals intent, but
+	// the caller may have supplied a partial chain (KTX2 truncated mip set,
+	// etc.), in which case gpu_tex.mip_levels is the truth.
+	return texture->gpu_tex.mip_levels > 0
+		? (int32_t)texture->gpu_tex.mip_levels
 		: 1;
 }
 

--- a/StereoKitC/asset_types/texture.cpp
+++ b/StereoKitC/asset_types/texture.cpp
@@ -52,17 +52,19 @@ tex_t tex_error_texture           = nullptr;
 tex_t tex_loading_texture         = nullptr;
 tex_t tex_error_texture_cubemap   = nullptr;
 tex_t tex_loading_texture_cubemap = nullptr;
+tex_t tex_error_texture_3d        = nullptr;
+tex_t tex_loading_texture_3d      = nullptr;
 
 tex_t _tex_get_loading_fallback(tex_t texture) {
-	return (texture->type & tex_type_cubemap)
-		? tex_loading_texture_cubemap
-		: tex_loading_texture;
+	if (texture->type & tex_type_volume)  return tex_loading_texture_3d;
+	if (texture->type & tex_type_cubemap) return tex_loading_texture_cubemap;
+	return tex_loading_texture;
 }
 
 tex_t _tex_get_error_fallback(tex_t texture) {
-	return (texture->type & tex_type_cubemap)
-		? tex_error_texture_cubemap
-		: tex_error_texture;
+	if (texture->type & tex_type_volume)  return tex_error_texture_3d;
+	if (texture->type & tex_type_cubemap) return tex_error_texture_cubemap;
+	return tex_error_texture;
 }
 
 ///////////////////////////////////////////
@@ -91,6 +93,7 @@ skr_tex_flags_ tex_type_to_skr_flags(tex_type_ type) {
 	if (type & tex_type_rendertarget) flags = (skr_tex_flags_)(flags | skr_tex_flags_writeable);
 	if (type & tex_type_depthtarget)  flags = (skr_tex_flags_)(flags | skr_tex_flags_writeable); // Readable depth (shadow maps)
 	if (type & tex_type_compute)      flags = (skr_tex_flags_)(flags | skr_tex_flags_compute);
+	if (type & tex_type_volume)       flags = (skr_tex_flags_)(flags | skr_tex_flags_3d);
 	return flags;
 }
 
@@ -249,7 +252,7 @@ bool32_t tex_load_arr_files(asset_task_t *task, asset_header_t *asset, void *job
 	tex_load_t* data = (tex_load_t*)job_data;
 	tex_t       tex  = (tex_t)asset;
 
-	tex_set_meta(tex, data->color_width, data->color_height, data->color_format);
+	tex_set_meta(tex, data->color_width, data->color_height, 1, data->color_format);
 	return true;
 }
 
@@ -530,7 +533,7 @@ tex_t tex_create_mem_type(tex_type_ type, void *data, size_t data_size, bool32_t
 		result->header.state = asset_state_error_unsupported;
 		return result;
 	}
-	tex_set_meta(result, load_data->color_width, load_data->color_height, format);
+	tex_set_meta(result, load_data->color_width, load_data->color_height, 1, format);
 
 	static const asset_load_action_t actions[] = {
 		asset_load_action_t {tex_load_arr_parse,  asset_thread_asset},
@@ -698,7 +701,7 @@ tex_t tex_create_cubemap_file(const char *cubemap_file, bool32_t srgb_data, int3
 			return (bool32_t)false;
 		}
 
-		tex_set_meta(tex, size_w, size_h, data->color_format);
+		tex_set_meta(tex, size_w, size_h, 1, data->color_format);
 		return (bool32_t)true;
 	};
 
@@ -739,7 +742,7 @@ tex_t tex_create_cubemap_file(const char *cubemap_file, bool32_t srgb_data, int3
 			tex->header.state = asset_state_error;
 			return (bool32_t)false;
 		}
-		tex_set_meta(tex, tex->width, tex->height, tex->format);
+		tex_set_meta(tex, tex->width, tex->height, 1, tex->format);
 		tex_update_label(tex);
 
 		shader_t convert_shader = shader_find(default_id_shader_equirect);
@@ -1096,6 +1099,11 @@ void tex_compute_sh(tex_t texture, bool end_cmd) {
 void _tex_set_color_arr(tex_t texture, int32_t width, int32_t height, void **array_data, int32_t array_count, int32_t mip_count, spherical_harmonics_t *sh_lighting_info, int32_t multisample) {
 	profiler_zone();
 
+	if (texture->type & tex_type_volume) {
+		log_warn("Use tex_set_colors_3d for volume textures, not tex_set_color_arr.");
+		return;
+	}
+
 	bool dynamic        = texture->type & tex_type_dynamic;
 	bool different_size = texture->width != width || texture->height != height || (int32_t)texture->gpu_tex.layer_count != array_count;
 	if (!different_size && (array_data == nullptr || *array_data == nullptr))
@@ -1191,7 +1199,7 @@ void _tex_set_color_arr(tex_t texture, int32_t width, int32_t height, void **arr
 			skr_tex_generate_mips(&texture->gpu_tex, nullptr);
 		}
 
-		tex_set_meta(texture, width, height, texture->format);
+		tex_set_meta(texture, width, height, 1, texture->format);
 
 		if (texture->depth_buffer != nullptr) {
 			tex_set_color_arr(texture->depth_buffer, width, height, nullptr, texture->gpu_tex.layer_count, multisample, nullptr);
@@ -1287,7 +1295,7 @@ void tex_set_mem(tex_t texture, void* data, size_t data_size, bool32_t srgb_data
 		texture->header.state = asset_state_error_unsupported;
 		return;
 	}
-	tex_set_meta(texture, load_data->color_width, load_data->color_height, format);
+	tex_set_meta(texture, load_data->color_width, load_data->color_height, 1, format);
 
 	static const asset_load_action_t actions[] = {
 		asset_load_action_t {tex_load_arr_parse,  asset_thread_asset},
@@ -1322,6 +1330,113 @@ spherical_harmonics_t tex_get_cubemap_lighting(tex_t cubemap_texture) {
 void tex_set_colors(tex_t texture, int32_t width, int32_t height, void *data) {
 	void *data_arr[1] = { data };
 	tex_set_color_arr(texture, width, height, data_arr, 1);
+}
+
+///////////////////////////////////////////
+
+void _tex_set_colors_3d(tex_t texture, int32_t width, int32_t height, int32_t depth, void *data) {
+	profiler_zone();
+
+	if (!(texture->type & tex_type_volume)) {
+		log_warn("Use tex_set_colors / tex_set_color_arr for non-volume textures, not tex_set_colors_3d.");
+		return;
+	}
+
+	bool dynamic        = (texture->type & tex_type_dynamic) != 0;
+	bool different_size =
+		texture->width  != width  ||
+		texture->height != height ||
+		texture->depth  != depth;
+
+	// No-op: existing same-sized texture and no new data to upload.
+	if (!different_size && data == nullptr && skr_tex_is_valid(&texture->gpu_tex))
+		return;
+
+	skr_tex_data_t tex_data = {};
+	if (data != nullptr) {
+		tex_data.data        = data;
+		tex_data.mip_count   = 1;
+		tex_data.layer_count = 1; // 3D: one "layer" with depth slices in the data block
+		tex_data.base_mip    = 0;
+		tex_data.base_layer  = 0;
+		tex_data.row_pitch   = 0;
+	}
+
+	if (!skr_tex_is_valid(&texture->gpu_tex) || different_size || (!different_size && !dynamic)) {
+		if (!different_size && !dynamic)
+			texture->type |= tex_type_dynamic;
+
+		skr_tex_flags_    flags   = tex_type_to_skr_flags(texture->type);
+		skr_tex_fmt_      format  = (skr_tex_fmt_)texture->format;
+		skr_tex_sampler_t sampler = tex_get_skr_sampler(texture);
+		skr_vec3i_t       size    = { width, height, depth };
+
+		// Mips: caller asked for a chain → pass 0 to auto-fill, otherwise 1.
+		int32_t create_mip_count = (texture->type & tex_type_mips) ? 0 : 1;
+
+		skr_tex_t new_tex;
+		skr_err_ err = skr_tex_create(
+			format, flags, sampler, size, 1, create_mip_count,
+			data != nullptr ? &tex_data : nullptr,
+			&new_tex);
+
+		if (err != skr_err_success) {
+			log_err("Failed to create 3D texture");
+			tex_set_fallback(texture, _tex_get_error_fallback(texture));
+			texture->header.state = asset_state_error;
+			return;
+		}
+
+		// Atomic swap: render thread always sees a valid handle.
+		skr_tex_t old_tex = texture->gpu_tex;
+		texture->gpu_tex = new_tex;
+		if (skr_tex_is_valid(&old_tex))
+			skr_tex_destroy(&old_tex);
+
+		if ((texture->type & tex_type_mips) && data != nullptr) {
+			skr_tex_generate_mips(&texture->gpu_tex, nullptr);
+		}
+
+		tex_set_meta(texture, width, height, depth, texture->format);
+		tex_update_label(texture);
+	} else if (dynamic) {
+		if (data != nullptr) {
+			skr_tex_set_data(&texture->gpu_tex, &tex_data);
+			if (texture->type & tex_type_mips) {
+				skr_tex_generate_mips(&texture->gpu_tex, nullptr);
+			}
+		}
+	} else {
+		log_warn("Attempting additional writes to a non-dynamic texture!");
+	}
+
+	if (skr_tex_is_valid(&texture->gpu_tex)) {
+		tex_set_fallback(texture, nullptr);
+		texture->header.state = asset_state_loaded;
+	}
+}
+
+///////////////////////////////////////////
+
+void tex_set_colors_3d(tex_t texture, int32_t width, int32_t height, int32_t depth, void *data) {
+	profiler_zone();
+
+	// Serialize the GPU work onto the asset thread, matching the 2D path.
+	// skr_tex_create / skr_tex_set_data assume single-threaded use.
+	struct tex_upload_3d_job_t {
+		tex_t   texture;
+		int32_t width;
+		int32_t height;
+		int32_t depth;
+		void   *data;
+	};
+	tex_upload_3d_job_t job_data = { texture, width, height, depth, data };
+
+	assets_execute_blocking([](void *data) {
+		tex_upload_3d_job_t *job = (tex_upload_3d_job_t *)data;
+		_tex_set_colors_3d(job->texture, job->width, job->height, job->depth, job->data);
+		return (bool32_t)true;
+	}, &job_data);
 }
 
 ///////////////////////////////////////////
@@ -1395,6 +1510,13 @@ int32_t tex_get_width(tex_t texture) {
 int32_t tex_get_height(tex_t texture) {
 	assets_block_until(&texture->header, asset_state_loaded_meta);
 	return texture->height;
+}
+
+///////////////////////////////////////////
+
+int32_t tex_get_depth(tex_t texture) {
+	assets_block_until(&texture->header, asset_state_loaded_meta);
+	return texture->depth;
 }
 
 ///////////////////////////////////////////
@@ -1530,6 +1652,7 @@ tex_format_ tex_get_supported_depth_format(tex_format_ preferred, bool needs_ste
 id_hash_t tex_meta_hash(tex_t texture) {
 	id_hash_t result = hash_int     (texture->width);
 	result           = hash_int_with(texture->height, result);
+	result           = hash_int_with(texture->depth,  result);
 	uint64_t image   = (uint64_t)texture->gpu_tex.image;
 	result           = hash_int_with((int32_t)(image & 0xFFFFFFFF), result);
 	result           = hash_int_with((int32_t)(image >> 32),        result);
@@ -1540,9 +1663,10 @@ id_hash_t tex_meta_hash(tex_t texture) {
 
 ///////////////////////////////////////////
 
-void tex_set_meta(tex_t texture, int32_t width, int32_t height, tex_format_ format) {
+void tex_set_meta(tex_t texture, int32_t width, int32_t height, int32_t depth, tex_format_ format) {
 	texture->width  = width;
 	texture->height = height;
+	texture->depth  = depth;
 	texture->format = format;
 
 	// Compressed formats can't be rendered into, so mip generation is not
@@ -1612,13 +1736,18 @@ void tex_set_loading_fallback(tex_t loading_texture) {
 		}
 		tex_addref(loading_texture);
 	}
-	// Assign to the appropriate fallback based on texture type, or clear both
-	// if nullptr
+	// Assign to the appropriate fallback based on texture type, or clear all
+	// slots if nullptr
 	if (loading_texture == nullptr) {
 		tex_release(tex_loading_texture);
 		tex_release(tex_loading_texture_cubemap);
+		tex_release(tex_loading_texture_3d);
 		tex_loading_texture         = nullptr;
 		tex_loading_texture_cubemap = nullptr;
+		tex_loading_texture_3d      = nullptr;
+	} else if (loading_texture->type & tex_type_volume) {
+		tex_release(tex_loading_texture_3d);
+		tex_loading_texture_3d = loading_texture;
 	} else if (loading_texture->type & tex_type_cubemap) {
 		tex_release(tex_loading_texture_cubemap);
 		tex_loading_texture_cubemap = loading_texture;
@@ -1639,13 +1768,18 @@ void tex_set_error_fallback(tex_t error_texture) {
 		}
 		tex_addref(error_texture);
 	}
-	// Assign to the appropriate fallback based on texture type, or clear both
-	// if nullptr
+	// Assign to the appropriate fallback based on texture type, or clear all
+	// slots if nullptr
 	if (error_texture == nullptr) {
 		tex_release(tex_error_texture);
 		tex_release(tex_error_texture_cubemap);
+		tex_release(tex_error_texture_3d);
 		tex_error_texture         = nullptr;
 		tex_error_texture_cubemap = nullptr;
+		tex_error_texture_3d      = nullptr;
+	} else if (error_texture->type & tex_type_volume) {
+		tex_release(tex_error_texture_3d);
+		tex_error_texture_3d = error_texture;
 	} else if (error_texture->type & tex_type_cubemap) {
 		tex_release(tex_error_texture_cubemap);
 		tex_error_texture_cubemap = error_texture;

--- a/StereoKitC/asset_types/texture.h
+++ b/StereoKitC/asset_types/texture.h
@@ -16,6 +16,7 @@ struct _tex_t {
 	// TODO: can get rid of some maybe?
 	int32_t          width;
 	int32_t          height;
+	int32_t          depth;
 	tex_format_      format;
 	uint64_t         meta_hash;
 

--- a/StereoKitC/asset_types/texture_.h
+++ b/StereoKitC/asset_types/texture_.h
@@ -10,7 +10,7 @@ size_t      tex_format_size      (tex_format_ format, int32_t width, int32_t hei
 tex_format_ tex_get_tex_format   (int64_t native_fmt);
 int64_t     tex_fmt_to_native    (tex_format_ format);
 tex_format_ tex_get_supported_depth_format(tex_format_ preferred, bool needs_stencil, int32_t multisample);
-void        tex_set_meta         (tex_t texture, int32_t width, int32_t height, tex_format_ format);
+void        tex_set_meta         (tex_t texture, int32_t width, int32_t height, int32_t depth, tex_format_ format);
 uint64_t    tex_meta_hash        (tex_t texture);
 
 uint8_t* unzip_malloc(const uint8_t* buffer, int32_t len, int32_t* out_len);

--- a/StereoKitC/stereokit.h
+++ b/StereoKitC/stereokit.h
@@ -1660,6 +1660,7 @@ SK_API bool32_t         compute_set_texture      (compute_t compute, const char 
 SK_API bool32_t         compute_set_storage      (compute_t compute, const char *name, compute_buffer_t  buffer);
 SK_API bool32_t         compute_set_constant     (compute_t compute, const char *name, material_buffer_t buffer);
 SK_API void             compute_dispatch         (compute_t compute, uint32_t group_count_x, uint32_t group_count_y, uint32_t group_count_z);
+SK_API void             compute_dispatch_now     (compute_t compute, uint32_t group_count_x, uint32_t group_count_y, uint32_t group_count_z);
 SK_API int32_t          compute_get_param_count  (compute_t compute);
 SK_API void             compute_get_param_info   (compute_t compute, int32_t index, char **out_name, material_param_ *out_type);
 SK_API void             compute_addref           (compute_t compute);
@@ -2058,7 +2059,7 @@ SK_API void                  render_screenshot     (const char *file_utf8, int32
 //TODO: for v0.4, reorder parameters, context in particular should be next to callback
 SK_API void                  render_screenshot_capture  (void (*render_on_screenshot_callback)(color32* color_buffer, int32_t width, int32_t height, void* context), pose_t viewpoint, int32_t width, int32_t height, float field_of_view_degrees, tex_format_ tex_format sk_default(tex_format_rgba32), void *context sk_default(nullptr));
 SK_API void                  render_screenshot_viewpoint(void (*render_on_screenshot_callback)(color32* color_buffer, int32_t width, int32_t height, void* context), matrix camera, matrix projection, int32_t width, int32_t height, render_layer_ layer_filter sk_default(render_layer_all), render_clear_ clear sk_default(render_clear_all), rect_t viewport sk_default(rect_t{}), tex_format_ tex_format sk_default(tex_format_rgba32), void* context sk_default(nullptr));
-SK_API void                  render_to             (tex_t to_rendertarget, int32_t to_target_index, const sk_ref(matrix) camera, const sk_ref(matrix) projection, render_layer_ layer_filter sk_default(render_layer_all), int32_t material_variant sk_default(0), render_clear_ clear sk_default(render_clear_all), rect_t viewport sk_default({}));
+SK_API void                  render_to             (tex_t to_rendertarget, int32_t to_target_index, const matrix* in_arr_cameras, const matrix* in_arr_projections, int32_t view_count, render_layer_ layer_filter sk_default(render_layer_all), int32_t material_variant sk_default(0), render_clear_ clear sk_default(render_clear_all), rect_t viewport sk_default({}));
 SK_API void                  render_get_device     (void **device, void **context);
 SK_API render_list_t         render_get_primary_list(void);
 

--- a/StereoKitC/stereokit.h
+++ b/StereoKitC/stereokit.h
@@ -1255,6 +1255,10 @@ typedef enum tex_type_ {
 	  Create it with a format that supports storage images, such as
 	  tex_format_rgba128.*/
 	tex_type_compute       = 1 << 7,
+	/*A volumetric (3D) texture, sized with width, height, and depth.
+	  Volume textures are mutually exclusive with Cubemap and array
+	  textures, and don't pair with a zbuffer.*/
+	tex_type_volume        = 1 << 8,
 	/*A standard color image that also generates mip-maps
 	  automatically.*/
 	tex_type_image         = tex_type_image_nomips | tex_type_mips,
@@ -1357,6 +1361,7 @@ SK_API void         tex_on_load_remove      (tex_t texture, void (*asset_on_load
 SK_API void         tex_set_colors          (tex_t texture, int32_t width, int32_t height, void *data);
 SK_API void         tex_set_color_arr       (tex_t texture, int32_t width, int32_t height, void** array_data, int32_t array_count,                    int32_t multisample sk_default(1), spherical_harmonics_t* out_sh_lighting_info sk_default(nullptr));
 SK_API void         tex_set_color_arr_mips  (tex_t texture, int32_t width, int32_t height, void** array_data, int32_t array_count, int32_t mip_count, int32_t multisample sk_default(1), spherical_harmonics_t* out_sh_lighting_info sk_default(nullptr));
+SK_API void         tex_set_colors_3d       (tex_t texture, int32_t width, int32_t height, int32_t depth, void *data);
 SK_API void         tex_set_mem             (tex_t texture, void* data, size_t data_size, bool32_t srgb_data sk_default(true), bool32_t blocking sk_default(false), int32_t priority sk_default(10));
 SK_API void         tex_add_zbuffer         (tex_t texture, tex_format_ format sk_default(tex_format_depthstencil));
 SK_API void         tex_set_zbuffer         (tex_t texture, tex_t depth_texture);
@@ -1369,6 +1374,7 @@ SK_API tex_t        tex_gen_cubemap_sh      (const sk_ref(spherical_harmonics_t)
 SK_API tex_format_  tex_get_format          (tex_t texture);
 SK_API int32_t      tex_get_width           (tex_t texture);
 SK_API int32_t      tex_get_height          (tex_t texture);
+SK_API int32_t      tex_get_depth           (tex_t texture);
 SK_API void         tex_set_sample          (tex_t texture, tex_sample_ sample sk_default(tex_sample_linear));
 SK_API tex_sample_  tex_get_sample          (tex_t texture);
 SK_API void             tex_set_sample_comp (tex_t texture, tex_sample_comp_ compare sk_default(tex_sample_comp_none));
@@ -3376,6 +3382,7 @@ SK_CONST char *default_id_tex_rough            = "default/tex_rough";
 SK_CONST char *default_id_tex_devtex           = "default/tex_devtex";
 SK_CONST char *default_id_tex_error            = "default/tex_error";
 SK_CONST char *default_id_cubemap              = "default/cubemap";
+SK_CONST char *default_id_tex_3d               = "default/tex_3d";
 SK_CONST char *default_id_font                 = "default/font";
 SK_CONST char *default_id_mesh_quad            = "default/mesh_quad";
 SK_CONST char *default_id_mesh_screen_quad     = "default/mesh_screen_quad";

--- a/StereoKitC/stereokit.h
+++ b/StereoKitC/stereokit.h
@@ -2059,8 +2059,23 @@ SK_API render_list_t         render_get_primary_list(void);
 ///////////////////////////////////////////
 
 
+/* Controls whether a RenderList holds asset references for the items it
+   contains. Tracked lists are safe to keep around across frames at the cost
+   of an addref/releaseref pair per item. */
+typedef enum render_list_refs_ {
+	/* The list calls addref on each item's mesh/material when added, and
+	   releaseref when cleared. This keeps assets alive for as long as the
+	   list holds them, and is the safe default. */
+	render_list_refs_tracked = 0,
+	/* The list does not addref or releaseref its items. The caller is
+	   responsible for ensuring referenced assets remain valid until the
+	   list is cleared. Useful for per-frame lists that are filled and
+	   drained inside a single frame. */
+	render_list_refs_none    = 1,
+} render_list_refs_;
+
 SK_API render_list_t         render_list_find         (const char* id);
-SK_API render_list_t         render_list_create       (void);
+SK_API render_list_t         render_list_create       (render_list_refs_ refs sk_default(render_list_refs_tracked));
 SK_API void                  render_list_set_id       (      render_list_t list, const char* id);
 SK_API const char*           render_list_get_id       (const render_list_t list);
 SK_API void                  render_list_addref       (      render_list_t list);

--- a/StereoKitC/stereokit.h
+++ b/StereoKitC/stereokit.h
@@ -2092,7 +2092,7 @@ SK_API int32_t               render_list_prev_count   (const render_list_t list)
 SK_API void                  render_list_add_mesh     (      render_list_t list, mesh_t  mesh,  material_t material,          matrix world_transform, color128 color_linear, render_layer_ layer);
 SK_API void                  render_list_add_model    (      render_list_t list, model_t model,                               matrix world_transform, color128 color_linear, render_layer_ layer);
 SK_API void                  render_list_add_model_mat(      render_list_t list, model_t model, material_t material_override, matrix world_transform, color128 color_linear, render_layer_ layer);
-SK_API void                  render_list_draw_now     (      render_list_t list, tex_t to_rendertarget, matrix camera, matrix projection, color128 clear_color sk_default({ 0,0,0,0 }), render_clear_ clear sk_default(render_clear_all), rect_t viewport_pct sk_default({}), render_layer_ layer_filter sk_default(render_layer_all), int32_t material_variant sk_default(0));
+SK_API void                  render_list_draw_now     (      render_list_t list, tex_t to_rendertarget, const matrix* in_arr_cameras, const matrix* in_arr_projections, int32_t view_count, color128 clear_color sk_default({ 0,0,0,0 }), render_clear_ clear sk_default(render_clear_all), rect_t viewport_pct sk_default({}), render_layer_ layer_filter sk_default(render_layer_all), int32_t material_variant sk_default(0));
 
 SK_API void                  render_list_push         (      render_list_t list);
 SK_API void                  render_list_pop          (void);

--- a/StereoKitC/systems/defaults.cpp
+++ b/StereoKitC/systems/defaults.cpp
@@ -24,6 +24,7 @@ tex_t        sk_default_tex_rough;
 tex_t        sk_default_tex_devtex;
 tex_t        sk_default_tex_error;
 tex_t        sk_default_cubemap;
+tex_t        sk_default_tex_3d;
 mesh_t       sk_default_quad;
 mesh_t       sk_default_screen_quad;
 mesh_t       sk_default_sphere;
@@ -182,6 +183,13 @@ bool defaults_init() {
 
 	tex_set_loading_fallback(sk_default_cubemap);
 	tex_set_error_fallback  (sk_default_cubemap);
+
+	color32 black_3d = { 0, 0, 0, 0 };
+	sk_default_tex_3d = tex_create(tex_type_image_nomips | tex_type_volume, tex_format_rgba32);
+	tex_set_colors_3d(sk_default_tex_3d, 1, 1, 1, &black_3d);
+	tex_set_id              (sk_default_tex_3d, default_id_tex_3d);
+	tex_set_loading_fallback(sk_default_tex_3d);
+	tex_set_error_fallback  (sk_default_tex_3d);
 
 	// Default quad mesh
 	sk_default_quad = mesh_create();
@@ -440,6 +448,7 @@ void defaults_shutdown() {
 	tex_release     (sk_default_tex_devtex);
 	tex_release     (sk_default_tex_error);
 	tex_release     (sk_default_cubemap);
+	tex_release     (sk_default_tex_3d);
 }
 
 } // namespace sk

--- a/StereoKitC/systems/defaults.h
+++ b/StereoKitC/systems/defaults.h
@@ -15,6 +15,7 @@ extern tex_t        sk_default_tex_rough;
 extern tex_t        sk_default_tex_devtex;
 extern tex_t        sk_default_tex_error;
 extern tex_t        sk_default_cubemap;
+extern tex_t        sk_default_tex_3d;
 extern mesh_t       sk_default_quad;
 extern mesh_t       sk_default_screen_quad;
 extern mesh_t       sk_default_sphere;

--- a/StereoKitC/systems/render.cpp
+++ b/StereoKitC/systems/render.cpp
@@ -117,13 +117,15 @@ enum render_action_type_ {
 	render_action_type_viewpoint,
 	render_action_type_global_texture,
 	render_action_type_global_buffer,
+	render_action_type_compute,
 };
 
 struct render_action_viewpoint_t {
 	tex_t         rendertarget;
 	int32_t       rendertarget_index;
-	matrix        camera;
-	matrix        projection;
+	matrix        cameras    [SK_MAX_VIEWS];
+	matrix        projections[SK_MAX_VIEWS];
+	int32_t       view_count;
 	rect_t        viewport;
 	render_layer_ layer_filter;
 	int32_t       material_variant;
@@ -140,12 +142,18 @@ struct render_action_global_buffer_t {
 	int32_t           slot;
 };
 
+struct render_action_compute_t {
+	compute_t compute;
+	uint32_t  groups[3];
+};
+
 struct render_action_t {
 	render_action_type_ type;
 	union {
 		render_action_viewpoint_t      viewpoint;
 		render_action_global_texture_t global_texture;
 		render_action_global_buffer_t  global_buffer;
+		render_action_compute_t        compute;
 	};
 };
 
@@ -271,6 +279,7 @@ void render_shutdown() {
 		case render_action_type_viewpoint: break;
 		case render_action_type_global_texture: tex_release            (a->global_texture.texture); break;
 		case render_action_type_global_buffer:  material_buffer_release(a->global_buffer .buffer ); break;
+		case render_action_type_compute:        compute_release        (a->compute       .compute); break;
 		}
 	}
 	local.render_action_list.free();
@@ -641,6 +650,21 @@ void render_global_texture_internal(int32_t register_slot, tex_t texture) {
 
 ///////////////////////////////////////////
 
+void render_queue_compute(compute_t compute, uint32_t group_count_x, uint32_t group_count_y, uint32_t group_count_z) {
+	if (compute == nullptr) return;
+	compute_addref(compute);
+
+	render_action_t action = {};
+	action.type             = render_action_type_compute;
+	action.compute.compute  = compute;
+	action.compute.groups[0]= group_count_x;
+	action.compute.groups[1]= group_count_y;
+	action.compute.groups[2]= group_count_z;
+	local.render_action_list.add(action);
+}
+
+///////////////////////////////////////////
+
 void render_global_texture(int32_t register_slot, tex_t texture) {
 	if (register_slot < 0 || register_slot >= _countof(local.global_textures)) {
 		log_errf("render_global_texture: Register_slot should be 0-16. Received %d.", register_slot);
@@ -967,17 +991,18 @@ void render_draw_viewpoint(render_action_viewpoint_t* vp) {
 
 	// Render!
 	skr_vec4_t clear_color = { local.clear_col.r, local.clear_col.g, local.clear_col.b, local.clear_col.a };
-	render_draw_queue(local.list_primary, &vp->camera, &vp->projection, 0, 1, vp->layer_filter, vp->material_variant, w, h);
+	render_draw_queue(local.list_primary, vp->cameras, vp->projections, 0, vp->view_count, vp->layer_filter, vp->material_variant, w, h);
 
 	skr_pass_t pass = {};
-	pass.color       = color_tex;
-	pass.depth       = depth_tex;
-	pass.clear       = clear_flags;
-	pass.clear_color = clear_color;
-	pass.clear_depth = 1.0f;
-	pass.viewport    = viewport;
-	pass.scissor     = scissor;
-	pass.view_count  = 1;
+	pass.color            = color_tex;
+	pass.depth            = depth_tex;
+	pass.clear            = clear_flags;
+	pass.clear_color      = clear_color;
+	pass.clear_depth      = 1.0f;
+	pass.viewport         = viewport;
+	pass.scissor          = scissor;
+	pass.view_count       = vp->view_count;
+	pass.views_correlated = vp->view_count == 2;
 	render_pass_add_draw(&pass);
 	skr_pass_submit(&pass);
 
@@ -994,6 +1019,7 @@ void render_action_list_execute() {
 		case render_action_type_viewpoint:      render_draw_viewpoint(&a->viewpoint); break;
 		case render_action_type_global_buffer:  render_global_buffer_internal ( a->global_buffer .slot, a->global_buffer .buffer ); material_buffer_release(a->global_buffer .buffer ); break;
 		case render_action_type_global_texture: render_global_texture_internal( a->global_texture.slot, a->global_texture.texture); tex_release            (a->global_texture.texture); break;
+		case render_action_type_compute:        compute_dispatch_now          ( a->compute       .compute, a->compute.groups[0], a->compute.groups[1], a->compute.groups[2]); compute_release(a->compute.compute); break;
 		default: break;
 		}
 	}
@@ -1063,21 +1089,26 @@ void render_screenshot_viewpoint(void (*render_on_screenshot_callback)(color32* 
 
 ///////////////////////////////////////////
 
-void render_to(tex_t to_rendertarget, int32_t to_target_index, const matrix& camera, const matrix& projection, render_layer_ layer_filter, int32_t material_variant, render_clear_ clear, rect_t viewport) {
+void render_to(tex_t to_rendertarget, int32_t to_target_index, const matrix* cameras, const matrix* projections, int32_t view_count, render_layer_ layer_filter, int32_t material_variant, render_clear_ clear, rect_t viewport) {
 	if (!(to_rendertarget->type & tex_type_rendertarget || to_rendertarget->type & tex_type_depthtarget || to_rendertarget->type & tex_type_zbuffer)) {
 		log_err("render_to texture must be a render target texture type!");
 		return;
 	}
+	if (view_count < 1 || view_count > SK_MAX_VIEWS) {
+		log_errf("render_to view_count %d out of range [1, %d]", view_count, SK_MAX_VIEWS);
+		return;
+	}
 	tex_addref(to_rendertarget);
 
-	matrix inv_cam;
-	matrix_inverse(camera, inv_cam);
 	render_action_t action = {};
 	action.type = render_action_type_viewpoint;
-	action.viewpoint.rendertarget      = to_rendertarget;
-	action.viewpoint.rendertarget_index= to_target_index;
-	action.viewpoint.camera            = inv_cam;
-	action.viewpoint.projection        = projection;
+	action.viewpoint.rendertarget       = to_rendertarget;
+	action.viewpoint.rendertarget_index = to_target_index;
+	action.viewpoint.view_count         = view_count;
+	for (int32_t i = 0; i < view_count; i++) {
+		matrix_inverse(cameras[i], action.viewpoint.cameras[i]);
+		action.viewpoint.projections[i] = projections[i];
+	}
 	action.viewpoint.layer_filter      = layer_filter;
 	action.viewpoint.viewport          = viewport;
 	action.viewpoint.clear             = clear;
@@ -1359,8 +1390,10 @@ void render_list_draw_now(render_list_t list, tex_t to_rendertarget, const matri
 	int32_t w = to_rendertarget->width;
 	int32_t h = to_rendertarget->height;
 
-	// Use depth buffer if attached to the render target
-	tex_t depth_surface = to_rendertarget->depth_buffer;
+	// Depth-only targets (e.g. shadow maps) — the rendertarget IS the depth
+	// buffer and there is no color attachment. Match render_draw_viewpoint.
+	bool  depth_only    = (to_rendertarget->type & tex_type_depth) || (to_rendertarget->type & tex_type_depthtarget);
+	tex_t depth_surface = depth_only ? to_rendertarget : to_rendertarget->depth_buffer;
 
 	// Set up viewport
 	if (viewport_pct.w == 0) viewport_pct.w = 1;
@@ -1387,7 +1420,7 @@ void render_list_draw_now(render_list_t list, tex_t to_rendertarget, const matri
 	render_draw_queue(list, cameras, projections, 0, view_count, layer_filter, material_variant, w, h);
 
 	skr_pass_t pass = {};
-	pass.color       = &to_rendertarget->gpu_tex;
+	pass.color       = depth_only ? nullptr : &to_rendertarget->gpu_tex;
 	pass.depth       = depth_surface ? &depth_surface->gpu_tex : nullptr;
 	pass.clear       = clear_flags;
 	pass.clear_color = skr_clear_color;

--- a/StereoKitC/systems/render.cpp
+++ b/StereoKitC/systems/render.cpp
@@ -791,7 +791,7 @@ void render_draw_queue(render_list_t list, const matrix *views, const matrix *pr
 	// render_global_textures system.
 	tex_t sky_tex = local.global_textures[render_skytex_register];
 	local.global_buffer.cubemap_i = sky_tex != nullptr
-		? vec4{ (float)sky_tex->width, (float)sky_tex->height, floorf(log2f((float)sky_tex->width)), 0 }
+		? vec4{ (float)sky_tex->width, (float)sky_tex->height, sky_tex->gpu_tex.mip_levels > 0 ? (float)(sky_tex->gpu_tex.mip_levels - 1) : 0, 0 }
 		: vec4{};
 
 	// Upload shader globals

--- a/StereoKitC/systems/render.cpp
+++ b/StereoKitC/systems/render.cpp
@@ -46,18 +46,22 @@ static void render_list_execute(render_list_t list, render_layer_ filter, int32_
 
 ///////////////////////////////////////////
 
+// Sizes the globally-bound shader buffer's per-view arrays (sk_view,
+// sk_proj, sk_viewproj, etc.). Must match SK_MAX_VIEWS in stereokit.hlsli.
+#define SK_MAX_VIEWS 6
+
 struct render_transform_buffer_t {
 	XMMATRIX world;
 	color128 color;
 };
 struct render_global_buffer_t {
-	XMMATRIX view[2];
-	XMMATRIX proj[2];
-	XMMATRIX proj_inv[2];
-	XMMATRIX viewproj[2];
+	XMMATRIX view[SK_MAX_VIEWS];
+	XMMATRIX proj[SK_MAX_VIEWS];
+	XMMATRIX proj_inv[SK_MAX_VIEWS];
+	XMMATRIX viewproj[SK_MAX_VIEWS];
 	vec4     lighting[7];
-	vec4     camera_pos[2];
-	vec4     camera_dir[2];
+	vec4     camera_pos[SK_MAX_VIEWS];
+	vec4     camera_dir[SK_MAX_VIEWS];
 	vec4     fingertip[2];
 	vec4     cubemap_i;
 	vec4     screen_size; // {width, height, 1/width, 1/height}
@@ -741,16 +745,6 @@ void render_add_model(model_t model, const matrix &transform, color128 color_lin
 ///////////////////////////////////////////
 
 void render_draw_queue(render_list_t list, const matrix *views, const matrix *projections, int32_t eye_offset, int32_t view_count, render_layer_ filter, int32_t material_variant, int32_t surface_width, int32_t surface_height) {
-	// A temporary fix for multiview trying to render to mono rendertargets
-	if (view_count == 1) {
-		memset(&local.global_buffer.view      [1], 0, sizeof(local.global_buffer.view      [1]));
-		memset(&local.global_buffer.proj      [1], 0, sizeof(local.global_buffer.proj      [1]));
-		memset(&local.global_buffer.proj_inv  [1], 0, sizeof(local.global_buffer.proj_inv  [1]));
-		memset(&local.global_buffer.viewproj  [1], 0, sizeof(local.global_buffer.viewproj  [1]));
-		memset(&local.global_buffer.camera_pos[1], 0, sizeof(local.global_buffer.camera_pos[1]));
-		memset(&local.global_buffer.camera_dir[1], 0, sizeof(local.global_buffer.camera_dir[1]));
-	}
-
 	// Copy camera information into the global buffer
 	for (int32_t i = 0; i < view_count; i++) {
 		XMMATRIX view_f, projection_f;
@@ -1361,7 +1355,7 @@ void render_list_add_model_mat(render_list_t list, model_t model, material_t mat
 
 ///////////////////////////////////////////
 
-void render_list_draw_now(render_list_t list, tex_t to_rendertarget, matrix camera, matrix projection, color128 clear_color, render_clear_ clear, rect_t viewport_pct, render_layer_ layer_filter, int32_t material_variant) {
+void render_list_draw_now(render_list_t list, tex_t to_rendertarget, const matrix* cameras, const matrix* projections, int32_t view_count, color128 clear_color, render_clear_ clear, rect_t viewport_pct, render_layer_ layer_filter, int32_t material_variant) {
 	int32_t w = to_rendertarget->width;
 	int32_t h = to_rendertarget->height;
 
@@ -1390,7 +1384,7 @@ void render_list_draw_now(render_list_t list, tex_t to_rendertarget, matrix came
 
 	// Render!
 	skr_vec4_t skr_clear_color = { clear_color.r, clear_color.g, clear_color.b, clear_color.a };
-	render_draw_queue(list, &camera, &projection, 0, 1, layer_filter, material_variant, w, h);
+	render_draw_queue(list, cameras, projections, 0, view_count, layer_filter, material_variant, w, h);
 
 	skr_pass_t pass = {};
 	pass.color       = &to_rendertarget->gpu_tex;
@@ -1400,7 +1394,8 @@ void render_list_draw_now(render_list_t list, tex_t to_rendertarget, matrix came
 	pass.clear_depth = 1.0f;
 	pass.viewport    = viewport;
 	pass.scissor     = scissor;
-	pass.view_count  = 1;
+	pass.view_count       = view_count;
+	pass.views_correlated = view_count == 2; // XR L/R eyes; assume uncorrelated for other counts
 	render_pass_add_draw(&pass);
 	skr_pass_submit(&pass);
 }

--- a/StereoKitC/systems/render.cpp
+++ b/StereoKitC/systems/render.cpp
@@ -240,7 +240,7 @@ bool render_init() {
 	render_set_clip    (local.clip_planes.x, local.clip_planes.y);
 	render_set_cam_root(matrix_identity);
 
-	local.list_primary = render_list_create();
+	local.list_primary = render_list_create(render_list_refs_none);
 	render_list_set_id(local.list_primary, "sk/render/primary_renderlist");
 	render_list_push  (local.list_primary);
 
@@ -1128,8 +1128,9 @@ render_list_t render_list_find(const char* id) {
 
 ///////////////////////////////////////////
 
-render_list_t render_list_create() {
+render_list_t render_list_create(render_list_refs_ refs) {
 	render_list_t result = (render_list_t)assets_allocate(asset_type_render_list);
+	result->refs = refs;
 	return result;
 }
 
@@ -1191,16 +1192,20 @@ void render_list_pop() {
 
 void render_list_add(const render_item_t *item) {
 	local.list_active->queue.add(*item);
-	assets_addref(&item->material->header);
-	assets_addref(&item->mesh->header);
+	if (local.list_active->refs == render_list_refs_tracked) {
+		assets_addref(&item->material->header);
+		assets_addref(&item->mesh->header);
+	}
 }
 
 ///////////////////////////////////////////
 
 void render_list_add_to(render_list_t list, const render_item_t *item) {
 	list->queue.add(*item);
-	assets_addref(&item->material->header);
-	assets_addref(&item->mesh->header);
+	if (list->refs == render_list_refs_tracked) {
+		assets_addref(&item->material->header);
+		assets_addref(&item->mesh->header);
+	}
 }
 
 ///////////////////////////////////////////
@@ -1267,9 +1272,11 @@ static void render_list_execute(render_list_t list, render_layer_ filter, int32_
 
 void render_list_clear(render_list_t list) {
 	list->prev_count = list->queue.count;
-	for (int32_t i = 0; i < list->queue.count; i++) {
-		assets_releaseref(&list->queue[i].material->header);
-		assets_releaseref(&list->queue[i].mesh    ->header);
+	if (list->refs == render_list_refs_tracked) {
+		for (int32_t i = 0; i < list->queue.count; i++) {
+			assets_releaseref(&list->queue[i].material->header);
+			assets_releaseref(&list->queue[i].mesh    ->header);
+		}
 	}
 	list->queue.clear();
 	list->stats = {};

--- a/StereoKitC/systems/render.h
+++ b/StereoKitC/systems/render.h
@@ -44,6 +44,7 @@ void          render_check_screenshots    ();
 void          render_check_pending_skytex ();
 void          render_global_buffer_internal (int32_t register_slot, material_buffer_t buffer);
 void          render_global_texture_internal(int32_t register_slot, tex_t             texture);
+void          render_queue_compute          (compute_t compute, uint32_t group_count_x, uint32_t group_count_y, uint32_t group_count_z);
 void          render_action_list_execute  ();
 
 void          render_list_destroy         (      render_list_t list);

--- a/StereoKitC/systems/render_.h
+++ b/StereoKitC/systems/render_.h
@@ -41,6 +41,7 @@ struct _render_list_t {
 	render_list_state_     state;
 	bool                   prepped;
 	int32_t                prev_count;
+	render_list_refs_      refs;
 };
 
 

--- a/tools/include/stereokit.hlsli
+++ b/tools/include/stereokit.hlsli
@@ -1,16 +1,20 @@
 #ifndef _STEREOKIT_HLSLI
 #define _STEREOKIT_HLSLI
 
+// Maximum number of views StereoKit can render in a single pass. Must
+// match SK_MAX_VIEWS in renderer.cpp.
+#define SK_MAX_VIEWS 6
+
 ///////////////////////////////////////////
 
 cbuffer stereokit_buffer : register(b1) {
-	float4x4 sk_view       [2];
-	float4x4 sk_proj       [2];
-	float4x4 sk_proj_inv   [2];
-	float4x4 sk_viewproj   [2];
+	float4x4 sk_view       [SK_MAX_VIEWS];
+	float4x4 sk_proj       [SK_MAX_VIEWS];
+	float4x4 sk_proj_inv   [SK_MAX_VIEWS];
+	float4x4 sk_viewproj   [SK_MAX_VIEWS];
 	float4   sk_lighting_sh[7];
-	float4   sk_camera_pos [2];
-	float4   sk_camera_dir [2];
+	float4   sk_camera_pos [SK_MAX_VIEWS];
+	float4   sk_camera_dir [SK_MAX_VIEWS];
 	float4   sk_fingertip  [2];
 	float4   sk_cubemap_i;   // .xy = width/height, .z  = mip count, .w = unused
 	float4   sk_screen_size; // .xy = width/height, .zw = 1/width, 1/height


### PR DESCRIPTION
- Added Tex.Volume and Tex.SetColors for 3D textures.
- Added Tex.SetColors for explicit array textures and mip level data.
- Added Renderer.RenderTo with multiview options.
- Added RenderList option for not reference counting, a big perf win for per-frame render lists.
- Compute.Dispatch now enqueues with the rest of render calls.
- Added Compute.DispatchNow to skip the queue if needed.