### PR TITLE
Istepper priority via `[StepperPriority()]`

### DIFF
--- a/Examples/StereoKitTest/Docs/DocFeatureImage.cs
+++ b/Examples/StereoKitTest/Docs/DocFeatureImage.cs
@@ -12,6 +12,9 @@ class DocFeatureImage : ITest
 	Vec3 screenshotFrom = new Vec3(0.103f, -0.032f, -0.308f);
 	Vec3 screenshotAt   = new Vec3(0.297f, -0.536f, -1.149f);
 
+	bool oldFingerGlow;
+	bool oldHandVisible;
+
 	// Oculus hand joints have a twisted thumb
 	static void FixHand(HandJoint[] joints, Quat rot, Vec3 translate)
 	{
@@ -35,10 +38,19 @@ class DocFeatureImage : ITest
 		FixHand(rightHand, Quat.FromAngles(0, 0, 90), Vec3.Zero);
 		Tests.Hand(Handed.Right, rightHand);
 		Tests.Hand(Handed.Left,  leftHand);
+
+		// Force hands visible and glowing for the screenshot, restoring the
+		// previous state in Shutdown.
+		oldFingerGlow  = Input.FingerGlow;
+		oldHandVisible = Input.HandGetVisible(Handed.Max);
+		Input.HandVisible(Handed.Max, true);
+		Input.FingerGlow = true;
 	}
 
 	public void Shutdown()
 	{
+		Input.HandVisible(Handed.Max, oldHandVisible);
+		Input.FingerGlow = oldFingerGlow;
 	}
 
 	public void Step()

--- a/Examples/StereoKitTest/Tests/TestStepperOrder.cs
+++ b/Examples/StereoKitTest/Tests/TestStepperOrder.cs
@@ -1,0 +1,97 @@
+using StereoKit;
+using StereoKit.Framework;
+using System.Collections.Generic;
+
+class TestStepperOrder : ITest
+{
+	// A running record of the order steppers and the app's Step ran in. It's
+	// cleared at the very start of each frame and snapshotted at the very end,
+	// so `captured` always holds one complete, clean frame.
+	static List<string> order    = new List<string>();
+	static List<string> captured = new List<string>();
+
+	// An IStepper that logs its priority tag when stepped. Priority is supplied
+	// via the StepperPriority attribute on each derived type, since the
+	// attribute is type-level metadata.
+	abstract class OrderStepper : IStepper
+	{
+		public abstract string Tag { get; }
+		public bool Enabled       => true;
+		public bool Initialize    () => true;
+		public void Shutdown      () { }
+		public void Step          () => order.Add(Tag);
+	}
+
+	// Runs first each frame (lowest priority) and clears the log. Records
+	// nothing itself.
+	[StepperPriority(-1000)] class StepperReset : IStepper
+	{
+		public bool Enabled    => true;
+		public bool Initialize () => true;
+		public void Shutdown   () { }
+		public void Step       () => order.Clear();
+	}
+
+	// Runs last each frame (highest priority) and snapshots the completed
+	// frame. Records nothing itself.
+	[StepperPriority(1000)] class StepperCapture : IStepper
+	{
+		public bool Enabled    => true;
+		public bool Initialize () => true;
+		public void Shutdown   () { }
+		public void Step       () { captured = new List<string>(order); }
+	}
+
+	[StepperPriority(-10)] class StepperNeg10 : OrderStepper { public override string Tag => "-10"; }
+	[StepperPriority( -1)] class StepperNeg1  : OrderStepper { public override string Tag => "-1";  }
+	/* default 0 */        class StepperZero  : OrderStepper { public override string Tag => "0";   }
+	[StepperPriority(  1)] class StepperPos1  : OrderStepper { public override string Tag => "1";   }
+	[StepperPriority( 10)] class StepperPos10 : OrderStepper { public override string Tag => "10";  }
+
+	public void Initialize()
+	{
+		// Add in a deliberately scrambled order to prove sorting, not add-order,
+		// determines execution order.
+		SK.AddStepper<StepperPos1  >();
+		SK.AddStepper<StepperNeg1  >();
+		SK.AddStepper<StepperCapture>();
+		SK.AddStepper<StepperPos10 >();
+		SK.AddStepper<StepperZero  >();
+		SK.AddStepper<StepperReset >();
+		SK.AddStepper<StepperNeg10 >();
+
+		// Steppers are initialized at the start of the next frame, so let a few
+		// frames run to capture a complete clean frame.
+		Tests.RunForFrames(4);
+	}
+
+	public void Step()
+	{
+		// The pre-app steppers (priority <= 0) have already run this frame; mark
+		// the app step here, then the post-app steppers (priority > 0) append
+		// after us.
+		order.Add("app");
+	}
+
+	public void Shutdown()
+	{
+		SK.RemoveStepper<StepperReset  >();
+		SK.RemoveStepper<StepperCapture>();
+		SK.RemoveStepper<StepperNeg10  >();
+		SK.RemoveStepper<StepperNeg1   >();
+		SK.RemoveStepper<StepperZero   >();
+		SK.RemoveStepper<StepperPos1   >();
+		SK.RemoveStepper<StepperPos10  >();
+
+		// A full clean frame: negative/zero priorities sorted ascending, then
+		// the app Step, then positive priorities sorted ascending.
+		string[] expected = { "-10", "-1", "0", "app", "1", "10" };
+		Tests.Test(() =>
+		{
+			if (captured.Count != expected.Length) return false;
+			for (int i = 0; i < expected.Length; i++)
+				if (captured[i] != expected[i]) return false;
+			return true;
+		});
+	}
+}

