### PR TITLE
Use more modern way to specify /MT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,14 @@ if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")
   cmake_policy(SET CMP0135 NEW)
 endif()
 
+# CMP0091 (CMake 3.15+): pick the MSVC runtime through the
+# CMAKE_MSVC_RUNTIME_LIBRARY abstraction instead of hard-coding /MD or /MT into
+# the default *_FLAGS_<CONFIG>. Our presets rely on this, and NEW keeps the MSVC
+# runtime flag from leaking onto non-MSVC toolchains (e.g. MinGW GCC).
+if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.15.0")
+  cmake_policy(SET CMP0091 NEW)
+endif()
+
 project(StereoKit VERSION "0.4.0" LANGUAGES CXX C)
 
 # Add this repository's cmake modules to CMAKE_MODULE_PATH

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,6 +221,14 @@ if (SK_BUILD_OPENXR_LOADER)
   )
   target_compile_options(openxr_loader PRIVATE $<$<CXX_COMPILER_ID:GNU>:-w> $<$<CXX_COMPILER_ID:Clang>:-w> $<$<CXX_COMPILER_ID:MSVC>:/W0>)
   
+  # OpenXR-SDK pins the loader to the dynamic CRT (/MD) when it's built as a
+  # static lib, which collides (LNK2038) with our static-CRT build. Re-assert
+  # our runtime on the target so both sides match.
+  if (CMAKE_MSVC_RUNTIME_LIBRARY)
+    set_target_properties(openxr_loader PROPERTIES
+      MSVC_RUNTIME_LIBRARY "${CMAKE_MSVC_RUNTIME_LIBRARY}")
+  endif()
+
   set(OPENXR_LIB openxr_loader)
 endif()
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -32,11 +32,10 @@
     },
     {
       "name":        "Win32_Release_MT_Flags",
-      "description": "Static runtime flags for Win32 Release builds",
+      "description": "Static CRT for Win32 Release builds (requires CMP0091 NEW)",
       "hidden":      true,
       "cacheVariables": {
-        "CMAKE_CXX_FLAGS_RELEASE": "/MT",
-        "CMAKE_C_FLAGS_RELEASE": "/MT"
+        "CMAKE_MSVC_RUNTIME_LIBRARY": "MultiThreaded"
       }
     },
     {


### PR DESCRIPTION
Previous method would get /MT into compilers that would get confused by it. MinGW in particular had some issues. This fix uses a more modern way to insert the MT libraries.