### PR TITLE
Fix for NRE if default interactors are destroyed externally

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,7 +97,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         ref: ${{ inputs.branch }}
-    - uses: lukka/get-cmake@v3.26.3
+    - uses: lukka/get-cmake@v4.3.3
 
     - name: Get Cache
       uses: actions/cache@v4
@@ -142,7 +142,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         ref: ${{ inputs.branch }}
-    - uses: lukka/get-cmake@v3.26.3
+    - uses: lukka/get-cmake@v4.3.3
 
     - name: Get Cache
       uses: actions/cache@v4
@@ -234,7 +234,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         ref: ${{ inputs.branch }}
-    - uses: lukka/get-cmake@v3.26.3
+    - uses: lukka/get-cmake@v4.3.3
 
     - name: Get Cache
       uses: actions/cache@v4

--- a/.github/workflows/verify_compile.yml
+++ b/.github/workflows/verify_compile.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: lukka/get-cmake@v3.26.3
+    - uses: lukka/get-cmake@v4.3.3
 
     - name: Get Cache
       uses: actions/cache@v3
@@ -35,7 +35,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: lukka/get-cmake@v3.26.3
+    - uses: lukka/get-cmake@v4.3.3
 
     - name: Get Cache
       uses: actions/cache@v3
@@ -56,7 +56,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: lukka/get-cmake@v3.26.3
+    - uses: lukka/get-cmake@v4.3.3
 
     - name: Get Cache
       uses: actions/cache@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -617,6 +617,11 @@ add_library(StereoKitC ${LIBRARY_TYPE}
 if (ANDROID)
   set_property(TARGET StereoKitC PROPERTY CXX_STANDARD 11)
   set_property(TARGET StereoKitC PROPERTY CXX_STANDARD_REQUIRED ON)
+elseif (MSVC)
+  # C++/WinRT (isac_spatial_sound.cpp) needs C++20's <coroutine>, the
+  # <experimental/coroutine> it falls back to in C++17 is removed in VS2026.
+  set_property(TARGET StereoKitC PROPERTY CXX_STANDARD 20)
+  set_property(TARGET StereoKitC PROPERTY CXX_STANDARD_REQUIRED ON)
 else()
   set_property(TARGET StereoKitC PROPERTY CXX_STANDARD 17)
   set_property(TARGET StereoKitC PROPERTY CXX_STANDARD_REQUIRED ON)

--- a/Examples/StereoKitTest/Demos/DemoUIGrabBar.cs
+++ b/Examples/StereoKitTest/Demos/DemoUIGrabBar.cs
@@ -18,6 +18,9 @@ class DemoUIGrabBar : ITest
 		UISettings settings = UI.Settings;
 		float      barSize  = Math.Max(0.01f, settings.rounding * 2);
 
+		// Show the window grab bar at its own location.
+		UI.Handle("GrabBar", ref grabBarPose, new Bounds(new Vec3(windowSize.x * 0.9f, barSize, settings.depth)), true, UIMove.FaceUser);
+
 		// Use the size of the Window to position it directly above the grab
 		// bar. Note that we're using the Pose relative Up direction instead of
 		// just the Y axis.
@@ -38,9 +41,6 @@ class DemoUIGrabBar : ITest
 
 		// Save the size of the window.
 		windowSize = UI.LayoutLast.dimensions.XY;
-
-		// Show the window grab bar at its own location.
-		UI.Handle("GrabBar", ref grabBarPose, new Bounds(new Vec3(windowSize.x * 0.9f, barSize, settings.depth)), true, UIMove.FaceUser);
 	}
 
 	public void Initialize() {}

--- a/Examples/StereoKitTest/Tests/TestInteractorDestroy.cs
+++ b/Examples/StereoKitTest/Tests/TestInteractorDestroy.cs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 // The authors below grant copyright rights under the MIT license:
 // Copyright (c) 2026 Nick Klingensmith