--- a/Examples/StereoKitTest/Tools/LogWindow.cs
+++ b/Examples/StereoKitTest/Tools/LogWindow.cs
@@ -1,7 +1,7 @@
 ﻿// SPDX-License-Identifier: MIT
 // The authors below grant copyright rights under the MIT license:
-// Copyright (c) 2023-2025 Nick Klingensmith
-// Copyright (c) 2023-2025 Qualcomm Technologies, Inc.
+// Copyright (c) 2023-2026 Nick Klingensmith
+// Copyright (c) 2023-2026 Qualcomm Technologies, Inc.
 
 using System;
 using System.Collections.Generic;
@@ -15,6 +15,14 @@ namespace StereoKit.Framework
 			public LogLevel level;
 			public string   text;
 			public int      count;
+			public float    height; // Cached layout height (m), incl. padding.
+		}
+		// One entry per log line that intersects the viewport. Rebuilt only
+		// when the scroll, content, or width changes - not every frame.
+		struct VisibleLine
+		{
+			public int   index; // Index into 'items'.
+			public float y;     // Entry top, viewport-relative (0 = viewport top, down is -).
 		}
 		private bool enabled = false;
 		public  bool Enabled { get => enabled; set { enabled = value; pose = UI.PopupPose(); } }
@@ -27,8 +35,29 @@ namespace StereoKit.Framework
 		TextStyle styleErr;
 		TextStyle styleGraph;
 
-		List<LogItem> items = new List<LogItem>();
-		static float  logIndex = 0;
+		// lineSpacing sets the distance between every line equally - both separate
+		// entries and lines within a wrapped entry - so the two look identical.
+		const float lineSpacing = 1.4f; // Line spacing as a fraction of font height (TextStyle.LineHeightPct).
+		// Sizes in lines of log text, scaled to meters in Initialize so they track
+		// the font size.
+		const float viewLines  = 16;   // Viewport height, in lines.
+		const float badgeLines = 1.5f; // Badge width, in lines.
+
+		float rowPad     = 0; // Per-entry padding (m); derived from lineSpacing.
+		float viewHeight = 0; // Viewport height (m); viewLines scaled in Initialize.
+		float badgeSize  = 0; // Badge box width (m); badgeLines scaled in Initialize.
+
+		List<LogItem>     items   = new List<LogItem>();
+		List<VisibleLine> visible = new List<VisibleLine>();
+
+		float scroll        = 0;     // Scroll offset (m) from the top (oldest) of the content.
+		float scrollMax     = 0;     // Largest valid scroll, so the newest line sits at the bottom.
+		float contentHeight = 0;     // Total height (m) of every log item.
+		bool  stickBottom   = true;  // Keep the view pinned to the newest line.
+		int   measuredCount = 0;     // How many items have a valid cached height.
+		float measureWidth  = 0;     // Width the cached heights were measured against.
+		float cachedScroll  = -1;    // Scroll value the visible list was built for.
+		bool  viewDirty     = true;
 
 		DiagGraph fpsGraph     = new DiagGraph(0, 0);
 		DiagGraph cpuPerfGraph = new DiagGraph(0, 0);
