### PR TITLE
Added `SKSettings.defaultFontFamily`

### DIFF
--- a/Examples/StereoKitCTest/main.cpp
+++ b/Examples/StereoKitCTest/main.cpp
@@ -161,6 +161,7 @@ int main() {
 	settings.app_name      = "StereoKit C";
 	settings.assets_folder = "Assets";
 	settings.mode          = app_mode_xr;
+	settings.default_font_family = "builtin, sans-serif";
 	if (!sk_init(settings))
 		return 1;
 

--- a/Examples/StereoKitTest/Program.cs
+++ b/Examples/StereoKitTest/Program.cs
@@ -16,10 +16,11 @@ class Program
 	// The base settings we use for this test app. Some of these, like mode,
 	// are overridden, particularly when running tests.
 	static SKSettings settings = new SKSettings {
-		appName         = "StereoKit C#",
-		blendPreference = DisplayBlend.AnyTransparent,
-		mode            = AppMode.XR,
-		renderScaling   = 1.5f,
+		appName           = "StereoKit C#",
+		blendPreference   = DisplayBlend.AnyTransparent,
+		mode              = AppMode.XR,
+		renderScaling     = 1.2f,
+		defaultFontFamily = "builtin, sans-serif", // We rely on the builtin Aileron font for test screenshot consistency!
 	};
 
 	static Mesh      floorMesh;

--- a/StereoKit/Native/NativeTypes.Custom.cs
+++ b/StereoKit/Native/NativeTypes.Custom.cs
@@ -10,6 +10,7 @@ namespace StereoKit
 	{
 		private IntPtr _appName;
 		private IntPtr _assetsFolder;
+		private IntPtr _defaultFontFamily;
 
 		/// <summary>Which operation mode should we use for this app? Default
 		/// is XR, and by default the app will fall back to Simulator if XR
@@ -163,6 +164,28 @@ namespace StereoKit
 				Marshal.Copy(str, 0, _assetsFolder, str.Length);
 			}
 			get => Marshal.PtrToStringAnsi(_assetsFolder);
+		}
+		/// <summary>A CSS-style comma-separated list of font families to use
+		/// for StereoKit's default font, e.g. "Segoe UI, Arial, sans-serif".
+		/// The first family that resolves on the host system is used, with
+		/// the remainder acting as fallbacks for missing glyphs. If null,
+		/// empty, or unresolvable, StereoKit falls back to its built-in
+		/// per-platform default font selection.</summary>
+		public string defaultFontFamily {
+			set {
+				if (_defaultFontFamily != IntPtr.Zero) Marshal.FreeHGlobal(_defaultFontFamily);
+
+				if (string.IsNullOrEmpty(value))
+				{
+					_defaultFontFamily = IntPtr.Zero;
+					return;
+				}
+
+				byte[] str = NativeHelper.ToUtf8(value);
+				_defaultFontFamily = Marshal.AllocHGlobal(str.Length);
+				Marshal.Copy(str, 0, _defaultFontFamily, str.Length);
+			}
+			get => Marshal.PtrToStringAnsi(_defaultFontFamily);
 		}
 	}
 

