### PR TITLE
Potential fix for dynamic mesh sync issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -292,7 +292,7 @@ if (NOT SK_LOCAL_SK_RENDERER)
   CPMAddPackage(
     NAME sk_renderer
     GITHUB_REPOSITORY StereoKit/sk_renderer
-    GIT_TAG v2026.5.20
+    GIT_TAG v2026.5.28
   )
 else()
   # For building directly with in-progress sk_renderer changes, point this to your


### PR DESCRIPTION
This pulls an sk_renderer update that adds an extra slot to the dynamic mesh ring buffer. In theory, this may avoid situations where SK is writing to a buffer that is currently actively being rendered. This worked previously on certain systems that may have different behaviors for synchronizing data for objects that were already submitted for rendering.