@@ -42,11 +71,25 @@ namespace StereoKit.Framework
 
 		public bool Initialize()
 		{
-			styleDiag  = TextStyle.FromFont(Font.Default, 0.008f, Color.HSV(1, 0, 0.7f));
-			styleInfo  = TextStyle.FromFont(Font.Default, 0.008f, Color.HSV(1, 0, 1));
-			styleWarn  = TextStyle.FromFont(Font.Default, 0.008f, Color.HSV(0.17f, 0.7f, 1));
-			styleErr   = TextStyle.FromFont(Font.Default, 0.008f, Color.HSV(1, 0.7f, 1));
-			styleGraph = TextStyle.FromFont(Font.Default, 1,      Color.HSV(1, 0, 1));
+			Font logFnt = Font.FromFamily("monospace");
+			styleDiag  = TextStyle.FromFont(logFnt, 0.008f, Color.HSV(1, 0, 0.7f));
+			styleInfo  = TextStyle.FromFont(logFnt, 0.008f, Color.HSV(1, 0, 1));
+			styleWarn  = TextStyle.FromFont(logFnt, 0.008f, Color.HSV(0.17f, 0.7f, 1));
+			styleErr   = TextStyle.FromFont(logFnt, 0.008f, Color.HSV(1, 0.7f, 1));
+			styleGraph = TextStyle.FromFont(logFnt, 1,      Color.HSV(1, 0, 1));
+
+			// Share the line spacing across every log style.
+			styleDiag.LineHeightPct = lineSpacing;
+			styleInfo.LineHeightPct = lineSpacing;
+			styleWarn.LineHeightPct = lineSpacing;
+			styleErr .LineHeightPct = lineSpacing;
+
+			// One line baseline to baseline; rowPad tops a single entry up to a full
+			// line (SizeLayout only returns the layout height), matching wrapped lines.
+			float line = styleInfo.TotalHeight * lineSpacing;
+			rowPad     = line - styleInfo.LayoutHeight;
+			viewHeight = line * viewLines;
+			badgeSize  = line * badgeLines;
 			return true;
 		}
 		public void Shutdown()
@@ -55,16 +98,18 @@ namespace StereoKit.Framework
 
 		void OnLog(LogLevel level, string logText)
 		{
-			if (level == LogLevel.Error)
-				level = LogLevel.Error;
-			if (items.Count>0 && items[items.Count-1].text == logText) {
-				LogItem item = items[items.Count - 1];
+			// Collapse a repeat of the previous line into a count on that entry.
+			int last = items.Count - 1;
+			if (last >= 0 && items[last].text == logText)
+			{
+				LogItem item = items[last];
 				item.count++;
-				items[items.Count - 1] = item;
+				items[last] = item;
 				return;
 			}
+			// New items append at the bottom, so existing scroll offsets stay valid;
+			// DrawLogs measures the new height and follows it if pinned to the bottom.
 			items.Add(new LogItem { level = level, text = logText, count = 1 });
-			if (logIndex != 0) logIndex += 1;
 		}
 
 		public void Step()
@@ -80,40 +125,101 @@ namespace StereoKit.Framework
 			UI.WindowEnd();
 		}
 