+// Copyright (c) 2026 Qualcomm Technologies, Inc.
 
 using StereoKit;
 

--- a/Examples/StereoKitTest/Tests/TestInteractorDestroy.cs
+++ b/Examples/StereoKitTest/Tests/TestInteractorDestroy.cs
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MIT
+// The authors below grant copyright rights under the MIT license:
+// Copyright (c) 2026 Nick Klingensmith
+
+using StereoKit;
+
+/// <summary>Users are allowed to destroy StereoKit's system interactors via
+/// Interactor.Destroy! This shouldn't crash the input or UI systems, they
+/// should just quietly stop interacting until a mode switch recreates them.
+/// This guards against a real issue where the rust bindings implicitly
+/// destroyed system interactors, crashing interactor mode updates.</summary>
+internal class TestInteractorDestroy : ITest
+{
+	int  frame = 0;
+	Pose windowPose = new Pose(0, 0, -0.5f, Quat.FromAngles(0, 180, 0));
+	DefaultInteractors prevInteractors;
+
+	public void Initialize()
+	{
+		prevInteractors = Interaction.DefaultInteractors;
+		Tests.RunForFrames(8);
+	}
+	public void Shutdown()
+	{
+		// Finish restoring the interactors we destroyed, the mode switch back
+		// from None recreates them. See the end of Step.
+		Interaction.DefaultInteractors = prevInteractors;
+	}
+
+	public void Step()
+	{
+		frame++;
+		// Destroying interactors is a blocker when visiting this scene
+		// interactively, so only do it during automated test runs.
+		if (Tests.IsTesting)
+		{
+			if (frame == 4)
+			{
+				foreach (Interactor i in Interactor.All)
+					i.Destroy();
+				Log.Info("Destroyed all system interactors");
+			}
+			// Interactors only recreate via a mode switch, so spend the last
+			// frames at None, and Shutdown will switch back to recreate them.
+			if (frame == 6)
+				Interaction.DefaultInteractors = DefaultInteractors.None;
+		}
+
+		// UI and interactor queries should still behave with no interactors
+		// present.
+		UI.WindowBegin("Interactor Destroy", ref windowPose);
+		UI.Button("Still alive?");
+		UI.WindowEnd();
+		foreach (Interactor i in Interactor.All)
+			_ = i.Tracked;
+	}
+}

--- a/StereoKitC/stereokit_ui.h
+++ b/StereoKitC/stereokit_ui.h
@@ -487,18 +487,7 @@ SK_CONST char* ui_default_id_spr_grid        = "sk/ui/grid";
 #define ui_toggle_sz_16     ui_toggle_16
 #define ui_toggle_img_sz    ui_toggle_img
 #define ui_toggle_img_sz_16 ui_toggle_img_16
-#pragma deprecated(ui_label_sz)
-#pragma deprecated(ui_label_sz_16)
-#pragma deprecated(ui_text_sz)
-#pragma deprecated(ui_text_sz_16)
-#pragma deprecated(ui_button_sz)
-#pragma deprecated(ui_button_sz_16)
-#pragma deprecated(ui_button_img_sz)
-#pragma deprecated(ui_button_img_sz_16)
-#pragma deprecated(ui_toggle_sz)
-#pragma deprecated(ui_toggle_sz_16)
-#pragma deprecated(ui_toggle_img_sz)
-#pragma deprecated(ui_toggle_img_sz_16)
+#if defined(__clang__)
 #pragma clang deprecated(ui_label_sz)
 #pragma clang deprecated(ui_label_sz_16)
 #pragma clang deprecated(ui_text_sz)
@@ -511,6 +500,22 @@ SK_CONST char* ui_default_id_spr_grid        = "sk/ui/grid";
 #pragma clang deprecated(ui_toggle_sz_16)
 #pragma clang deprecated(ui_toggle_img_sz)
 #pragma clang deprecated(ui_toggle_img_sz_16)