--- a/StereoKitC/asset_types/font.cpp
+++ b/StereoKitC/asset_types/font.cpp
@@ -652,23 +652,106 @@ void font_update_fonts() {
 
 ///////////////////////////////////////////
 
-font_t font_create_family(const char* font_family) {
-	font_fallback_info_t* info;
-	int32_t               info_count;
-	fontfile_from_css(font_family, &info, &info_count);
+enum fam_kind_ { fam_kind_family, fam_kind_builtin, fam_kind_path };
+struct fam_token_t { stref_t text; fam_kind_ kind; };
 
-	if (info_count == 0) {
-		log_errf("No font files provided for the font_family %s.", font_family);
+static int32_t font_source_add_token(const fam_token_t &t) {
+	if (t.kind == fam_kind_builtin)
+		return font_source_add_data("sk/builtin/aileron", aileron_font_ttf, aileron_font_ttf_len);
+
+	char*   path = stref_copy(t.text);
+	int32_t id   = font_source_add(path);
+		
+	sk_free(path);
+	return id;
+}
+
+font_t font_create_family(const char* font_family) {
+	if (font_family == nullptr || font_family[0] == '\0') {
+		log_err("font_create_family: no font family provided.");
 		return nullptr;
 	}
-	const char** files = sk_malloc_t(const char*, info_count);
+
+	// Cache identical requests by hashing the full input.
+	char file_id[64];
+	snprintf(file_id, sizeof(file_id), "sk/font/%" PRIu64, hash_string(font_family));
+	font_t cached = font_find(file_id);
+	if (cached != nullptr) return cached;
+
+	// Walk comma-separated tokens via stref. Each token is classified as the
+	// "builtin" sentinel (the bundled Aileron, case-sensitive), a file path
+	// (contains / or \, or ends in a recognized font extension), or a family
+	// name (resolved via fontfile_from_css). A bare '.' is not enough to
+	// classify as a path, since family names like "PT Sans 1.1" contain dots.
+	array_t<fam_token_t> tokens       = {};
+	int32_t              family_count = 0;
+	stref_t              line         = stref_make(font_family);
+	stref_t              word         = {};
+	while (stref_nextword(line, word, ',')) {
+		stref_trim(word);
+		if (word.length == 0) continue;
+
+		fam_token_t t = {};
+		t.text = word;
+		if (stref_equals(word, "builtin")) {
+			t.kind = fam_kind_builtin;
+		} else if (stref_indexof(word, '/') >= 0 || stref_indexof(word, '\\') >= 0) {
+			t.kind = fam_kind_path;
+		} else if (stref_indexof(word, '.') >= 0) {
+			char* tmp = stref_copy(word);
+			t.kind = font_is_valid_extension(tmp) ? fam_kind_path : fam_kind_family;
+			sk_free(tmp);
+			if (t.kind == fam_kind_family) family_count++;
+		} else {
+			t.kind = fam_kind_family;
+			family_count++;
+		}
+		tokens.add(t);
+	}
+
+	// If any family-name tokens are present, hand the original input to
+	// fontfile_from_css. Unknown tokens (builtin, paths) just don't match on
+	// any backend and are silently dropped from the resolved list.
+	font_fallback_info_t* info       = nullptr;
+	int32_t               info_count = 0;
+	if (family_count > 0) fontfile_from_css(font_family, &info, &info_count);
+
+	// Construct the font. Position rules: the leading run of special tokens
+	// (builtin/path, before any family name) takes priority over the css-
+	// resolved set. Anything from the first family token onwards is treated
+	// as trailing - css-resolved family files first, then any remaining
+	// specials in their original order.
+	font_t result = (font_t)assets_allocate(asset_type_font);
+	assets_set_id(&result->header, file_id);
+
+	int32_t leading_end = tokens.count;
+	for (int32_t i = 0; i < tokens.count; i++) {
+		if (tokens[i].kind == fam_kind_family) { leading_end = i; break; }
+	}
+
+	for (int32_t i = 0; i < leading_end; i++) {
+		int32_t id = font_source_add_token(tokens[i]);
+		if (id >= 0) result->font_ids.add(id);
+	}
 	for (int32_t i = 0; i < info_count; i++) {
-		files[i] = string_copy(info[i].filepath);
+		int32_t id = font_source_add(info[i].filepath);
+		if (id >= 0) result->font_ids.add(id);
+	}
+	for (int32_t i = leading_end; i < tokens.count; i++) {
+		if (tokens[i].kind == fam_kind_family) continue;
+		int32_t id = font_source_add_token(tokens[i]);
+		if (id >= 0) result->font_ids.add(id);
 	}
 
 	free(info);
-	font_t font = font_create_files(files, info_count);
-	return font;
+	tokens.free();
+
+	if (!font_setup(result)) {
+		font_release(result);
+		return nullptr;
+	}
+	font_list.add(result);
+	return result;
 }
 
 } // namespace sk

--- a/StereoKitC/libraries/sk_fontfile.cpp
+++ b/StereoKitC/libraries/sk_fontfile.cpp
@@ -141,12 +141,19 @@ void fontfile_from_css(const char* fontlist_utf8, font_fallback_info_t** out_inf
 			if (data == nullptr) return;
 
 			strncpy(data[count].name, trimmed, sizeof(data[count].name));
-			char* folder = fontfile_folder();
-			snprintf(data[count].filepath, 256, "%s/%s", folder, file);
+			// fontfile_name_to_path may return either a basename (Win/macOS)
+			// or an absolute path (Android via AFontMatcher); only prepend the
+			// font folder when it's actually a basename.
+			if (file[0] == '/' || (file[0] != '\0' && file[1] == ':')) {
+				snprintf(data[count].filepath, 256, "%s",    file);
+			} else {
+				char* folder = fontfile_folder();
+				snprintf(data[count].filepath, 256, "%s/%s", folder, file);
+				free(folder);
+			}
 			data[count].scale = 1;
 			count += 1;
 
-			free(folder);
 			free(file);
 
 			int32_t               link_count;

--- a/StereoKitC/stereokit.h
+++ b/StereoKitC/stereokit.h
@@ -624,6 +624,7 @@ typedef enum standby_mode_ {
 typedef struct sk_settings_t {
 	const char    *app_name;
 	const char    *assets_folder;
+	const char    *default_font_family;
 	app_mode_      mode;
 	display_blend_ blend_preference;
 	bool32_t       no_flatscreen_fallback;
@@ -3082,12 +3083,12 @@ SK_API bool32_t              world_raycast                   (ray_t ray, ray_t *
 SK_API void                  world_set_occlusion             (occlusion_caps_ flags);
 SK_API occlusion_caps_       world_get_occlusion             (void);
 SK_API occlusion_caps_       world_occlusion_capabilities    (void);
-SK_DEPRECATED SK_API void    world_set_occlusion_enabled     (bool32_t enabled);
-SK_DEPRECATED SK_API bool32_t world_get_occlusion_enabled    (void);
+SK_API SK_DEPRECATED void    world_set_occlusion_enabled     (bool32_t enabled);
+SK_API SK_DEPRECATED bool32_t world_get_occlusion_enabled    (void);
 SK_API void                  world_set_raycast_enabled       (bool32_t enabled);
 SK_API bool32_t              world_get_raycast_enabled       (void);
-SK_DEPRECATED SK_API void    world_set_occlusion_material    (material_t material);
-SK_DEPRECATED SK_API material_t world_get_occlusion_material (void);
+SK_API SK_DEPRECATED void    world_set_occlusion_material    (material_t material);
+SK_API SK_DEPRECATED material_t world_get_occlusion_material (void);
 SK_API void                  world_set_refresh_type          (world_refresh_ refresh_type);
 SK_API world_refresh_        world_get_refresh_type          (void);
 SK_API void                  world_set_refresh_radius        (float radius_meters);

--- a/StereoKitC/systems/defaults.cpp
+++ b/StereoKitC/systems/defaults.cpp
@@ -1,6 +1,7 @@
 #include "defaults.h"
 #include "../platforms/platform.h"
 #include "../stereokit.h"
+#include "../_stereokit.h"
 #include "../shaders_builtin/shader_builtin.h"
 #include "../asset_types/font.h"
 #include "../asset_types/texture_.h"
@@ -332,7 +333,15 @@ bool defaults_init() {
 	material_set_transparency(sk_default_material_ui_box, transparency_msaa);
 
 	// Text!
-	sk_default_font = platform_default_font();
+	const sk_settings_t* settings = sk_get_settings_ref();
+	sk_default_font = nullptr;
+	if (settings->default_font_family != nullptr && settings->default_font_family[0] != '\0') {
+		sk_default_font = font_create_family(settings->default_font_family);
+		if (sk_default_font == nullptr)
+			log_warnf("Default font family '%s' could not be resolved, falling back to platform default.", settings->default_font_family);
+	}
+	if (sk_default_font == nullptr)
+		sk_default_font = platform_default_font();
 	if (sk_default_font == nullptr) {
 		log_warn("Failed to create default font!");
 		return false;


### PR DESCRIPTION
- `SKSettings.defaultFontFamily` - This lets you set the app's default font at startup via CSS style font family selectors.
- Fixes font family path issue on Android
- Built-in Aileron font can be specified using keyword `builtin`
- Allows for path based fonts in CSS selectors as well