+		TextStyle StyleFor(LogLevel level) => level switch
+		{
+			LogLevel.Error      => styleErr,
+			LogLevel.Warning    => styleWarn,
+			LogLevel.Info       => styleInfo,
+			LogLevel.Diagnostic => styleDiag,
+			_                   => styleInfo,
+		};
+
+		// Fills 'visible' with each item that intersects the viewport, walking the
+		// content from the oldest (top) to newest (bottom). Each line stores only
+		// its top offset; clipping at both viewport edges is handled at draw time
+		// (see DrawLogs), so partially visible lines at the top and bottom are kept.
+		void RebuildVisible()
+		{
+			visible.Clear();
+			float o = 0; // Content offset (m) of the current item's top.
+			for (int i = 0; i < items.Count; i++)
+			{
+				float h    = items[i].height;
+				float topY = scroll - o; // Item top, viewport-relative (0 = top, down is -).
+				o += h;
+
+				if (topY >= h)           continue; // Entirely above the viewport.
+				if (topY <= -viewHeight) break;    // Entirely below the viewport.
+
+				visible.Add(new VisibleLine { index = i, y = topY });
+			}
+		}
+
 		void DrawLogs()
 		{
-			Vec2 textSize = V.XY(UI.LayoutRemaining.x, 0.024f);
-			const int count = 10;
+			float width     = UI.LayoutRemaining.x;
+			float sliderW   = UI.LineHeight*0.6f;
+			float textWidth = width - sliderW; // Stop short of the slider.
 
-			UI.LayoutPushCut(UICut.Top, textSize.y * count);
-			UI.LayoutPushCut(UICut.Right, UI.LineHeight*0.6f);
-			if (UI.VSlider("scroll", ref logIndex, 0, Math.Max(items.Count - 3, 0), 1))
-				logIndex = Math.Max(Math.Min((int)logIndex, items.Count - 1), 0);
+			// Measure & cache the layout height of any item not yet measured (or all
+			// of them if the width changed, since wrapping depends on it), keeping
+			// contentHeight and scrollMax current. Cheap unless something changed.
+			if (textWidth != measureWidth) { measuredCount = 0; measureWidth = textWidth; contentHeight = 0; }
+			if (measuredCount != items.Count)
+			{
+				for (int i = measuredCount; i < items.Count; i++)
+				{
+					LogItem item = items[i];
+					item.height   = Text.SizeLayout(item.text, StyleFor(item.level), textWidth).y + rowPad;
+					items[i]      = item;
+					contentHeight += item.height;
+				}
+				measuredCount = items.Count;
+				scrollMax     = Math.Max(0, contentHeight - viewHeight);
+				viewDirty     = true;
+			}
+
+			if (stickBottom) scroll = scrollMax;
+
+			UI.LayoutPushCut(UICut.Top, viewHeight);
+			UI.LayoutPushCut(UICut.Right, sliderW);
+			// The slider handle tracks the content directly: bottom of the track
+			// is the newest line, top is the oldest.
+			if (UI.VSlider("scroll", ref scroll, 0, scrollMax))
+				stickBottom = scroll >= scrollMax - 0.0001f;
 			UI.LayoutPop();
 
-			Vec3 start = UI.LayoutAt;
-			UI.LayoutReserve(V.XY(textSize.x, textSize.y*count));
-
-			int index = (int)logIndex;
-			for (int i = index; i < index + count && i < items.Count; i++)
+			// Rebuild the cached visible list only when the scroll or content moved.
+			scroll = Math.Clamp(scroll, 0, scrollMax);
+			if (scroll != cachedScroll || viewDirty)
 			{
-				LogItem item = items[(items.Count - 1) - i];
-				TextStyle ts = item.level switch
-				{
-					LogLevel.Error     => styleErr,
-					LogLevel.Warning   => styleWarn,
-					LogLevel.Info      => styleInfo,
-					LogLevel.Diagnostic=> styleDiag,
-					_                  => styleInfo,
-				};
-				float y = (i - index) * -textSize.y;
-				Text.Add(item.text, Matrix.T(start + new Vec3(0,y, -.004f)), textSize, TextFit.Clip | TextFit.Wrap, ts, Pivot.TopLeft, Align.CenterLeft);
+				RebuildVisible();
+				cachedScroll = scroll;
+				viewDirty    = false;
+			}
 
+			Vec3 start = UI.LayoutAt;
+			UI.LayoutReserve(V.XY(width, viewHeight));
+
+			// Text.Add's 'size' is also its clip rectangle, and it's computed from
+			// the pivot *before* offX/offY are applied - so the offset slides the text
+			// independently of the clip box. We anchor the box to the whole viewport
+			// and push each line into place with offY, which clips top *and* bottom in
+			// one uniform top-anchored pass. The badge shares the text's plane so it
+			// can't parallax-drift against it.
+			float  z        = start.z - 0.004f;
+			Matrix textTr   = Matrix.T(start.x,             start.y, z);
+			Matrix badgeTr  = Matrix.T(start.x - textWidth, start.y, z);
+			Vec2   textBox  = V.XY(textWidth, viewHeight);
+			Vec2   badgeBox = V.XY(badgeSize, viewHeight);
+			foreach (VisibleLine line in visible)
+			{
+				LogItem item = items[line.index];
+				Text.Add(item.text, textTr, textBox, TextFit.Clip | TextFit.Wrap, StyleFor(item.level), Pivot.TopLeft, Align.TopLeft, 0, line.y);
+
+				// Right-aligned duplicate-count badge, just inside the slider.
 				if (item.count > 1)
-				{
-					Vec3 at = V.XYZ(start.x - textSize.x, start.y + y, start.z-0.014f);
-					Text.Add(item.count.ToString(), Matrix.T(at), V.XY(textSize.y, textSize.y), TextFit.Clip, styleInfo, Pivot.TopRight, Align.Center);
-				}
+					Text.Add(item.count.ToString(), badgeTr, badgeBox, TextFit.Clip, styleInfo, Pivot.TopRight, Align.TopRight, 0, line.y);
 			}
 			UI.LayoutPop();
 		}
