### PR TITLE
Add interactor property getters to the public API.

### DIFF
--- a/Examples/StereoKitTest/Tests/TestInteractorVis.cs
+++ b/Examples/StereoKitTest/Tests/TestInteractorVis.cs
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: MIT
+// The authors below grant copyright rights under the MIT license:
+// Copyright (c) 2026 Nick Klingensmith
+// Copyright (c) 2026 Qualcomm Technologies, Inc.
+
+using System;
+using StereoKit;
+
+/// This test turns off StereoKit's built-in interactor visualization
+/// (`Interaction.DefaultDraw`) and attempts to replicate the internal far-ray
+/// indicator (`interactor_show_ray` in interactor_modes.cpp) entirely at the
+/// application level, using only the public `Interactor` API.
+///
+/// It drives a single custom Line interactor with simulated motion so the ray
+/// focuses and activates a UI button, exercising the "centered" / curved ray
+/// behavior the internal indicator produces.
+class TestInteractorVis : ITest
+{
+	DefaultInteractors prevDefault;
+	bool               prevDraw;
+	Interactor         ray;
+
+	// Per-interactor smoothing state. Internally this lives alongside each
+	// default interactor (interact_mode_hands_t::ray_visible / ray_active);
+	// here we keep it ourselves since we own the interactor.
+	float rayVisible = 0;
+	float rayActive  = 0;
+
+	Pose windowPose = new Pose(0, 0, -0.5f, Quat.LookDir(-Vec3.Forward));
+
+	// Origin of the ray, roughly where a hand's aim ray would start.
+	Vec3 rayOrigin = V.XYZ(0, -0.15f, 0.25f);
+
+	public void Initialize()
+	{
+		// Replace SK's default interactors with our own, and turn off the
+		// built-in ray visualization so we can draw our own.
+		prevDefault = Interaction.DefaultInteractors;
+		prevDraw    = Interaction.DefaultDraw;
+		Interaction.DefaultInteractors = DefaultInteractors.None;
+		Interaction.DefaultDraw        = false;
+
+		ray = Interactor.Create(InteractorType.Line, InteractorEvent.Pinch | InteractorEvent.Poke, InteractorActivation.State, 42, 0.05f, 2);
+
+		// The creation parameters are now readable back off the interactor.
+		Tests.Test(CreationParamsReadBack);
+
+		Tests.RunForFrames(20);
+	}
+
+	// Verifies the creation parameters can be read back off the Interactor
+	// exactly as they were passed to Interactor.Create above.
+	bool CreationParamsReadBack() =>
+		ray.Type          == InteractorType.Line                          &&
+		ray.Events        == (InteractorEvent.Pinch|InteractorEvent.Poke) &&
+		ray.Activation    == InteractorActivation.State                   &&
+		ray.InputSourceId == 42                                           &&
+		ray.SecondaryDims == 2;
+
+	public void Shutdown()
+	{
+		ray.Destroy();
+		Interaction.DefaultInteractors = prevDefault;
+		Interaction.DefaultDraw        = prevDraw;
+	}
+
+	Vec3 target;
+	public void Step()
+	{
+		// Aim the ray straight at the button so it stays focused, and report it
+		// as active so we exercise the active/curved branch of the indicator.
+		Vec3     dir    = (target - rayOrigin).Normalized;
+		BtnState active = BtnState.Active;
+		ray.Update(rayOrigin, rayOrigin + dir * 100, new Pose(rayOrigin, Quat.LookDir(dir)), rayOrigin, Vec3.Zero, active, BtnState.Active);
+
+		// Our application-level replica of the internal indicator.
+		ShowRay(ray, 0.07f, true, ref rayVisible, ref rayActive);
+
+		UI.WindowBegin("Interactor Vis", ref windowPose, V.XY(0.2f, 0));
+		UI.Button("Target");
+		target = Hierarchy.ToWorld(UI.LayoutLast.center - V.XYZ(UI.LayoutLast.dimensions.x/2 + ray.Radius*0.8f,0,0));
+		UI.WindowEnd();
+
+		// Screenshot late enough that the visibility/active smoothing has
+		// ramped up to full.
+		Tests.Screenshot("Tests/InteractorVis.jpg", 18, 600, 400, 60, V.XYZ(0.25f, 0.1f, 0.4f), V.XYZ(0, 0, -0.5f));
+	}
+
+	/// A direct port of `interactor_show_ray` from interactor_modes.cpp, built
+	/// only from the public `Interactor` API.
+	static void ShowRay(Interactor actor, float skip, bool hideInactive, ref float refVisibleAmt, ref float refActiveAmt)
+	{
+		if (!actor.Tracked.IsActive()) return;
+
+		bool  actorVisible = hideInactive == false || actor.Focused != IdHash.None;
+		refVisibleAmt = SKMath.Lerp(refVisibleAmt, actorVisible ? 1f : 0f, 16.0f * Time.StepUnscaledf);
+		float visibility = refVisibleAmt;
+		if (visibility < 0.001f) return;
+
+		refActiveAmt = SKMath.Lerp(refActiveAmt, actor.Active != IdHash.None ? 1f : 0f, 16.0f * Time.StepUnscaledf);
+		float active = refActiveAmt;
+
+		Vec3  motionPos     = actor.Motion.position;
+		float length        = 0.35f;
+		Vec3  uncenteredDir = (actor.End - motionPos).Normalized;
+		Vec3  centeredDir   = uncenteredDir;
+		if (actor.Focused != IdHash.None && actor.TryGetFocusBounds(out Pose poseWorld, out Bounds boundsLocal, out Vec3 atLocal))
+		{
+			Vec3 pt = poseWorld.ToMatrix().Transform(boundsLocal.center + atLocal);
+			length      = Vec3.Distance(pt, motionPos);
+			centeredDir = (pt - motionPos).Normalized;
+		}
+		length = SKMath.Lerp(0.35f, length, visibility);
+		length = Math.Max(0, length - skip);
+
+		float alpha = 0.35f + active * 0.65f;
+		if (hideInactive) alpha *= visibility;
+
+		const int   ct      = 20;
+		const float raySnap = 1.0f;
+		LinePoint[] pts = new LinePoint[ct];
+		for (int i = 0; i < ct; i++)
+		{
+			float pct   = (float)i / (ct - 1);
+			float blend = pct * pct * pct * raySnap;
+			float d     = skip + pct * length;
+
+			float pctI  = 1 - pct;
+			float curve = SKMath.Lerp(
+				MathF.Sin(pctI * pctI * MathF.PI),
+				MathF.Min(1f, MathF.Sin(pct * pct * MathF.PI) * 1.5f), active);
+			float width = (0.002f + curve * 0.003f) * visibility;
+			Vec3  at    = motionPos + Vec3.Lerp(uncenteredDir * d, centeredDir * d, blend);
+			pts[i] = new LinePoint(at, new Color32(255, 255, 255, (byte)(curve * alpha * 255)), width);
+		}
+		Lines.Add(pts);
+	}
+}