+#elif defined(_MSC_VER)
+// MSVC requires quotes here, otherwise the macros get expanded and the
+// pragma deprecates the functions they point to!
+#pragma deprecated("ui_label_sz")
+#pragma deprecated("ui_label_sz_16")
+#pragma deprecated("ui_text_sz")
+#pragma deprecated("ui_text_sz_16")
+#pragma deprecated("ui_button_sz")
+#pragma deprecated("ui_button_sz_16")
+#pragma deprecated("ui_button_img_sz")
+#pragma deprecated("ui_button_img_sz_16")
+#pragma deprecated("ui_toggle_sz")
+#pragma deprecated("ui_toggle_sz_16")
+#pragma deprecated("ui_toggle_img_sz")
+#pragma deprecated("ui_toggle_img_sz_16")
+#endif
 
 #ifdef __cplusplus
 } // namespace sk

--- a/StereoKitC/ui/interactor_modes.cpp
+++ b/StereoKitC/ui/interactor_modes.cpp
@@ -177,7 +177,7 @@ void interact_mode_switch(interact_mode_ mode) {
 
 void interactor_show_ray(interactor_t interactor, float skip, bool hide_inactive, float *ref_visible_amt, float *ref_active_amt) {
 	_interactor_t* actor = _interactor_get(interactor);
-	if ((actor->tracked & button_state_active) == 0) return;
+	if (actor == nullptr || (actor->tracked & button_state_active) == 0) return;
 
 	bool  actor_visible = hide_inactive == false || actor->focused_prev != 0;
 	float visibility    = 1;
@@ -261,13 +261,15 @@ void interact_mode_hands_step(interact_mode_hands_t* ref_hands) {
 		const hand_t* hand = input_hand((handed_)i);
 
 		// Poke
-		interactor_t id         = ref_hands->poke[i];
+		interactor_t   id         = ref_hands->poke[i];
 		_interactor_t* interactor = _interactor_get(id);
-		interactor_set_radius(id, hand->fingers[1][4].radius);
-		interactor_update    (id,
-			(hand->tracked_state & button_state_just_active) ? hand->fingers[1][4].position : interactor->capsule_end_world, hand->fingers[1][4].position,
-			pose_t{ hand->fingers[1][4].position, hand->palm.orientation }, hand->fingers[1][4].position, vec3_zero,
-			button_state_inactive, hand->tracked_state);
+		if (interactor != nullptr) {
+			interactor_set_radius(id, hand->fingers[1][4].radius);
+			interactor_update    (id,
+				(hand->tracked_state & button_state_just_active) ? hand->fingers[1][4].position : interactor->capsule_end_world, hand->fingers[1][4].position,
+				pose_t{ hand->fingers[1][4].position, hand->palm.orientation }, hand->fingers[1][4].position, vec3_zero,
+				button_state_inactive, hand->tracked_state);
+		}
 
 		// Pinch
 		id = ref_hands->pinch[i];
@@ -375,6 +377,9 @@ void interact_mode_mouse_stop(interact_mode_mouse_t* ref_mouse) {
 void interact_mode_mouse_step(interact_mode_mouse_t *ref_mouse) {
 	if (ui_far_interact_enabled() == false) return;
 
+	_interactor_t* actor = _interactor_get(ref_mouse->interactor);
+	if (actor == nullptr) return;
+
 	const mouse_t* m = input_mouse();
 	ray_t ray;
 	bool  tracked = ray_from_mouse(m->pos, ray);
@@ -383,7 +388,7 @@ void interact_mode_mouse_step(interact_mode_mouse_t *ref_mouse) {
 	interactor_update(ref_mouse->interactor,
 		ray.pos, end,
 		pose_t{ end, quat_lookat(ray.pos, end) }, end, vec3{ m->scroll_change / -6000.0f, 0, 0 },
-		input_key(key_mouse_left), button_make_state(_interactor_get(ref_mouse->interactor)->tracked & button_state_active, tracked));
+		input_key(key_mouse_left), button_make_state(actor->tracked & button_state_active, tracked));
 }
 
 ///////////////////////////////////////////
@@ -446,12 +451,13 @@ pointer_t input_pointer(int32_t index, input_source_ filter) {
 		int32_t idx = index + start;
 		if (idx > 1) return {};
 
-		interactor_t actor_id = local.controllers.far[idx];
+		_interactor_t* actor = _interactor_get(local.controllers.far[idx]);
+		if (actor == nullptr) return {};
 		pointer_t result   = {};
-		result.orientation = interactor_get_motion (actor_id).orientation;
-		result.state       = _interactor_get       (actor_id)->pinch_state;
-		result.tracked     = interactor_get_tracked(actor_id);
-		result.ray         = { _interactor_get(actor_id)->capsule_start_world, result.orientation * vec3_forward };
+		result.orientation = actor->motion.orientation;
+		result.state       = actor->pinch_state;
+		result.tracked     = actor->tracked;
+		result.ray         = { actor->capsule_start_world, result.orientation * vec3_forward };
 		result.source      = idx == 0 ? input_source_hand_left : input_source_hand_right;
 		return result;
 	} break;
@@ -463,23 +469,25 @@ pointer_t input_pointer(int32_t index, input_source_ filter) {
 		int32_t idx = index + start;
 		if (idx > 1) return {};
 
-		interactor_t actor_id = local.hands.far[idx];
+		_interactor_t* actor = _interactor_get(local.hands.far[idx]);
+		if (actor == nullptr) return {};
 		pointer_t result   = {};
-		result.orientation = interactor_get_motion (actor_id).orientation;
-		result.state       = _interactor_get        (actor_id)->pinch_state;
-		result.tracked     = interactor_get_tracked(actor_id);
-		result.ray         = { _interactor_get(actor_id)->capsule_start_world, result.orientation * vec3_forward };
+		result.orientation = actor->motion.orientation;
+		result.state       = actor->pinch_state;
+		result.tracked     = actor->tracked;
+		result.ray         = { actor->capsule_start_world, result.orientation * vec3_forward };
 		result.source      = idx == 0 ? input_source_hand_left : input_source_hand_right;
 		return result;
 	} break;
 	case interact_mode_mouse: {
 		if (index > 0) return {};
-		interactor_t actor_id = local.mouse.interactor;
+		_interactor_t* actor = _interactor_get(local.mouse.interactor);
+		if (actor == nullptr) return {};
 		pointer_t result   = {};
-		result.orientation = interactor_get_motion (actor_id).orientation;
-		result.state       = _interactor_get        (actor_id)->pinch_state;
-		result.tracked     = interactor_get_tracked(actor_id);
-		result.ray         = { _interactor_get(actor_id)->capsule_start_world, result.orientation * vec3_forward };
+		result.orientation = actor->motion.orientation;
+		result.state       = actor->pinch_state;
+		result.tracked     = actor->tracked;
+		result.ray         = { actor->capsule_start_world, result.orientation * vec3_forward };
 		result.source      = input_source_hand_right;
 		return result;
 	} break;

--- a/StereoKitC/ui/interactors.cpp
+++ b/StereoKitC/ui/interactors.cpp
@@ -579,6 +579,7 @@ bool32_t interactor_check_box(const _interactor_t* actor, bounds_t box, vec3* ou
 		if (actor->shape_type == interactor_type_line)
 			*out_distance += vec3_distance(*out_at, start_local);
 	}
+
 	// Point interactors should always be intersecting from their position,
 	// even if they're just passing through. Some elements rely on this
 	// position for animation and activation.


### PR DESCRIPTION
If the default interactors get destroyed while StereoKit was still using them, it didn't check for their validity. In this case, users should still be able to destroy the interactors manually if they so desire, so SK now checks for validity of the interactors before using them.