@@ -129,20 +235,16 @@ namespace StereoKit.Framework
 			float thirdWidth = (UI.LayoutRemaining.x - UI.Settings.gutter*2) / 3.0f;
 			Vec2  graphSize  = V.XY(thirdWidth, UI.LineHeight);
 
-			fpsGraph.Add(Time.Stepf*1000);
-			fpsGraph.Draw(styleGraph, "Frame (ms)", UI.LayoutAt + V.XYZ(0,0,-0.004f), graphSize);
-			UI.LayoutReserve(graphSize);
-			UI.SameLine();
-
-			cpuPerfGraph.Add(Time.PerfCPUus / 1000.0f);
-			cpuPerfGraph.Draw(styleGraph, "CPU (ms)", UI.LayoutAt + V.XYZ(0,0,-0.004f), graphSize);
-			UI.LayoutReserve(graphSize);
-			UI.SameLine();
-
-			gpuPerfGraph.Add(Time.PerfGPUus / 1000.0f);
-			gpuPerfGraph.Draw(styleGraph, "GPU (ms)", UI.LayoutAt + V.XYZ(0,0,-0.004f), graphSize);
-			UI.LayoutReserve(graphSize);
-			UI.SameLine();
+			void Graph(ref DiagGraph graph, string label, float ms)
+			{
+				graph.Add(ms);
+				graph.Draw(styleGraph, label, UI.LayoutAt + V.XYZ(0,0,-0.004f), graphSize);
+				UI.LayoutReserve(graphSize);
+				UI.SameLine();
+			}
+			Graph(ref fpsGraph,     "Frame (ms)", Time.Stepf*1000);
+			Graph(ref cpuPerfGraph, "CPU (ms)",   Time.PerfCPUus / 1000.0f);
+			Graph(ref gpuPerfGraph, "GPU (ms)",   Time.PerfGPUus / 1000.0f);
 		}
 
 		struct DiagGraph

--- a/StereoKit/Framework/IStepper.cs
+++ b/StereoKit/Framework/IStepper.cs
@@ -31,8 +31,11 @@
 		bool Initialize();
 
 		/// <summary>This Step method will be called every frame of the
-		/// application, as long as `Enabled` is `true`. This happens
-		/// immediately before the main application's `Step` callback.
+		/// application, as long as `Enabled` is `true`. By default this happens
+		/// immediately before the main application's `Step` callback, but this
+		/// can be configured by adding a `[StepperPriority]` attribute to the
+		/// `IStepper` type: a positive priority steps _after_ the app's `Step`
+		/// callback, and `IStepper`s are sorted in ascending order of priority.
 		/// </summary>
 		void Step();
 