--- a/StereoKit/Native/NativeAPI.cs
+++ b/StereoKit/Native/NativeAPI.cs
@@ -769,6 +769,11 @@ namespace StereoKit
 		[return: MarshalAs(UnmanagedType.Bool)]
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern bool         interactor_get_focus_bounds(int interactor, out Pose out_pose_world, out Bounds out_bounds_local, out Vec3 out_at_local);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern Pose         interactor_get_motion(int interactor);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern InteractorType interactor_get_type(int interactor);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern InteractorEvent interactor_get_events(int interactor);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern InteractorActivation interactor_get_activation(int interactor);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern int          interactor_get_input_source_id(int interactor);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern int          interactor_get_secondary_dims(int interactor);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern int          interactor_count();
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern int          interactor_get(int index);
 

--- a/StereoKit/Systems/Interactor.cs
+++ b/StereoKit/Systems/Interactor.cs
@@ -66,6 +66,34 @@ namespace StereoKit
 		/// may be something else!</summary>
 		public Pose     Motion  => NativeAPI.interactor_get_motion (_inst);
 
+		/// <summary>A line, or a point? These interactors behave slightly
+		/// differently with respect to distance checks and directionality. See
+		/// `InteractorType` for more details. This is set at creation time and
+		/// does not change.</summary>
+		public InteractorType       Type       => NativeAPI.interactor_get_type(_inst);
+		/// <summary>What type of interaction events does this interactor fire?
+		/// Interaction elements use this bitflag as a filter to avoid
+		/// interacting with certain interactors. This is set at creation time
+		/// and does not change.</summary>
+		public InteractorEvent      Events     => NativeAPI.interactor_get_events(_inst);
+		/// <summary>How does this interactor activate elements? Does it use the
+		/// physical position of the interactor, or its activation state? This is
+		/// set at creation time and does not change.</summary>
+		public InteractorActivation Activation => NativeAPI.interactor_get_activation(_inst);
+		/// <summary>An identifier that uniquely indicates a shared source for
+		/// inputs. Interactors that share a source will deactivate each other
+		/// when one becomes active, for example the poke, pinch, and aim
+		/// interactors of a single hand. A negative id indicates a unique source
+		/// that does not check against others. This is set at creation time and
+		/// does not change.</summary>
+		public int                  InputSourceId => NativeAPI.interactor_get_input_source_id(_inst);
+		/// <summary>How many axes of secondary motion can this interactor
+		/// provide? Secondary motion is input that comes from somewhere other
+		/// than the interactor's own movement through space. For example, a
+		/// mouse's scroll wheel is 1 axis, and a controller's analog thumbstick
+		/// is 2 axes (X/Y). This should be 0-3.</summary>
+		public int                  SecondaryDims => NativeAPI.interactor_get_secondary_dims(_inst);
+
 		/// <summary>Update the interactor with data for the current frame!
 		/// This should be called as soon as possible at the start of the frame
 		/// before any UI is done, otherwise the UI will not properly react.</summary>
