### PR TITLE
Fix early cleanup crash

### DIFF
--- a/StereoKitC/xr_backends/openxr_view.cpp
+++ b/StereoKitC/xr_backends/openxr_view.cpp
@@ -384,8 +384,11 @@ void openxr_views_destroy() {
 	// Wait for all GPU work to complete before destroying swapchain resources.
 	// The textures have ImageViews/Framebuffers that may still be referenced
 	// by in-flight command buffers, and OpenXR swapchain images can't be
-	// destroyed while in use.
-	vkDeviceWaitIdle(skr_get_vk_device());
+	// destroyed while in use. The device may not exist yet, since cleanup can
+	// run during an early failed openxr_create_system probe, before skr_init.
+	VkDevice vk_device = skr_get_vk_device();
+	if (vk_device != VK_NULL_HANDLE)
+		vkDeviceWaitIdle(vk_device);
 
 	for (int32_t i = 0; i < xr_displays.count; i++) {
 		device_display_delete(&xr_displays[i]);


### PR DESCRIPTION
vkDeviceWaitIdle in openxr_views_destroy was getting called regardless of if Vulkan had been initialized or not.