--- a/StereoKit/Framework/StepperPriorityAttribute.cs
+++ b/StereoKit/Framework/StepperPriorityAttribute.cs
@@ -1,0 +1,35 @@
+using System;
+
+namespace StereoKit.Framework
+{
+	/// <summary>An optional `[StepperPriority]` attribute for `IStepper` types
+	/// that controls when and in what order their `Step` method is called
+	/// relative to the app's main `Step` callback.
+	///
+	/// The priority value determines both the _phase_ and the _sort order_:
+	/// `IStepper`s with a negative priority (or the default of 0) are stepped
+	/// _before_ the app's main `Step` callback, and `IStepper`s with a positive
+	/// priority are stepped _after_ it. In all cases, `IStepper`s are stepped in
+	/// ascending order of priority, and ties preserve the order they were added
+	/// in.
+	///
+	/// If an `IStepper` type does not have this attribute, it behaves as though
+	/// it has a priority of 0.</summary>
+	[AttributeUsage(AttributeTargets.Class, Inherited = true)]
+	public sealed class StepperPriorityAttribute : Attribute
+	{
+		/// <summary>The priority value for this `IStepper`. Negative or zero
+		/// values step before the app's main `Step` callback, positive values
+		/// step after it, and all `IStepper`s are sorted in ascending order by
+		/// this value.</summary>
+		public int Priority { get; }
+
+		/// <summary>Creates a priority attribute for an `IStepper` type.
+		/// </summary>
+		/// <param name="priority">The priority value. Negative or zero values
+		/// step before the app's main `Step` callback, positive values step
+		/// after it, and all `IStepper`s are sorted in ascending order by this
+		/// value.</param>
+		public StepperPriorityAttribute(int priority) { Priority = priority; }
+	}
+}

--- a/StereoKit/Framework/Steppers.cs
+++ b/StereoKit/Framework/Steppers.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Reflection;
 
 namespace StereoKit.Framework
 {
@@ -13,15 +14,33 @@ namespace StereoKit.Framework
 			public ActionType type;
 			public StepperAction(IStepper stepper, ActionType type) { this.stepper = stepper; this.type = type; }
 		}
+		struct StepperItem
+		{
+			public IStepper stepper;
+			public int      priority;
+			public StepperItem(IStepper stepper, int priority) { this.stepper = stepper; this.priority = priority; }
+		}
 		readonly object                _stepperLock = new object();
-		List           <IStepper>      _steppers    = new List<IStepper>();
+		List           <StepperItem>   _steppers    = new List<StepperItem>();
 		ConcurrentQueue<StepperAction> _actions     = new ConcurrentQueue<StepperAction>();
+		// _steppers is sorted ascending by priority, and this is the index of
+		// the first stepper with a priority greater than zero. It's the boundary
+		// between the pre-app steppers [0.._postApp) and the post-app steppers
+		// [_postApp..Count), maintained as items are inserted and removed.
+		int                            _postApp     = 0;
 
-		public IEnumerable<IStepper> steppers { get { return _steppers; } }
+		public IEnumerable<IStepper> steppers
+		{
+			get
+			{
+				foreach (StepperItem item in _steppers)
+					yield return item.stepper;
+			}
+		}
 
 		// Add steppers via the threadsafe action queue
 		public T Add<T>() where T : IStepper