@@ -127,7 +155,10 @@ namespace StereoKit
 		/// <param name="capsuleRadius">The radius of the interactor's capsule,
 		/// in meters.</param>
 		/// <param name="secondaryMotionDimensions">How many axes of secondary
-		/// motion can this interactor provide? This should be 0-3.</param>
+		/// motion can this interactor provide? Secondary motion is input from a
+		/// source other than the interactor's own movement, such as a mouse's
+		/// scroll wheel (1 axis) or a controller's analog thumbstick (2 axes,
+		/// X/Y). This should be 0-3.</param>
 		/// <returns>The Interactor that was just created.</returns>
 		public static Interactor Create(InteractorType shapeType, InteractorEvent events, InteractorActivation activationType, int inputSourceId, float capsuleRadius, int secondaryMotionDimensions)
 			=> new Interactor(NativeAPI.interactor_create(shapeType, events, activationType, inputSourceId, capsuleRadius, secondaryMotionDimensions));

--- a/StereoKitC/stereokit.h
+++ b/StereoKitC/stereokit.h
@@ -2510,6 +2510,11 @@ SK_API id_hash_t             interactor_get_focused             (const interacto
 SK_API id_hash_t             interactor_get_active              (const interactor_t interactor);
 SK_API bool32_t              interactor_get_focus_bounds        (const interactor_t interactor, pose_t* out_pose_world, bounds_t* out_bounds_local, vec3* out_at_local);
 SK_API pose_t                interactor_get_motion              (const interactor_t interactor);
+SK_API interactor_type_      interactor_get_type                (const interactor_t interactor);
+SK_API interactor_event_     interactor_get_events              (const interactor_t interactor);
+SK_API interactor_activation_ interactor_get_activation         (const interactor_t interactor);
+SK_API int32_t               interactor_get_input_source_id     (const interactor_t interactor);
+SK_API int32_t               interactor_get_secondary_dims      (const interactor_t interactor);
 
 SK_API int32_t               interactor_count                   (void);
 SK_API interactor_t          interactor_get                     (int32_t index);

--- a/StereoKitC/ui/interactors.cpp
+++ b/StereoKitC/ui/interactors.cpp
@@ -508,6 +508,41 @@ pose_t interactor_get_motion(interactor_t interactor) {
 
 ///////////////////////////////////////////
 
+interactor_type_ interactor_get_type(interactor_t interactor) {
+	_interactor_t* actor = _interactor_get(interactor);
+	return actor ? actor->shape_type : interactor_type_point;
+}
+
+///////////////////////////////////////////
+
+interactor_event_ interactor_get_events(interactor_t interactor) {
+	_interactor_t* actor = _interactor_get(interactor);
+	return actor ? actor->events : (interactor_event_)0;
+}
+
+///////////////////////////////////////////
+
+interactor_activation_ interactor_get_activation(interactor_t interactor) {
+	_interactor_t* actor = _interactor_get(interactor);
+	return actor ? actor->activation_type : interactor_activation_state;
+}
+
+///////////////////////////////////////////
+
+int32_t interactor_get_input_source_id(interactor_t interactor) {
+	_interactor_t* actor = _interactor_get(interactor);
+	return actor ? actor->input_source_id : 0;
+}
+
+///////////////////////////////////////////
+
+int32_t interactor_get_secondary_dims(interactor_t interactor) {
+	_interactor_t* actor = _interactor_get(interactor);
+	return actor ? actor->secondary_motion_dimensions : 0;
+}
+
+///////////////////////////////////////////
+
 bool32_t interactor_check_box(const _interactor_t* actor, bounds_t box, vec3* out_at, float* out_distance) {
 	*out_distance = FLT_MAX;
 	*out_at       = vec3_zero;


### PR DESCRIPTION
- Added properties to `Interactor`: `Type`, `Events`, `Activation`, `InputSourceId`, and `SecondaryDims`
- Added a `TestInteractorVis.cs` to verify SK's internal interactor visualization can be replicated with top level APIs.