-		{ 
+		{
 			T inst = Activator.CreateInstance<T>();
 			_actions.Enqueue(new StepperAction(inst, ActionType.Add));
 			return inst;
@@ -46,10 +65,10 @@ namespace StereoKit.Framework
 		{
 			lock (_stepperLock)
 			{
-				foreach (IStepper stepper in _steppers)
+				foreach (StepperItem item in _steppers)
 				{
-					if (type.IsAssignableFrom(stepper.GetType()))
-						_actions.Enqueue(new StepperAction(stepper, ActionType.Remove));
+					if (type.IsAssignableFrom(item.stepper.GetType()))
+						_actions.Enqueue(new StepperAction(item.stepper, ActionType.Remove));
 				}
 			}
 		}
@@ -64,10 +83,10 @@ namespace StereoKit.Framework
 		{
 			lock (_stepperLock)
 			{
-				foreach (IStepper stepper in _steppers)
+				foreach (StepperItem item in _steppers)
 				{
-					if (type.IsAssignableFrom(stepper.GetType()))
-						return stepper;
+					if (type.IsAssignableFrom(item.stepper.GetType()))
+						return item.stepper;
 				}
 			}
 			foreach (StepperAction action in _actions)
@@ -89,31 +108,71 @@ namespace StereoKit.Framework
 					case ActionType.Add:
 						if (action.stepper.Initialize())
 						{
-							lock (_stepperLock) _steppers.Add(action.stepper);
+							// Read the priority from the optional [StepperPriority]
+							// attribute, defaulting to 0 when it's absent.
+							StepperPriorityAttribute attr = action.stepper.GetType().GetCustomAttribute<StepperPriorityAttribute>(true);
+							StepperItem item = new StepperItem(action.stepper, attr?.Priority ?? 0);
+
+							// Insert keeping _steppers sorted ascending by priority.
+							// This is stable: an item is placed after any existing
+							// items with an equal priority, preserving add order.
+							lock (_stepperLock)
+							{
+								int i = _steppers.Count;
+								while (i > 0 && _steppers[i - 1].priority > item.priority)
+									i -= 1;
+								_steppers.Insert(i, item);
+								// A pre-app item pushes the boundary forward.
+								if (item.priority <= 0) _postApp += 1;
+							}
 						}
 						break;
 					case ActionType.Remove:
 						bool result = false;
-						lock (_stepperLock) result = _steppers.Remove(action.stepper);
+						lock (_stepperLock)
+						{
+							// Pull the boundary back for each pre-app item removed.
+							result = _steppers.RemoveAll(i =>
+							{
+								if (i.stepper != action.stepper) return false;
+								if (i.priority <= 0) _postApp -= 1;
+								return true;
+							}) > 0;
+						}
 						if (result) action.stepper.Shutdown();
 						break;
 				}
 			}
 		}
 
-		public void Step()
+		// Steps all ISteppers with a priority less than or equal to zero. This
+		// runs before the app's main Step callback. New stepper Add/Remove
+		// actions are also processed here, at the start of the frame.
+		public void StepPreApp()
 		{
 			DequeueActions();
 
-			foreach (IStepper stepper in _steppers)
-				stepper.Step();
+			// _steppers only changes via DequeueActions on this thread, so the
+			// list and _postApp boundary are stable for the rest of this frame.
+			for (int i = 0; i < _postApp; i += 1)
+				_steppers[i].stepper.Step();
+		}
+
+		// Steps all ISteppers with a priority greater than zero. This runs after
+		// the app's main Step callback.
+		public void StepPostApp()
+		{
+			int count = _steppers.Count;
+			for (int i = _postApp; i < count; i += 1)
+				_steppers[i].stepper.Step();
 		}
 
 		public void Shutdown()
 		{
 			_actions = new ConcurrentQueue<StepperAction>();
-			_steppers.ForEach(s => s.Shutdown());
+			_steppers.ForEach(i => i.stepper.Shutdown());
 			_steppers.Clear();
+			_postApp = 0;
 		}
 	}
 }

--- a/StereoKit/SK.cs
+++ b/StereoKit/SK.cs
@@ -215,10 +215,12 @@ namespace StereoKit
 		{
 			if (NativeAPI.sk_step(null) == false) return false;
 
-			_steppers.Step();
+			_steppers.StepPreApp();
 			while (_mainThreadInvoke.TryDequeue(out Action a)) a();
 
 			if (onStep != null) onStep();
+
+			_steppers.StepPostApp();
 
 			return true;
 		}
@@ -241,8 +243,7 @@ namespace StereoKit
 		/// StereoKit shuts down.</param>
 		public static void Run(Action onStep = null, Action onShutdown = null)
 		{
-			while (Step())
-				if (onStep != null) onStep();
+			while (Step(onStep)) { }
 
 			if (onShutdown != null) onShutdown();
 			Shutdown();


### PR DESCRIPTION
- Added a `[StepperPriority]` attribute that allows setting a sort order for the IStepper. Larger than 0 will run _after_ the app's Step, and less than 1 will run _before_ the app's step.
- Revised the Log window tool, now uses a monospace font, packs text closer together, flows in the right direction, and just generally looks better.
- Fixed the feature image, it wasn't showing the hand mesh/glow due to changes to the defaults.