### PR TITLE
Improved Handles with multi-interactor and scaling

### DIFF
--- a/Examples/StereoKitCTest/demo_bvh.cpp
+++ b/Examples/StereoKitCTest/demo_bvh.cpp
@@ -124,19 +124,19 @@ void demo_bvh_update() {
 
 	// Model being intersected
 
-	ui_handle_begin("model", model_pose, model_to_intersection_bounds, false);
+	ui_handle_begin("model", model_pose, nullptr, model_to_intersection_bounds, false);
 	model_draw     (model_to_intersect, model_scale_matrix);
 	ui_handle_end  ();
 
 	// World-space ray defined by two endpoint handles
 
-	ui_handle_begin("from", from_pose, mesh_get_bounds(mesh_from), false, ui_move_pos_only);
+	ui_handle_begin("from", from_pose, nullptr, mesh_get_bounds(mesh_from), false, ui_move_pos_only);
 	mesh_draw      (mesh_from, ray_material, matrix_identity);
 	ui_handle_end  ();
 
 	to_pose.orientation = quat_lookat(from_pose.position, to_pose.position);
 
-	ui_handle_begin("to", to_pose, mesh_get_bounds(mesh_to), false, ui_move_pos_only);
+	ui_handle_begin("to", to_pose, nullptr, mesh_get_bounds(mesh_to), false, ui_move_pos_only);
 	mesh_draw      (mesh_to, ray_material, matrix_identity);
 	ui_handle_end  ();
 

--- a/Examples/StereoKitCTest/demo_desktop.cpp
+++ b/Examples/StereoKitCTest/demo_desktop.cpp
@@ -186,7 +186,7 @@ void demo_desktop_update() {
 	static pose_t desktop_pose        = pose_t{ vec3{0,0,-0.5f}, quat_lookat(vec3_zero, {0,0,1}) };
 	static pose_t desktop_pose_smooth = desktop_pose;
 	ui_enable_far_interact(false);
-	ui_handle_begin("Desktop", desktop_pose, bounds, true);
+	ui_handle_begin("Desktop", desktop_pose, nullptr, bounds, true);
 	ui_handle_end();
 	ui_enable_far_interact(true);
 

--- a/Examples/StereoKitCTest/demo_draw.cpp
+++ b/Examples/StereoKitCTest/demo_draw.cpp
@@ -23,7 +23,7 @@ void demo_draw_init() {
 ///////////////////////////////////////////
 
 void demo_draw_update() {
-	ui_handle_begin("Draw", draw_pose, mesh_get_bounds(draw_mesh), false);
+	ui_handle_begin("Draw", draw_pose, nullptr, mesh_get_bounds(draw_mesh), false);
 	mesh_draw      (draw_mesh, draw_material, matrix_identity);
 	ui_handle_end  ();
 }

--- a/Examples/StereoKitCTest/demo_lines.cpp
+++ b/Examples/StereoKitCTest/demo_lines.cpp
@@ -55,7 +55,7 @@ bool swatch_button(const char* id, vec2 c, vec2 size) {
 
 void demo_lines_palette()
 {
-	ui_handle_begin("PaletteMenu", line_palette_pose, model_get_bounds( line_palette_model ), false);
+	ui_handle_begin("PaletteMenu", line_palette_pose, nullptr, model_get_bounds( line_palette_model ), false);
 	render_add_model(line_palette_model, matrix_identity);
 	ui_push_surface({ {}, quat_from_angles(90,0,0) });
 

--- a/Examples/StereoKitCTest/demo_picker.cpp
+++ b/Examples/StereoKitCTest/demo_picker.cpp
@@ -109,7 +109,7 @@ void demo_picker_update() {
 
 	ui_window_end();
 	if (picker_model) {
-		ui_handle_begin("picker model", picker_pose, picker_bounds, false);
+		ui_handle_begin("picker model", picker_pose, nullptr, picker_bounds, false);
 		render_add_model(picker_model, matrix_trs(vec3_zero, quat_identity, vec3_one * picker_scale));
 		ui_handle_end();
 	}

--- a/Examples/StereoKitCTest/demo_shadows.cpp
+++ b/Examples/StereoKitCTest/demo_shadows.cpp
@@ -166,7 +166,7 @@ void demo_shadows_update() {
 
 	// UI handle for the model
 	bounds_t model_bounds = model_get_bounds(shadow_model);
-	ui_handle_begin("ShadowModel", shadow_model_pose, model_bounds, false, ui_move_exact);
+	ui_handle_begin("ShadowModel", shadow_model_pose, nullptr, model_bounds, false, ui_move_exact);
 	model_draw(shadow_model, matrix_identity);
 	ui_handle_end();
 }

--- a/Examples/StereoKitCTest/main.cpp
+++ b/Examples/StereoKitCTest/main.cpp
@@ -267,7 +267,7 @@ void common_shutdown() {
 
 void ruler_window() {
 	static pose_t window_pose = pose_t{{0, 0, 0.5f}, quat_identity};
-	ui_handle_begin("Ruler", window_pose,
+	ui_handle_begin("Ruler", window_pose, nullptr,
 					bounds_t{vec3_zero, vec3{30*cm2m, 4*cm2m, 1*cm2m}},
 					true, ui_move_exact);
 	color32 color = color_to_32(color_hsv(0.6f, 0.5f, 1, 1));

--- a/Examples/StereoKitTest/Demos/DemoRayMesh.cs
+++ b/Examples/StereoKitTest/Demos/DemoRayMesh.cs
@@ -18,22 +18,23 @@ class DemoRayMesh : ITest
 	/// 
 	/// ![Ray Mesh Intersection]({{site.url}}/img/screenshots/RayMeshIntersect.jpg)
 	///
-	Mesh sphereMesh = Default.MeshSphere;
-	Mesh boxMesh    = Mesh.GenerateRoundedCube(Vec3.One*0.2f, 0.05f);
-	Pose boxPose    = (Demo.contentPose * Matrix.T(0, -0.1f, 0)).Pose;
-	Pose castPose   = (Demo.contentPose * Matrix.T(0.25f, 0.11f, 0.2f)).Pose;
+	Mesh  sphereMesh = Default.MeshSphere;
+	Mesh  boxMesh    = Mesh.GenerateRoundedCube(Vec3.One*0.2f, 0.05f);
+	Pose  boxPose    = (Demo.contentPose * Matrix.T(0, -0.1f, 0)).Pose;
+	float boxScale   = 1;
+	Pose  castPose   = (Demo.contentPose * Matrix.T(0.25f, 0.11f, 0.2f)).Pose;
 
 	public void StepRayMesh()
 	{
 		// Draw our setup, and make the visuals grab/moveable!
-		UI.Handle("Box",  ref boxPose,  boxMesh.Bounds);
+		UI.Handle("Box",  ref boxPose, boxMesh.Bounds, ref boxScale);
 		UI.Handle("Cast", ref castPose, sphereMesh.Bounds*0.03f);
-		boxMesh   .Draw(Default.MaterialUI, boxPose .ToMatrix());
+		boxMesh   .Draw(Default.MaterialUI, boxPose .ToMatrix(boxScale));
 		sphereMesh.Draw(Default.MaterialUI, castPose.ToMatrix(0.03f));
 		Lines.Add(castPose.position, boxPose.position, Color.White, 0.005f);
 
 		// Create a ray that's in the Mesh's model space
-		Matrix transform = boxPose.ToMatrix();
+		Matrix transform = boxPose.ToMatrix(boxScale);
 		Ray    ray       = transform
 			.Inverse
 			.Transform(Ray.FromTo(castPose.position, boxPose.position));

--- a/Examples/StereoKitTest/Docs/DocLastElement.cs
+++ b/Examples/StereoKitTest/Docs/DocLastElement.cs
@@ -1,4 +1,4 @@
-﻿using StereoKit;
+using StereoKit;
 
 class DocLastElement : ITest
 {
@@ -7,15 +7,29 @@ class DocLastElement : ITest
 
 	public void Step()
 	{
+		// Point a single custom far-ray interactor at the slider. Frame 0 is a
+		// warm-up (a freshly-created interactor can't focus yet), then frames 1-3
+		// run focus -> activate -> hold. The ray starts below and a little in
+		// front of the window so it reads nicely in the screenshot.
+		Vec3     dir   = (rayTarget - rayOrigin).Normalized;
+		BtnState pinch = frame switch {
+			0 => BtnState.Inactive,                     // warm-up
+			1 => BtnState.Inactive,                     // focus
+			2 => BtnState.Active | BtnState.JustActive, // activate
+			_ => BtnState.Active };                     // hold
+		ray.Update(rayOrigin, rayOrigin + dir * 100, new Pose(rayOrigin, Quat.LookDir(dir)), rayOrigin, Vec3.Zero, pinch, BtnState.Active);
+		rayVisible = 1;
+		Tests.DrawInteractorRay(ray, ref rayVisible, ref rayActive);
+
 		/// :CodeSample: UI.LastElementSourceActive UI.LastElementSourceFocused UI.LastElementActive UI.LastElementFocused
 		/// ### Checking UI element status
 		/// It can sometimes be nice to know how the user is interacting with a
 		/// particular UI element! The UI.LastElementX functions can be used to
 		/// query a bit of this information, but only for _the most recent_ UI
 		/// element that **uses an id**!
-		/// 
+		///
 		/// ![A window containing the status of a UI element]({{site.screen_url}}/UI/LastElementAPI.jpg)
-		/// 
+		///
 		/// So in this example, we're querying the information for the "Slider"
 		/// UI element. Note that UI.Text does NOT use an id, which is why this
 		/// works.
@@ -33,20 +47,29 @@ class DocLastElement : ITest
 		UI.WindowEnd();
 		/// :End:
 
-		Tests.Screenshot("UI/LastElementAPI.jpg", 1, 500, 500, 90, V.XYZ(0, -0.08f, -0.35f), V.XYZ(0, -0.08f, -0.5f));
+		Tests.Screenshot("UI/LastElementAPI.jpg", 3, 500, 500, 90, V.XYZ(0, -0.10f, -0.35f), V.XYZ(0, -0.10f, -0.5f));
+		frame++;
 	}
 
 	DefaultInteractors oldInteractors;
+	Interactor         ray;
+	Vec3               rayOrigin  = V.XYZ(0.05f, -0.2f, -0.35f); // below and a bit in front of the window
+	Vec3               rayTarget;
+	float              rayVisible = 0;
+	float              rayActive  = 0;
+	int                frame      = 0;
 	public void Initialize()
 	{
 		oldInteractors = Interaction.DefaultInteractors;
-		Interaction.DefaultInteractors = DefaultInteractors.All;
+		Interaction.DefaultInteractors = DefaultInteractors.None;
 
-		Tests.RunForFrames(2);
-		Tests.Hand(new HandJoint[] { new HandJoint(V.XYZ(0.049f, -0.004f, -0.415f), new Quat(-0.359f, -0.281f, -0.375f, -0.807f), 0.006f), new HandJoint(V.XYZ(0.049f, -0.004f, -0.415f), new Quat(-0.103f, -0.370f, -0.491f, -0.782f), 0.015f), new HandJoint(V.XYZ(0.019f, -0.013f, -0.447f), new Quat(-0.039f, -0.323f, -0.521f, -0.789f), 0.013f), new HandJoint(V.XYZ(0.001f, -0.021f, -0.471f), new Quat(0.081f, -0.231f, -0.565f, -0.788f), 0.011f), new HandJoint(V.XYZ(-0.003f, -0.028f, -0.486f), new Quat(0.081f, -0.231f, -0.565f, -0.788f), 0.008f), new HandJoint(V.XYZ(0.062f, 0.016f, -0.419f), new Quat(-0.071f, -0.307f, 0.104f, -0.943f), 0.005f), new HandJoint(V.XYZ(0.021f, 0.030f, -0.477f), new Quat(0.305f, -0.346f, -0.028f, -0.887f), 0.013f), new HandJoint(V.XYZ(-0.002f, 0.008f, -0.499f), new Quat(0.696f, -0.263f, -0.201f, -0.637f), 0.011f), new HandJoint(V.XYZ(-0.003f, -0.014f, -0.497f), new Quat(0.827f, -0.197f, -0.269f, -0.453f), 0.010f), new HandJoint(V.XYZ(-0.000f, -0.024f, -0.491f), new Quat(0.827f, -0.197f, -0.269f, -0.453f), 0.007f), new HandJoint(V.XYZ(0.071f, 0.016f, -0.428f), new Quat(-0.043f, -0.247f, 0.191f, -0.949f), 0.005f), new HandJoint(V.XYZ(0.040f, 0.028f, -0.487f), new Quat(0.083f, -0.318f, 0.151f, -0.932f), 0.013f), new HandJoint(V.XYZ(0.013f, 0.026f, -0.521f), new Quat(0.317f, -0.337f, 0.066f, -0.884f), 0.011f), new HandJoint(V.XYZ(-0.003f, 0.013f, -0.536f), new Quat(0.460f, -0.338f, 0.007f, -0.821f), 0.010f), new HandJoint(V.XYZ(-0.010f, 0.003f, -0.541f), new Quat(0.460f, -0.338f, 0.007f, -0.821f), 0.007f), new HandJoint(V.XYZ(0.079f, 0.012f, -0.435f), new Quat(-0.032f, -0.174f, 0.231f, -0.957f), 0.004f), new HandJoint(V.XYZ(0.060f, 0.020f, -0.492f), new Quat(0.005f, -0.236f, 0.220f, -0.946f), 0.011f), new HandJoint(V.XYZ(0.042f, 0.024f, -0.529f), new Quat(0.165f, -0.275f, 0.177f, -0.930f), 0.010f), new HandJoint(V.XYZ(0.027f, 0.019f, -0.549f), new Quat(0.283f, -0.299f, 0.140f, -0.900f), 0.008f), new HandJoint(V.XYZ(0.019f, 0.013f, -0.558f), new Quat(0.283f, -0.299f, 0.140f, -0.900f), 0.006f), new HandJoint(V.XYZ(0.088f, 0.001f, -0.439f), new Quat(-0.041f, -0.108f, 0.316f, -0.942f), 0.004f), new HandJoint(V.XYZ(0.078f, 0.010f, -0.495f), new Quat(-0.006f, -0.145f, 0.310f, -0.940f), 0.010f), new HandJoint(V.XYZ(0.069f, 0.013f, -0.526f), new Quat(0.129f, -0.206f, 0.284f, -0.927f), 0.008f), new HandJoint(V.XYZ(0.061f, 0.011f, -0.542f), new Quat(0.230f, -0.249f, 0.260f, -0.904f), 0.007f), new HandJoint(V.XYZ(0.054f, 0.007f, -0.551f), new Quat(0.230f, -0.249f, 0.260f, -0.904f), 0.006f), new HandJoint(V.XYZ(0.056f, 0.022f, -0.457f), new Quat(-0.585f, 0.252f, 0.057f, 0.769f), 0.000f), new HandJoint(V.XYZ(0.075f, 0.009f, -0.429f), new Quat(-0.585f, 0.252f, 0.057f, 0.769f), 0.000f) });
+		ray       = Interactor.Create(InteractorType.Line, InteractorEvent.Pinch | InteractorEvent.Poke, InteractorActivation.State, InteractorSource.HandRight, 0.015f, 0);
+		rayTarget = windowPose.position + V.XYZ(0, -0.03f, 0); // Slider handle location, may need updated if UI changes
+		Tests.RunForFrames(4);
 	}
 	public void Shutdown()
 	{
+		ray.Destroy();
 		Interaction.DefaultInteractors = oldInteractors;
 	}
 }

--- a/Examples/StereoKitTest/Tests.cs
+++ b/Examples/StereoKitTest/Tests.cs
@@ -31,6 +31,7 @@ public static class Tests
 	static int             sceneFrame  = 0;
 	static float           sceneTime   = 0;
 	static int             failures    = 0;
+	static int             shutdownFrames = 0;
 	static HashSet<string> screenshots = new HashSet<string>();
 
 	private static Type   ActiveScene        { set { nextScene = (ITest)Activator.CreateInstance(value); } }
@@ -83,6 +84,15 @@ public static class Tests
 		if (IsTesting && runSeconds != 0)
 			Time.SetTime(Time.Total+(1/90.0), 1/90.0);
 
+		// Run a few more frames after we're finished testing to flush screenshots
+		if (shutdownFrames > 0)
+		{
+			shutdownFrames--;
+			if (shutdownFrames == 0)
+				SK.Quit();
+			return;
+		}
+
 		if (nextScene != null)
 		{
 			activeScene?.Shutdown();
@@ -122,7 +132,7 @@ public static class Tests
 		{
 			sceneIndex += 1;
 			if (sceneIndex >= allScenes.Length || TestSingle)
-				SK.Quit();
+				shutdownFrames = 4; // run a few more frames so the last screenshot flushes
 			else
 				SetTestActive(allScenes[sceneIndex].Name);
 		}
@@ -236,5 +246,55 @@ public static class Tests
 			return;
 		Input.HandVisible (hand, true);
 		Input.HandOverride(hand, joints);
+	}
+
+	public static void DrawInteractorRay(Interactor actor, ref float refVisibleAmt, ref float refActiveAmt, float skip = 0.07f, bool hideInactive = true)
+	{
+		// This is a port of the internal `interactor_show_ray` (interactor_modes.cpp)
+		// built only from the public Interactor API
+		if (!actor.Tracked.IsActive()) return;
+
+		bool  actorVisible = hideInactive == false || actor.Focused != IdHash.None;
+		refVisibleAmt = SKMath.Lerp(refVisibleAmt, actorVisible ? 1f : 0f, 16.0f * Time.StepUnscaledf);
+		float visibility = refVisibleAmt;
+		if (visibility < 0.001f) return;
+
+		refActiveAmt = SKMath.Lerp(refActiveAmt, actor.Active != IdHash.None ? 1f : 0f, 16.0f * Time.StepUnscaledf);
+		float active = refActiveAmt;
+
+		Vec3  motionPos     = actor.Motion.position;
+		float length        = 0.35f;
+		Vec3  uncenteredDir = (actor.End - motionPos).Normalized;
+		Vec3  centeredDir   = uncenteredDir;
+		if (actor.Focused != IdHash.None && actor.TryGetFocusBounds(out Pose poseWorld, out Bounds boundsLocal, out Vec3 atLocal))
+		{
+			Vec3 pt = poseWorld.ToMatrix().Transform(boundsLocal.center + atLocal);
+			length      = Vec3.Distance(pt, motionPos);
+			centeredDir = (pt - motionPos).Normalized;
+		}
+		length = SKMath.Lerp(0.35f, length, visibility);
+		length = Math.Max(0, length - skip);
+
+		float alpha = 0.35f + active * 0.65f;
+		if (hideInactive) alpha *= visibility;
+
+		const int   ct      = 20;
+		const float raySnap = 1.0f;
+		LinePoint[] pts = new LinePoint[ct];
+		for (int i = 0; i < ct; i++)
+		{
+			float pct   = (float)i / (ct - 1);
+			float blend = pct * pct * pct * raySnap;
+			float d     = skip + pct * length;
+
+			float pctI  = 1 - pct;
+			float curve = SKMath.Lerp(
+				MathF.Sin(pctI * pctI * MathF.PI),
+				MathF.Min(1f, MathF.Sin(pct * pct * MathF.PI) * 1.5f), active);
+			float width = (0.002f + curve * 0.003f) * visibility;
+			Vec3  at    = motionPos + Vec3.Lerp(uncenteredDir * d, centeredDir * d, blend);
+			pts[i] = new LinePoint(at, new Color32(255, 255, 255, (byte)(curve * alpha * 255)), width);
+		}
+		Lines.Add(pts);
 	}
 }

--- a/Examples/StereoKitTest/Tests/TestInteractorMultiHandle.cs
+++ b/Examples/StereoKitTest/Tests/TestInteractorMultiHandle.cs
@@ -1,0 +1,281 @@
+using System;
+using StereoKit;
+
+// Validates multi-interactor UI.Handle: 2+ point interactors combine into one
+// translate + rotate, can join/leave without the handle jumping, and rotation
+// follows where the grab points MOVE (not the interactors' orientations).
+//
+// Deliberately awkward (these exposed real bugs - don't "simplify" them away):
+// the handle rests at a 180-degree turn and is nested in a parent handle with
+// its own non-identity pose. Checks use the WORLD pose and verify the grabbed
+// direction follows the grab point, so they hold under both.
+//
+// Run: dotnet run [-test] -start TestInteractorMultiHandle
+class TestInteractorMultiHandle : ITest
+{
+	DefaultInteractors prevDefault;
+	Interactor[]       actors;
+
+	// Parent handle (non-identity pose, centered ahead). UIMove.None makes it a
+	// nested coordinate frame that can't itself be grabbed.
+	Pose parentPose = new Pose(new Vec3(0, 0, -0.5f), Quat.FromAngles(10, 35, 0));
+	static readonly Bounds parentBounds = new Bounds(Vec3.Zero, new Vec3(0.1f, 0.1f, 0.1f));
+
+	// The inner multi-interactor handle, in the PARENT's local space. Sits at the
+	// parent origin and rests at a 180-degree turn -> a non-identity world rest.
+	Pose handlePose;
+	Pose worldHandle;   // its world pose, recomputed each frame
+	static readonly Pose InnerRestLocal = new Pose(Vec3.Zero, Quat.LookDir(0, 0, 1));
+	static readonly Vec3 boxDims        = new Vec3(0.0625f, 0.0625f, 0.0625f);
+	Vec3 worldRestCenter;  // world position of the inner handle at rest
+
+	const float grabRadius0 = 0.02f;
+	const float grabRadius1 = 0.08f;
+	const float ExpectAngle = 90.0f;
+	const float PullTilt    = 20.0f;
+	static readonly Vec3 TransTo = new Vec3(0.02f, 0.02f, 0.02f);
+
+	struct Cfg
+	{
+		public float radius, angleY, angleZ, tilt;
+		public Vec3  trans;
+		public Cfg(float r, float y, float z, float t, Vec3 tr) { radius = r; angleY = y; angleZ = z; tilt = t; trans = tr; }
+		public static Cfg Lerp(Cfg a, Cfg b, float t) => new Cfg(
+			a.radius + (b.radius - a.radius) * t,
+			a.angleY + (b.angleY - a.angleY) * t,
+			a.angleZ + (b.angleZ - a.angleZ) * t,
+			a.tilt   + (b.tilt   - a.tilt)   * t,
+			Vec3.Lerp(a.trans, b.trans, t));
+	}
+
+	enum P { Focus, Grab, Pull, Translate, SwingY, NeutralY, SwingZPos, NeutralZ, SwingZNeg, Drop, COUNT }
+
+	static readonly Cfg cfgInitial = new Cfg(grabRadius0, 0, 0, 0, Vec3.Zero);
+	static readonly Cfg[] phaseTarget = {
+		new Cfg(grabRadius0, 0,            0,            0,        Vec3.Zero), // Focus
+		new Cfg(grabRadius0, 0,            0,            0,        Vec3.Zero), // Grab
+		new Cfg(grabRadius1, 0,            0,            PullTilt, Vec3.Zero), // Pull
+		new Cfg(grabRadius1, 0,            0,            PullTilt, TransTo),   // Translate
+		new Cfg(grabRadius1, ExpectAngle,  0,            PullTilt, TransTo),   // SwingY    - +X -> -Z
+		new Cfg(grabRadius1, 0,            0,            PullTilt, TransTo),   // NeutralY
+		new Cfg(grabRadius1, 0,            ExpectAngle,  PullTilt, TransTo),   // SwingZPos - +X -> +Y
+		new Cfg(grabRadius1, 0,            0,            PullTilt, TransTo),   // NeutralZ
+		new Cfg(grabRadius1, 0,           -ExpectAngle,  PullTilt, TransTo),   // SwingZNeg - +X -> -Y
+		new Cfg(grabRadius1, 0,           -ExpectAngle,  PullTilt, TransTo),   // Drop
+	};
+	static readonly string[] phaseName = { "focus", "grab", "pull apart", "translate", "swing +90 Y", "neutral", "swing +90 Z", "neutral", "swing -90 Z", "drop one hand" };
+
+	const int   FramesPerPhase  = 10;
+	const float SecondsPerPhase = 1.5f;
+
+	int   phase      = 0;
+	int   prevPhase  = -1;
+	int   phaseFrame = 0;
+	float phaseTime  = 0;
+	int   failures   = 0;
+	Vec3  expectCenter;
+	Vec3  preDropPos;
+	Quat  qRest;
+	Vec3  localGrabDir;
+
+	public void Initialize()
+	{
+		prevDefault = Interaction.DefaultInteractors;
+		Interaction.DefaultInteractors = DefaultInteractors.None;
+
+		handlePose      = InnerRestLocal;
+		worldHandle     = (InnerRestLocal.ToMatrix() * parentPose.ToMatrix()).Pose; // inner world rest pose
+		worldRestCenter = worldHandle.position;
+		expectCenter    = worldRestCenter;
+		qRest           = worldHandle.orientation;
+		localGrabDir    = qRest.Inverse * Vec3.Right;
+
+		actors = new Interactor[2];
+		for (int i = 0; i < actors.Length; i++)
+			actors[i] = Interactor.Create(InteractorType.Point, InteractorEvent.Pinch, InteractorActivation.State, InteractorSource.Unique, 0.01f, 0);
+
+		if (Tests.IsTesting)
+			Tests.RunForFrames((int)P.COUNT * FramesPerPhase + 2);
+	}
+
+	public void Shutdown()
+	{
+		foreach (Interactor a in actors) a.Destroy();
+		Interaction.DefaultInteractors = prevDefault;
+
+		if (failures == 0) Log.Info("TestInteractorMultiHandle: all checks passed.");
+	}
+
+	public void Step()
+	{
+		if (Tests.IsTesting && phase >= (int)P.COUNT) return;
+
+		bool entering = phase != prevPhase;
+		prevPhase = phase;
+		if (entering && phase == (int)P.Drop) preDropPos = worldHandle.position;
+
+		float progress;
+		bool  phaseDone;
+		if (Tests.IsTesting)
+		{
+			phaseFrame++;
+			progress  = MathF.Min(1, phaseFrame / (float)FramesPerPhase);
+			phaseDone = phaseFrame >= FramesPerPhase;
+		}
+		else
+		{
+			phaseTime += Time.Stepf;
+			progress   = MathF.Min(1, phaseTime / SecondsPerPhase);
+			phaseDone  = phaseTime >= SecondsPerPhase;
+		}
+
+		Cfg start = phase == 0 ? cfgInitial : phaseTarget[phase - 1];
+		Cfg cfg   = Cfg.Lerp(start, phaseTarget[phase], progress);
+
+		BtnState pinchA, pinchB;
+		if (phase == (int)P.Focus)
+		{
+			pinchA = pinchB = BtnState.Inactive;
+		}
+		else
+		{
+			pinchA = (phase == (int)P.Grab && entering) ? (BtnState.Active | BtnState.JustActive) : BtnState.Active;
+			pinchB = phase == (int)P.Drop
+				? (entering ? BtnState.JustInactive : BtnState.Inactive)
+				: pinchA;
+		}
+
+		// Grab points are driven in WORLD space around the inner handle's world
+		// rest center, regardless of the parent frame it lives in.
+		Quat ori    = Quat.FromAngles(cfg.tilt, 0, 0);
+		Vec3 center = worldRestCenter + cfg.trans;
+		Vec3 offset = Quat.FromAngles(0, cfg.angleY, cfg.angleZ) * new Vec3(cfg.radius, 0, 0);
+		expectCenter = center;
+		DriveActor(actors[0], center + offset, ori, pinchA);
+		DriveActor(actors[1], center - offset, ori, pinchB);
+
+		// Nest the handle in a parent with a non-identity pose. UIMove.None means
+		// the parent only supplies the coordinate frame; it never gets grabbed.
+		bool grabbed;
+		UI.HandleBegin("ParentHandle", ref parentPose, parentBounds, false, UIMove.None);
+		{
+			grabbed     = UI.Handle("multiHandle", ref handlePose, new Bounds(Vec3.Zero, boxDims), true);
+			worldHandle = Hierarchy.ToWorld(handlePose);
+		}
+		UI.HandleEnd();
+
+		DrawVisuals();
+		DrawLabel();
+
+		if (phaseDone)
+		{
+			if (Tests.IsTesting) CheckPhaseEnd(grabbed);
+
+			phase++;
+			phaseFrame = 0;
+			phaseTime  = 0;
+			if (phase >= (int)P.COUNT && !Tests.IsTesting)
+			{
+				phase      = 0;
+				prevPhase  = -1;
+				handlePose = InnerRestLocal;
+			}
+		}
+	}
+
+	void CheckPhaseEnd(bool grabbed)
+	{
+		switch ((P)phase)
+		{
+		case P.Grab:
+			qRest        = worldHandle.orientation;
+			localGrabDir = qRest.Inverse * (actors[0].Motion.position - expectCenter).Normalized;
+			Check("grab is stable", Vec3.Distance(worldHandle.position, expectCenter) < 0.01f && grabbed);
+			break;
+
+		case P.Pull:
+			Check("pull no rotation", RotationDeg(worldHandle.orientation, qRest) < 3.0f);
+			Check("pull position",    Vec3.Distance(worldHandle.position, expectCenter) < 0.02f);
+			break;
+
+		case P.Translate:
+			Check("translate position",    Vec3.Distance(worldHandle.position, expectCenter) < 0.02f);
+			Check("translate no rotation", RotationDeg(worldHandle.orientation, qRest) < 3.0f);
+			break;
+
+		case P.SwingY:    CheckSwing("swingY",  Vec3.Up);      break;
+		case P.NeutralY:  Check("neutralY returns to rest", RotationDeg(worldHandle.orientation, qRest) < 3.0f); break;
+		case P.SwingZPos: CheckSwing("swingZ+", Vec3.Forward); break;
+		case P.NeutralZ:  Check("neutralZ returns to rest", RotationDeg(worldHandle.orientation, qRest) < 3.0f); break;
+		case P.SwingZNeg: CheckSwing("swingZ-", Vec3.Forward); break;
+
+		case P.Drop:
+			Check("no jump on drop", Vec3.Distance(worldHandle.position, preDropPos) < 0.01f && grabbed);
+			break;
+		}
+	}
+
+	// Verifies a swing independently of rest orientation and parent frame: the
+	// handle's grabbed direction must now point where the grab point moved to.
+	void CheckSwing(string name, Vec3 worldAxis)
+	{
+		Quat  q          = worldHandle.orientation;
+		Vec3  grabDirNow = (actors[0].Motion.position - expectCenter).Normalized;
+		Vec3  grabbedDir = q * localGrabDir;
+		Vec3  axisDir    = q * (qRest.Inverse * worldAxis);
+		float swungDeg   = RotationDeg(q, qRest);
+
+		Log.Info($"TestInteractorMultiHandle {name}: swung {swungDeg:F1}deg; grabbed dir {grabbedDir} vs grab point {grabDirNow} (match => follows hands)");
+		Check($"{name} angle ~90",       MathF.Abs(swungDeg - ExpectAngle) < 6.0f);
+		Check($"{name} follows grab pt", Vec3.AngleBetween(grabbedDir, grabDirNow) < 6.0f);
+		Check($"{name} about axis",      Vec3.AngleBetween(axisDir, worldAxis) < 4.0f);
+		Check($"{name} position",        Vec3.Distance(worldHandle.position, expectCenter) < 0.02f);
+	}
+
+	void Check(string name, bool passed)
+	{
+		if (!passed)
+		{
+			failures += 1;
+			Log.Err($"TestInteractorMultiHandle: '{name}' failed on frame {phaseFrame} of phase {phaseName[phase]} (world pose {worldHandle.position}).");
+		}
+		Tests.Test(() => passed);
+	}
+
+	static readonly Color RedActor  = new Color(1.0f, 0.25f, 0.25f);
+	static readonly Color BlueActor = new Color(0.3f, 0.5f,  1.0f);
+
+	void DrawVisuals()
+	{
+		DrawInteractor(actors[0], RedActor);
+		DrawInteractor(actors[1], BlueActor);
+
+		Lines.Add(actors[0].Motion.position, actors[1].Motion.position, new Color(1, 1, 1, 0.4f), 0.0015f);
+
+		// Red line points where the handle THINKS its grabbed (red) face is; if
+		// it tracks the red sphere, the handle is following the hands.
+		float reach = (actors[0].Motion.position - worldHandle.position).Length;
+		Lines.Add(worldHandle.position, worldHandle.position + (worldHandle.orientation * localGrabDir) * reach, RedActor, 0.0025f);
+	}
+
+	static void DrawInteractor(Interactor actor, Color color)
+	{
+		bool active = actor.Active != IdHash.None;
+		Mesh.Sphere.Draw(Material.Default, Matrix.TS(actor.Motion.position, 0.012f), active ? color : color * 0.4f);
+	}
+
+	void DrawLabel()
+	{
+		Vec3 at = worldHandle.position + new Vec3(0, boxDims.y * 0.5f + 0.04f, 0);
+		Text.Add(phaseName[phase], Matrix.TRS(at, Quat.LookAt(at, Input.Head.position), 0.5f), Pivot.BottomCenter, Align.Center);
+	}
+
+	static float RotationDeg(Quat a, Quat b)
+	{
+		float dot = a.x*b.x + a.y*b.y + a.z*b.z + a.w*b.w;
+		return 2 * MathF.Acos(MathF.Min(1, MathF.Abs(dot))) * (180.0f / MathF.PI);
+	}
+
+	static void DriveActor(Interactor actor, Vec3 pos, Quat ori, BtnState pinch)
+		=> actor.Update(pos, pos, new Pose(pos, ori), pos, Vec3.Zero, pinch, BtnState.Active);
+}

--- a/Examples/StereoKitTest/Tests/TestInteractorVis.cs
+++ b/Examples/StereoKitTest/Tests/TestInteractorVis.cs
@@ -73,8 +73,9 @@ class TestInteractorVis : ITest
 		BtnState active = BtnState.Active;
 		ray.Update(rayOrigin, rayOrigin + dir * 100, new Pose(rayOrigin, Quat.LookDir(dir)), rayOrigin, Vec3.Zero, active, BtnState.Active);
 
-		// Our application-level replica of the internal indicator.
-		ShowRay(ray, 0.07f, true, ref rayVisible, ref rayActive);
+		// Draw the far-ray indicator (a shared helper on Tests, ported from the
+		// internal interactor_show_ray).
+		Tests.DrawInteractorRay(ray, ref rayVisible, ref rayActive);
 
 		UI.WindowBegin("Interactor Vis", ref windowPose, V.XY(0.2f, 0));
 		UI.Button("Target");
@@ -84,55 +85,5 @@ class TestInteractorVis : ITest
 		// Screenshot late enough that the visibility/active smoothing has
 		// ramped up to full.
 		Tests.Screenshot("Tests/InteractorVis.jpg", 18, 600, 400, 60, V.XYZ(0.25f, 0.1f, 0.4f), V.XYZ(0, 0, -0.5f));
-	}
-
-	/// A direct port of `interactor_show_ray` from interactor_modes.cpp, built
-	/// only from the public `Interactor` API.
-	static void ShowRay(Interactor actor, float skip, bool hideInactive, ref float refVisibleAmt, ref float refActiveAmt)
-	{
-		if (!actor.Tracked.IsActive()) return;
-
-		bool  actorVisible = hideInactive == false || actor.Focused != IdHash.None;
-		refVisibleAmt = SKMath.Lerp(refVisibleAmt, actorVisible ? 1f : 0f, 16.0f * Time.StepUnscaledf);
-		float visibility = refVisibleAmt;
-		if (visibility < 0.001f) return;
-
-		refActiveAmt = SKMath.Lerp(refActiveAmt, actor.Active != IdHash.None ? 1f : 0f, 16.0f * Time.StepUnscaledf);
-		float active = refActiveAmt;
-
-		Vec3  motionPos     = actor.Motion.position;
-		float length        = 0.35f;
-		Vec3  uncenteredDir = (actor.End - motionPos).Normalized;
-		Vec3  centeredDir   = uncenteredDir;
-		if (actor.Focused != IdHash.None && actor.TryGetFocusBounds(out Pose poseWorld, out Bounds boundsLocal, out Vec3 atLocal))
-		{
-			Vec3 pt = poseWorld.ToMatrix().Transform(boundsLocal.center + atLocal);
-			length      = Vec3.Distance(pt, motionPos);
-			centeredDir = (pt - motionPos).Normalized;
-		}
-		length = SKMath.Lerp(0.35f, length, visibility);
-		length = Math.Max(0, length - skip);
-
-		float alpha = 0.35f + active * 0.65f;
-		if (hideInactive) alpha *= visibility;
-
-		const int   ct      = 20;
-		const float raySnap = 1.0f;
-		LinePoint[] pts = new LinePoint[ct];
-		for (int i = 0; i < ct; i++)
-		{
-			float pct   = (float)i / (ct - 1);
-			float blend = pct * pct * pct * raySnap;
-			float d     = skip + pct * length;
-
-			float pctI  = 1 - pct;
-			float curve = SKMath.Lerp(
-				MathF.Sin(pctI * pctI * MathF.PI),
-				MathF.Min(1f, MathF.Sin(pct * pct * MathF.PI) * 1.5f), active);
-			float width = (0.002f + curve * 0.003f) * visibility;
-			Vec3  at    = motionPos + Vec3.Lerp(uncenteredDir * d, centeredDir * d, blend);
-			pts[i] = new LinePoint(at, new Color32(255, 255, 255, (byte)(curve * alpha * 255)), width);
-		}
-		Lines.Add(pts);
 	}
 }

--- a/Examples/StereoKitTest/Tests/TestUIFocus.cs
+++ b/Examples/StereoKitTest/Tests/TestUIFocus.cs
@@ -1,0 +1,119 @@
+using StereoKit;
+
+// Investigates the focus/active lifecycle of UI elements. Two custom far-ray
+// interactors (one per element) point at a slider and a button and pinch with a
+// real Inactive -> JustActive transition. We log both each interactor's own
+// focus/active state and what the UI.LastElement* queries report, to see how the
+// timing lines up - and whether a button behaves any differently than a slider.
+//
+// Frame 0 is a warm-up: a freshly-created interactor misses its first per-frame
+// reset (interaction_update runs in the UI system, before this Initialize/Step),
+// so it can't focus yet. The real focus -> activate -> hold sequence runs on
+// frames 1, 2, 3, matching how a startup-created interactor behaves.
+class TestUIFocus : ITest
+{
+	float sliderVal  = 0.5f;
+	Pose  windowPose = new Pose(0, 0, -0.5f, Quat.LookDir(0, 0, 1));
+
+	DefaultInteractors oldInteractors;
+	Interactor         raySlider, rayButton;
+	Vec3               rayOrigin    = V.XYZ(0.05f, -0.2f, -0.35f);
+	Vec3               sliderTarget, buttonTarget;
+	int                frame        = 0;
+
+	// Per-frame recording of what the UI queries reported, checked at the end.
+	BtnState[] sliderFocused = new BtnState[4];
+	BtnState[] sliderActive  = new BtnState[4];
+	BtnState[] buttonFocused = new BtnState[4];
+	BtnState[] buttonActive  = new BtnState[4];
+
+	public void Initialize()
+	{
+		oldInteractors = Interaction.DefaultInteractors;
+		Interaction.DefaultInteractors = DefaultInteractors.None;
+
+		// Unique sources so the two interactors never preoccupy each other.
+		raySlider = Interactor.Create(InteractorType.Line, InteractorEvent.Pinch | InteractorEvent.Poke, InteractorActivation.State, InteractorSource.Unique, 0.015f, 0);
+		rayButton = Interactor.Create(InteractorType.Line, InteractorEvent.Pinch | InteractorEvent.Poke, InteractorActivation.State, InteractorSource.Unique, 0.015f, 0);
+		sliderTarget = windowPose.position + V.XYZ(0, -0.03f, 0); // guesses at each element, refined once focused
+		buttonTarget = windowPose.position + V.XYZ(0, -0.09f, 0);
+
+		Tests.RunForFrames(4);
+	}
+
+	public void Step()
+	{
+		// frame 0 warm-up, 1 establishes focus, 2 is the one-frame JustActive that
+		// activates, 3 holds Active - same drive for both interactors.
+		BtnState pinch = frame switch {
+			0 => BtnState.Inactive,
+			1 => BtnState.Inactive,
+			2 => BtnState.Active | BtnState.JustActive,
+			_ => BtnState.Active };
+		Aim(raySlider, sliderTarget, pinch);
+		Aim(rayButton, buttonTarget, pinch);
+
+		UI.WindowBegin("UI Focus", ref windowPose);
+
+		UI.HSlider("Slider", ref sliderVal, 0, 1, 0.1f, 0, UIConfirm.Pinch);
+		sliderFocused[frame] = UI.LastElementFocused; sliderActive[frame] = UI.LastElementActive;
+
+		UI.Button("Button");
+		buttonFocused[frame] = UI.LastElementFocused; buttonActive[frame] = UI.LastElementActive;
+
+		UI.WindowEnd();
+
+		Log.Info($"frame {frame}: pinch=[{pinch}]");
+		Log.Info($"  slider: UI.Focused=[{sliderFocused[frame]}] UI.Active=[{sliderActive[frame]}]  (interactor focused={raySlider.Focused != IdHash.None} active={raySlider.Active != IdHash.None})");
+		Log.Info($"  button: UI.Focused=[{buttonFocused[frame]}] UI.Active=[{buttonActive[frame]}]  (interactor focused={rayButton.Focused != IdHash.None} active={rayButton.Active != IdHash.None})");
+
+		// Keep each ray aimed at its element once it's focused it.
+		if (raySlider.TryGetFocusBounds(out Pose sp, out Bounds sb, out _)) sliderTarget = sp.ToMatrix().Transform(sb.center);
+		if (rayButton.TryGetFocusBounds(out Pose bp, out Bounds bb, out _)) buttonTarget = bp.ToMatrix().Transform(bb.center);
+
+		// Once the full sequence is recorded, check it.
+		if (frame == 3)
+		{
+			Tests.Test(SliderLifecycle);
+			Tests.Test(ButtonLifecycle);
+			Tests.Test(ButtonMatchesSlider);
+		}
+		frame++;
+	}
+
+	// Expected lifecycle (post warm-up): frames 0-1 report nothing, frame 2 is the
+	// JustActive edge where focus and active light up together, frame 3 holds
+	// Active. Focus and active line up because the warm-up removes the first-frame
+	// focus gap, and focus's one-frame report lag puts it on the activation frame.
+	bool SliderLifecycle() => Lifecycle(sliderFocused, sliderActive);
+	bool ButtonLifecycle() => Lifecycle(buttonFocused, buttonActive);
+	static bool Lifecycle(BtnState[] focused, BtnState[] active) =>
+		!focused[0].IsActive() && !active[0].IsActive() &&
+		!focused[1].IsActive() && !active[1].IsActive() &&
+		 focused[2].IsActive() &&  focused[2].IsJustActive() &&
+		 active [2].IsActive() &&  active [2].IsJustActive() &&
+		 focused[3].IsActive() && !focused[3].IsJustActive() &&
+		 active [3].IsActive() && !active [3].IsJustActive();
+
+	// A button should behave identically to a slider here.
+	bool ButtonMatchesSlider()
+	{
+		for (int i = 0; i < 4; i++)
+			if (buttonFocused[i] != sliderFocused[i] || buttonActive[i] != sliderActive[i])
+				return false;
+		return true;
+	}
+
+	void Aim(Interactor ray, Vec3 target, BtnState pinch)
+	{
+		Vec3 dir = (target - rayOrigin).Normalized;
+		ray.Update(rayOrigin, rayOrigin + dir * 100, new Pose(rayOrigin, Quat.LookDir(dir)), rayOrigin, Vec3.Zero, pinch, BtnState.Active);
+	}
+
+	public void Shutdown()
+	{
+		raySlider.Destroy();
+		rayButton.Destroy();
+		Interaction.DefaultInteractors = oldInteractors;
+	}
+}

--- a/StereoKit/Native/NativeAPI.Custom.cs
+++ b/StereoKit/Native/NativeAPI.Custom.cs
@@ -155,6 +155,12 @@ namespace StereoKit
 		[DllImport(dll, CharSet = CharSet.Unicode, CallingConvention = call)]
 		public static extern void ui_window_begin_16([MarshalAs(UnmanagedType.LPWStr)] string text, ref Pose opt_pose, Vec2 size, UIWin window_type, UIMove move_type);
 
+		// ref-float overload of the IntPtr-based generated binding, for passing a
+		// present (non-null) opt_ref_scale.
+		[return: MarshalAs(UnmanagedType.Bool)]
+		[DllImport(dll, CharSet = CharSet.Unicode, CallingConvention = call)]
+		public static extern bool ui_handle_begin_16([MarshalAs(UnmanagedType.LPWStr)] string text, ref Pose movement, ref float opt_ref_scale, Bounds handle, [MarshalAs(UnmanagedType.Bool)] bool draw, UIMove move_type, UIGesture allowed_gestures);
+
 		// UI button/slider behavior - opt/nullable
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)]
 		public static extern void ui_button_behavior(Vec3 window_relative_pos, Vec2 size, IdHash id, out float out_finger_offset, out BtnState out_button_state, out BtnState out_focus_state, out Interactor out_opt_interactor);

--- a/StereoKit/Native/NativeAPI.cs
+++ b/StereoKit/Native/NativeAPI.cs
@@ -1165,9 +1165,9 @@ namespace StereoKit
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         ui_hspace(float horizontal_space);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         ui_vspace(float vertical_space);
 		[return: MarshalAs(UnmanagedType.Bool)]
-		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern bool         ui_handle_begin([MarshalAs(UnmanagedType.LPUTF8Str)] string text, ref Pose movement, Bounds handle, [MarshalAs(UnmanagedType.Bool)] bool draw, UIMove move_type, UIGesture allowed_gestures);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern bool         ui_handle_begin([MarshalAs(UnmanagedType.LPUTF8Str)] string text, ref Pose movement, IntPtr opt_ref_scale, Bounds handle, [MarshalAs(UnmanagedType.Bool)] bool draw, UIMove move_type, UIGesture allowed_gestures);
 		[return: MarshalAs(UnmanagedType.Bool)]
-		[DllImport(dll, CharSet = CharSet.Unicode, CallingConvention = call)] public static extern bool         ui_handle_begin_16([MarshalAs(UnmanagedType.LPWStr)] string text, ref Pose movement, Bounds handle, [MarshalAs(UnmanagedType.Bool)] bool draw, UIMove move_type, UIGesture allowed_gestures);
+		[DllImport(dll, CharSet = CharSet.Unicode, CallingConvention = call)] public static extern bool         ui_handle_begin_16([MarshalAs(UnmanagedType.LPWStr)] string text, ref Pose movement, IntPtr opt_ref_scale, Bounds handle, [MarshalAs(UnmanagedType.Bool)] bool draw, UIMove move_type, UIGesture allowed_gestures);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         ui_handle_end();
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         ui_window_begin([MarshalAs(UnmanagedType.LPUTF8Str)] string text, IntPtr opt_pose, Vec2 size, UIWin window_type, UIMove move_type);
 		[DllImport(dll, CharSet = CharSet.Unicode, CallingConvention = call)] public static extern void         ui_window_begin_16([MarshalAs(UnmanagedType.LPWStr)] string text, IntPtr opt_pose, Vec2 size, UIWin window_type, UIMove move_type);

--- a/StereoKit/Native/NativeEnums.cs
+++ b/StereoKit/Native/NativeEnums.cs
@@ -2134,6 +2134,10 @@ namespace StereoKit
 		/// <summary>Do not allow user input to change the element's pose at all! You may also be
 		/// interested in UI.Push/PopSurface.</summary>
 		None,
+		/// <summary>Behaves just like ui_move_exact, but opts out of uniform scaling. Use this
+		/// when a Handle is provided a scale value, but should only ever be translated
+		/// and rotated by multiple interactors, never scaled.</summary>
+		ExactNoscale,
 	}
 
 	/// <summary>A description of what type of window to draw! This is a bit flag, so it can

--- a/StereoKit/Systems/UI.cs
+++ b/StereoKit/Systems/UI.cs
@@ -1403,7 +1403,39 @@ namespace StereoKit
 		/// <returns>Returns true for every frame the user is grabbing the
 		/// handle.</returns>
 		public static bool HandleBegin (string id, ref Pose pose, Bounds handle, bool drawHandle = false, UIMove moveType = UIMove.Exact, UIGesture allowedGestures = UIGesture.Pinch)
-			=> NativeAPI.ui_handle_begin_16(id, ref pose, handle, drawHandle, moveType, allowedGestures);
+			=> NativeAPI.ui_handle_begin_16(id, ref pose, IntPtr.Zero, handle, drawHandle, moveType, allowedGestures);
+
+		/// <summary>This is a variant of `UI.HandleBegin` that additionally
+		/// supports uniform scaling when two or more interactors grab the handle
+		/// at the same time. With a single interactor the handle behaves exactly
+		/// like the normal handle. With multiple interactors, their motion is
+		/// combined into a translation, rotation, and a uniform scale. Interactors
+		/// may freely join or leave the interaction without the handle jumping.
+		/// Providing a scale here enables scaling; pass `UIMove.ExactNoscale` as
+		/// the moveType if you want multi-interactor translate/rotate but no
+		/// scaling.</summary>
+		/// <param name="id">An id for tracking element state. MUST be unique
+		/// within current hierarchy.</param>
+		/// <param name="pose">The pose state for the handle! The user will be
+		/// able to grab this handle and move it around. The pose is relative
+		/// to the current hierarchy stack.</param>
+		/// <param name="handle">Size and location of the handle, relative to
+		/// the pose.</param>
+		/// <param name="scale">A uniform scale multiplier that gets accumulated
+		/// as the user scales the handle with multiple interactors. Seed this
+		/// with 1 (or your starting scale). Since the Pose has no scale of its
+		/// own, you should apply this value to both your content AND the `handle`
+		/// Bounds you pass in so the grab volume matches the visual.</param>
+		/// <param name="drawHandle">Should this function draw the handle
+		/// visual for you, or will you draw that yourself?</param>
+		/// <param name="moveType">Describes how the handle will move when
+		/// dragged around. Use `UIMove.ExactNoscale` to disable scaling.</param>
+		/// <param name="allowedGestures">Which hand gestures are used for
+		/// interacting with this Handle?</param>
+		/// <returns>Returns true for every frame the user is grabbing the
+		/// handle.</returns>
+		public static bool HandleBegin (string id, ref Pose pose, Bounds handle, ref float scale, bool drawHandle = false, UIMove moveType = UIMove.Exact, UIGesture allowedGestures = UIGesture.Pinch)
+			=> NativeAPI.ui_handle_begin_16(id, ref pose, ref scale, handle, drawHandle, moveType, allowedGestures);
 
 		/// <summary>Finishes a handle! Must be called after UI.HandleBegin()
 		/// and all elements have been drawn. Pops the pose transform pushed
@@ -1433,7 +1465,41 @@ namespace StereoKit
 		/// handle.</returns>
 		public static bool Handle(string id, ref Pose pose, Bounds handle, bool drawHandle = false, UIMove moveType = UIMove.Exact, UIGesture allowedGestures = UIGesture.Pinch)
 		{
-			bool result = NativeAPI.ui_handle_begin_16(id, ref pose, handle, drawHandle, moveType, allowedGestures);
+			bool result = NativeAPI.ui_handle_begin_16(id, ref pose, IntPtr.Zero, handle, drawHandle, moveType, allowedGestures);
+			NativeAPI.ui_handle_end();
+			return result;
+		}
+
+		/// <summary>This begins and ends a handle, like `UI.Handle`, but with
+		/// support for multi-interactor uniform scaling. With two or more
+		/// interactors grabbing the handle, their motion is combined into a
+		/// translation, rotation, and a uniform scale. Interactors may freely
+		/// join or leave the interaction without the handle jumping. Providing a
+		/// scale here enables scaling; pass `UIMove.ExactNoscale` as the moveType
+		/// if you want multi-interactor translate/rotate but no scaling.</summary>
+		/// <param name="id">An id for tracking element state. MUST be unique
+		/// within current hierarchy.</param>
+		/// <param name="pose">The pose state for the handle! The user will
+		/// be able to grab this handle and move it around. The pose is relative
+		/// to the current hierarchy stack.</param>
+		/// <param name="handle">Size and location of the handle, relative to
+		/// the pose.</param>
+		/// <param name="scale">A uniform scale multiplier that gets accumulated
+		/// as the user scales the handle with multiple interactors. Seed this
+		/// with 1 (or your starting scale). Since the Pose has no scale of its
+		/// own, you should apply this value to both your content AND the `handle`
+		/// Bounds you pass in so the grab volume matches the visual.</param>
+		/// <param name="drawHandle">Should this function draw the handle for
+		/// you, or will you draw that yourself?</param>
+		/// <param name="moveType">Describes how the handle will move when
+		/// dragged around. Use `UIMove.ExactNoscale` to disable scaling.</param>
+		/// <param name="allowedGestures">Which hand gestures are used for
+		/// interacting with this Handle?</param>
+		/// <returns>Returns true for every frame the user is grabbing the
+		/// handle.</returns>
+		public static bool Handle(string id, ref Pose pose, Bounds handle, ref float scale, bool drawHandle = false, UIMove moveType = UIMove.Exact, UIGesture allowedGestures = UIGesture.Pinch)
+		{
+			bool result = NativeAPI.ui_handle_begin_16(id, ref pose, ref scale, handle, drawHandle, moveType, allowedGestures);
 			NativeAPI.ui_handle_end();
 			return result;
 		}

--- a/StereoKit/Systems/UI.cs
+++ b/StereoKit/Systems/UI.cs
@@ -1420,12 +1420,14 @@ namespace StereoKit
 		/// able to grab this handle and move it around. The pose is relative
 		/// to the current hierarchy stack.</param>
 		/// <param name="handle">Size and location of the handle, relative to
-		/// the pose.</param>
+		/// the pose. When a `scale` is provided, the handle multiplies these
+		/// Bounds by it - so pass your unscaled base size, and the grab volume
+		/// and drawn handle grow and shrink to match your scaled content.</param>
 		/// <param name="scale">A uniform scale multiplier that gets accumulated
 		/// as the user scales the handle with multiple interactors. Seed this
 		/// with 1 (or your starting scale). Since the Pose has no scale of its
-		/// own, you should apply this value to both your content AND the `handle`
-		/// Bounds you pass in so the grab volume matches the visual.</param>
+		/// own, apply this value to your content - the `handle` Bounds are scaled
+		/// by it for you, so the grab volume and drawn handle stay matched.</param>
 		/// <param name="drawHandle">Should this function draw the handle
 		/// visual for you, or will you draw that yourself?</param>
 		/// <param name="moveType">Describes how the handle will move when
@@ -1483,12 +1485,14 @@ namespace StereoKit
 		/// be able to grab this handle and move it around. The pose is relative
 		/// to the current hierarchy stack.</param>
 		/// <param name="handle">Size and location of the handle, relative to
-		/// the pose.</param>
+		/// the pose. When a `scale` is provided, the handle multiplies these
+		/// Bounds by it - so pass your unscaled base size, and the grab volume
+		/// and drawn handle grow and shrink to match your scaled content.</param>
 		/// <param name="scale">A uniform scale multiplier that gets accumulated
 		/// as the user scales the handle with multiple interactors. Seed this
 		/// with 1 (or your starting scale). Since the Pose has no scale of its
-		/// own, you should apply this value to both your content AND the `handle`
-		/// Bounds you pass in so the grab volume matches the visual.</param>
+		/// own, apply this value to your content - the `handle` Bounds are scaled
+		/// by it for you, so the grab volume and drawn handle stay matched.</param>
 		/// <param name="drawHandle">Should this function draw the handle for
 		/// you, or will you draw that yourself?</param>
 		/// <param name="moveType">Describes how the handle will move when

--- a/StereoKitC/stereokit_ui.h
+++ b/StereoKitC/stereokit_ui.h
@@ -19,6 +19,10 @@ typedef enum ui_move_ {
 	/*Do not allow user input to change the element's pose at all! You may also be
 	interested in UI.Push/PopSurface.*/
 	ui_move_none,
+	/*Behaves just like ui_move_exact, but opts out of uniform scaling. Use this
+	when a Handle is provided a scale value, but should only ever be translated
+	and rotated by multiple interactors, never scaled.*/
+	ui_move_exact_noscale,
 } ui_move_;
 
 /*A description of what type of window to draw! This is a bit flag, so it can
@@ -448,8 +452,8 @@ SK_API void     ui_hseparator        (void);
 SK_API void     ui_hspace            (float horizontal_space);
 SK_API void     ui_vspace            (float vertical_space);
 
-SK_API bool32_t ui_handle_begin      (const char     *text, sk_ref(pose_t) movement, bounds_t handle, bool32_t draw, ui_move_ move_type sk_default(ui_move_exact), ui_gesture_ allowed_gestures sk_default(ui_gesture_pinch));
-SK_API bool32_t ui_handle_begin_16   (const char16_t *text, sk_ref(pose_t) movement, bounds_t handle, bool32_t draw, ui_move_ move_type sk_default(ui_move_exact), ui_gesture_ allowed_gestures sk_default(ui_gesture_pinch));
+SK_API bool32_t ui_handle_begin      (const char     *text, sk_ref(pose_t) movement, float* opt_ref_scale, bounds_t handle, bool32_t draw, ui_move_ move_type sk_default(ui_move_exact), ui_gesture_ allowed_gestures sk_default(ui_gesture_pinch));
+SK_API bool32_t ui_handle_begin_16   (const char16_t *text, sk_ref(pose_t) movement, float* opt_ref_scale, bounds_t handle, bool32_t draw, ui_move_ move_type sk_default(ui_move_exact), ui_gesture_ allowed_gestures sk_default(ui_gesture_pinch));
 SK_API void     ui_handle_end        (void);
 SK_API void     ui_window_begin      (const char     *text, pose_t* opt_pose, vec2 size sk_default({ 0,0 }), ui_win_ window_type sk_default(ui_win_normal), ui_move_ move_type sk_default(ui_move_face_user));
 SK_API void     ui_window_begin_16   (const char16_t *text, pose_t* opt_pose, vec2 size sk_default({ 0,0 }), ui_win_ window_type sk_default(ui_win_normal), ui_move_ move_type sk_default(ui_move_face_user));

--- a/StereoKitC/ui/interactors.cpp
+++ b/StereoKitC/ui/interactors.cpp
@@ -312,12 +312,14 @@ bool32_t interaction_handle(id_hash_t id, int32_t priority, pose_t* ref_handle_p
 			(actor_world->pinch_state & button_state_active      && actor_world->active_prev  == id));
 
 		if (active & button_state_just_active) {
+			vec3 grab_world = hierarchy_to_world_point(at_local);
 			actor_world->interaction_start_motion           = actor_world->motion;
 			actor_world->interaction_start_motion_anchor    = actor_world->motion_anchor;
 			actor_world->interaction_start_el               = *ref_handle_pose;
 			actor_world->interaction_start_el_pivot         = at_local;
 			actor_world->interaction_secondary_motion_total = vec3_zero;
-			actor_world->interaction_intersection_local     = matrix_transform_pt(pose_matrix_inv(actor_world->motion), hierarchy_to_world_point(at_local));
+			actor_world->interaction_intersection_local     = matrix_transform_pt(pose_matrix_inv(actor_world->motion), grab_world);
+			actor_world->interaction_start_flat_depth       = vec3_dot(grab_world - actor_world->capsule_start_world, input_head().orientation * vec3_forward);
 		}
 
 		if (active & button_state_active) {
@@ -338,6 +340,7 @@ bool32_t interaction_handle(id_hash_t id, int32_t priority, pose_t* ref_handle_p
 		actor_world->interaction_start_el               = *ref_handle_pose;
 		actor_world->interaction_start_el_pivot         = hierarchy_to_local_point(world_grab);
 		actor_world->interaction_secondary_motion_total = vec3_zero;
+		actor_world->interaction_start_flat_depth       = vec3_dot(world_grab - actor_world->capsule_start_world, input_head().orientation * vec3_forward);
 	}
 
 	// Both branches below produce a world-space target pose in these.
@@ -361,8 +364,37 @@ bool32_t interaction_handle(id_hash_t id, int32_t priority, pose_t* ref_handle_p
 		else if (actor_world->secondary_motion_dimensions == 2) { secondary_motion = actor_world->motion.orientation * vec3{ 0,0,-actor_world->interaction_secondary_motion_total.y }; }
 		else if (actor_world->secondary_motion_dimensions == 3) { secondary_motion = actor_world->motion.orientation * actor_world->interaction_secondary_motion_total; }
 
+		vec3 pivot_base = matrix_transform_pt(matrix_trs(actor_world->motion.position, actor_world->motion.orientation, vec3_one * amplify_factor), actor_world->interaction_intersection_local);
+
+		// Keep secondary motion from pulling the grab point back through the
+		// interactor origin; rescale the running total so reversing has no dead zone.
+		if (actor_world->secondary_motion_dimensions != 0) {
+			vec3  origin    = actor_world->capsule_start_world;
+			vec3  ray_dir   = vec3_normalize(actor_world->capsule_end_world - origin);
+			float base_dist = vec3_dot(pivot_base - origin, ray_dir);
+			float sec_along = vec3_dot(secondary_motion, ray_dir);
+			const float min_dist = 0.0f;
+			if (base_dist > min_dist && base_dist + sec_along < min_dist) {
+				float clamped = min_dist - base_dist; // allowed along-ray displacement (negative)
+				actor_world->interaction_secondary_motion_total *= clamped / sec_along;
+				secondary_motion = ray_dir * clamped;
+			}
+		}
+
 		// Where the grabbed point lands this frame, from the interactor's input.
-		vec3 pivot_new_position_world = matrix_transform_pt(matrix_trs(actor_world->motion.position + secondary_motion, actor_world->motion.orientation, vec3_one * amplify_factor), actor_world->interaction_intersection_local);
+		vec3 pivot_new_position_world = pivot_base + secondary_motion;
+
+		// A flat-screen cursor ray would arc the grab point as the mouse moves; pin it
+		// to a camera-parallel plane at the grab-time depth so windows slide flat.
+		if (move_type == ui_move_face_user && device_display_get_type() == display_type_flatscreen) {
+			vec3  camera       = actor_world->capsule_start_world;
+			vec3  forward      = input_head().orientation * vec3_forward;
+			float target_depth = actor_world->interaction_start_flat_depth + vec3_dot(secondary_motion, forward);
+			vec3  cursor_dir   = vec3_normalize(pivot_new_position_world - camera);
+			float cursor_dot   = vec3_dot(cursor_dir, forward);
+			if (cursor_dot > 0.001f)
+				pivot_new_position_world = camera + cursor_dir * (target_depth / cursor_dot);
+		}
 
 		switch (move_type) {
 		case ui_move_exact:

--- a/StereoKitC/ui/interactors.cpp
+++ b/StereoKitC/ui/interactors.cpp
@@ -249,10 +249,11 @@ static quat ui_multi_solve_rotation(const float m[3][3]) {
 
 ///////////////////////////////////////////
 
-// Orientation for a ui_move_face_user handle, facing the user's head. It looks
-// from `look_from_world` (blended toward handle_center_world as it nears the
-// face); the single path passes the grab pivot, the multi path handle_center.
-static quat ui_face_user_rotation(vec3 look_from_world, vec3 handle_center_world) {
+// Orientation for a ui_move_face_user handle: faces the user's head from
+// `look_from_world`, which should be ~the bounds center. Callers must build it
+// from a point that does NOT depend on the handle's own orientation, or the
+// facing feeds back into the pose and spins.
+static quat ui_face_user_rotation(vec3 look_from_world) {
 	pose_t head_world = input_head();
 	// On a flat screen, facing the window beats facing the 'user'.
 	if (device_display_get_type() == display_type_flatscreen)
@@ -261,12 +262,9 @@ static quat ui_face_user_rotation(vec3 look_from_world, vec3 handle_center_world
 	// The head pose sits at the eyes, so nudge back and down to the head center.
 	const float head_center_dist = 5    * cm2m;
 	const float head_height      = 7.5f * cm2m;
-	vec3  head_center_world = head_world.position + head_world.orientation * vec3{0, 0, head_center_dist};
-	vec3  face_point_world  = head_center_world + vec3{0, -head_height, 0};
-
-	float head_xz_lerp = fminf(1, vec2_distance_sq({ face_point_world.x, face_point_world.z }, { look_from_world.x, look_from_world.z }) / 0.1f);
-	vec3  look_from    = vec3_lerp(look_from_world, handle_center_world, head_xz_lerp);
-	return quat_lookat_up(look_from, face_point_world, vec3_up);
+	vec3 head_center_world = head_world.position + head_world.orientation * vec3{0, 0, head_center_dist};
+	vec3 face_point_world  = head_center_world + vec3{0, -head_height, 0};
+	return quat_lookat_up(look_from_world, face_point_world, vec3_up);
 }
 
 ///////////////////////////////////////////
@@ -342,25 +340,14 @@ bool32_t interaction_handle(id_hash_t id, int32_t priority, pose_t* ref_handle_p
 		actor_world->interaction_secondary_motion_total = vec3_zero;
 	}
 
+	// Both branches below produce a world-space target pose in these.
+	vec3 new_pos_world = vec3_zero;
+	quat new_rot_world = quat_identity;
 	if (active_count == 1) {
 		// A single interactor: classic one-handed 6DOF manipulation.
 		_interactor_t* actor_world = active_actors[0];
 
-		quat dest_rot_world = quat_identity;
-		switch (move_type) {
-		case ui_move_exact:
-		case ui_move_exact_noscale: {
-			dest_rot_world = matrix_transform_quat(handle_parent_to_world, actor_world->interaction_start_el.orientation) * quat_difference(actor_world->interaction_start_motion.orientation, actor_world->motion.orientation);
-		} break;
-		case ui_move_face_user: {
-			dest_rot_world = ui_face_user_rotation(hierarchy_to_world_point(actor_world->interaction_start_el_pivot), hierarchy_to_world_point(handle_bounds.center));
-		} break;
-		case ui_move_pos_only: { dest_rot_world = matrix_transform_quat(handle_parent_to_world, actor_world->interaction_start_el.orientation); } break;
-		default:               { dest_rot_world = matrix_transform_quat(handle_parent_to_world, actor_world->interaction_start_el.orientation); log_err("Unimplemented move type!"); } break;
-		}
-
-		// Amplify the movement in and out, so that objects at a
-		// distance can be manipulated easier.
+		// Amplify the movement in and out, so distant objects are easier to move.
 		const float amplify_push = 1.5f;
 		const float amplify_pull = 2;
 		float       amplify_factor =
@@ -368,22 +355,37 @@ bool32_t interaction_handle(id_hash_t id, int32_t priority, pose_t* ref_handle_p
 			fmaxf(0.01f, vec3_distance(actor_world->interaction_start_motion.position, actor_world->interaction_start_motion_anchor));
 		amplify_factor = powf(amplify_factor, amplify_factor > 1 ? amplify_push : amplify_pull);
 
-		// Find secondary motion from scroll wheels/analog sticks, etc.
+		// Secondary motion from scroll wheels/analog sticks, etc.
 		vec3 secondary_motion = vec3_zero;
 		if      (actor_world->secondary_motion_dimensions == 1) { secondary_motion = actor_world->motion.orientation * vec3{ 0,0, actor_world->interaction_secondary_motion_total.x }; }
 		else if (actor_world->secondary_motion_dimensions == 2) { secondary_motion = actor_world->motion.orientation * vec3{ 0,0,-actor_world->interaction_secondary_motion_total.y }; }
 		else if (actor_world->secondary_motion_dimensions == 3) { secondary_motion = actor_world->motion.orientation * actor_world->interaction_secondary_motion_total; }
 
+		// Where the grabbed point lands this frame, from the interactor's input.
 		vec3 pivot_new_position_world = matrix_transform_pt(matrix_trs(actor_world->motion.position + secondary_motion, actor_world->motion.orientation, vec3_one * amplify_factor), actor_world->interaction_intersection_local);
-		vec3 handle_offset_world      = dest_rot_world * (matrix_extract_scale(handle_parent_to_world) * -actor_world->interaction_start_el_pivot);
-		vec3 dest_pos_world           = pivot_new_position_world + handle_offset_world;
 
-		// Transform from world space, to the space the handle is in
-		vec3 dest_pos_handle = matrix_transform_pt  (to_handle_parent_local, dest_pos_world);
-		quat dest_rot_handle = matrix_transform_quat(to_handle_parent_local, dest_rot_world);
+		switch (move_type) {
+		case ui_move_exact:
+		case ui_move_exact_noscale: {
+			new_rot_world = matrix_transform_quat(handle_parent_to_world, actor_world->interaction_start_el.orientation) * quat_difference(actor_world->interaction_start_motion.orientation, actor_world->motion.orientation);
+		} break;
+		case ui_move_face_user: {
+			// Face from the bounds center, but build that look-from from the
+			// grab-time orientation and the (input-only) grab target so it can't
+			// feed back and spin. The offset below still uses the facing, which
+			// keeps the grabbed point pinned exactly under the hand.
+			quat grab_rot      = matrix_transform_quat(handle_parent_to_world, actor_world->interaction_start_el.orientation);
+			vec3 center_offset = grab_rot * (matrix_extract_scale(handle_parent_to_world) * (handle_bounds.center - actor_world->interaction_start_el_pivot));
+			new_rot_world = ui_face_user_rotation(pivot_new_position_world + center_offset);
+		} break;
+		case ui_move_pos_only: { new_rot_world = matrix_transform_quat(handle_parent_to_world, actor_world->interaction_start_el.orientation); } break;
+		default:               { new_rot_world = matrix_transform_quat(handle_parent_to_world, actor_world->interaction_start_el.orientation); log_err("Unimplemented move type!"); } break;
+		}
 
-		ref_handle_pose->position    = vec3_lerp (ref_handle_pose->position,    dest_pos_handle, 0.6f);
-		ref_handle_pose->orientation = quat_slerp(ref_handle_pose->orientation, dest_rot_handle, 0.4f);
+		// Offset uses the facing (new_rot_world), so the grabbed point lands
+		// exactly at pivot_new_position_world - pinned under the hand.
+		vec3 handle_offset_world = new_rot_world * (matrix_extract_scale(handle_parent_to_world) * -actor_world->interaction_start_el_pivot);
+		new_pos_world            = pivot_new_position_world + handle_offset_world;
 	} else if (active_count >= 2) {
 		// Multiple interactors: solve one incremental translate/rotate/scale that
 		// maps each grab point from its previous- to current-frame world position.
@@ -437,24 +439,28 @@ bool32_t interaction_handle(id_hash_t id, int32_t priority, pose_t* ref_handle_p
 		// delta_rot is world-space, so the handle orientation goes on the LEFT;
 		// reversing applies it in the handle's local frame, which inverts axes for
 		// any non-identity rest pose (a 180-turned handle would invert its roll).
-		quat   new_rot_world = quat_mul(handle_world.orientation, delta_rot);
+		new_rot_world = quat_mul(handle_world.orientation, delta_rot);
 		if (move_type == ui_move_pos_only) {
 			swing_rot     = quat_identity;
 			new_rot_world = handle_world.orientation;
 		} else if (move_type == ui_move_face_user) {
 			swing_rot = quat_identity;
-			vec3 handle_center = hierarchy_to_world_point(handle_bounds.center);
-			new_rot_world = ui_face_user_rotation(handle_center, handle_center);
+			new_rot_world = ui_face_user_rotation(hierarchy_to_world_point(handle_bounds.center));
 		}
 
 		// Apply the combined transform: scale & rotate the handle about the grab
 		// centroid, then carry it along with the centroid's motion.
-		vec3 new_pos_world = cur_centroid + delta_scale * (swing_rot * (handle_world.position - prev_centroid));
+		new_pos_world = cur_centroid + delta_scale * (swing_rot * (handle_world.position - prev_centroid));
 
-		ref_handle_pose->position    = matrix_transform_pt  (to_handle_parent_local, new_pos_world);
-		ref_handle_pose->orientation = quat_normalize(matrix_transform_quat(to_handle_parent_local, new_rot_world));
 		if (allow_scaling)
 			*opt_ref_scale *= delta_scale;
+	}
+
+	// Both paths produced a world-space target pose; write it back into the
+	// handle's parent space.
+	if (active_count > 0) {
+		ref_handle_pose->position    = matrix_transform_pt  (to_handle_parent_local, new_pos_world);
+		ref_handle_pose->orientation = quat_normalize(matrix_transform_quat(to_handle_parent_local, new_rot_world));
 	}
 
 	// Whichever path ran, keep each active interactor's focus tracking in sync

--- a/StereoKitC/ui/interactors.cpp
+++ b/StereoKitC/ui/interactors.cpp
@@ -205,11 +205,81 @@ void interaction_1h_box(id_hash_t id, interactor_event_ event_mask, int32_t prio
 
 ///////////////////////////////////////////
 
-bool32_t interaction_handle(id_hash_t id, int32_t priority, pose_t* ref_handle_pose, bounds_t handle_bounds, ui_move_ move_type, ui_gesture_ allowed_gestures) {
+// Solves for the rotation that best maps a set of 'from' vectors onto a set of
+// 'to' vectors, using Horn's quaternion method. The cross-covariance matrix is
+// provided as `m`, where m[r][c] = sum( from_r * to_c ).
+static quat ui_multi_solve_rotation(const float m[3][3]) {
+	// Build Horn's symmetric, zero-trace 4x4 N matrix from the
+	// cross-covariance. Its largest (most positive) eigenvalue's eigenvector is
+	// the optimal rotation quaternion, ordered (w,x,y,z).
+	float sxx = m[0][0], sxy = m[0][1], sxz = m[0][2];
+	float syx = m[1][0], syy = m[1][1], syz = m[1][2];
+	float szx = m[2][0], szy = m[2][1], szz = m[2][2];
+	float n[4][4] = {
+		{ sxx + syy + szz,         syz - szy,         szx - sxz,         sxy - syx },
+		{       syz - szy,   sxx - syy - szz,         sxy + syx,         szx + sxz },
+		{       szx - sxz,         sxy + syx,  -sxx + syy - szz,         syz + szy },
+		{       sxy - syx,         szx + sxz,         syz + szy,  -sxx - syy + szz },
+	};
+
+	// N has both positive and negative eigenvalues (zero trace), but power
+	// iteration converges to the largest *magnitude* one. Shifting by c*I (a
+	// Gershgorin spectral-radius bound) makes N positive semi-definite without
+	// changing eigenvectors, so the largest eigenvalue becomes the dominant one.
+	float c = 0;
+	for (int32_t r = 0; r < 4; r++) {
+		float row = fabsf(n[r][0]) + fabsf(n[r][1]) + fabsf(n[r][2]) + fabsf(n[r][3]);
+		if (row > c) c = row;
+	}
+
+	// Seeded with the identity quaternion. The per-frame deltas this is used for
+	// are always near identity, so this converges in just a few iterations.
+	float v[4] = { 1, 0, 0, 0 };
+	for (int32_t it = 0; it < 16; it++) {
+		float o[4];
+		for (int32_t r = 0; r < 4; r++)
+			o[r] = (n[r][0] + (r==0?c:0))*v[0] + (n[r][1] + (r==1?c:0))*v[1] + (n[r][2] + (r==2?c:0))*v[2] + (n[r][3] + (r==3?c:0))*v[3];
+		float len = sqrtf(o[0]*o[0] + o[1]*o[1] + o[2]*o[2] + o[3]*o[3]);
+		if (len < 1e-10f) { v[0]=1; v[1]=v[2]=v[3]=0; break; }
+		float inv = 1.0f / len;
+		v[0]=o[0]*inv; v[1]=o[1]*inv; v[2]=o[2]*inv; v[3]=o[3]*inv;
+	}
+	return quat{ v[1], v[2], v[3], v[0] };
+}
+
+///////////////////////////////////////////
+
+// Orientation for a ui_move_face_user handle, facing the user's head. It looks
+// from `look_from_world` (blended toward handle_center_world as it nears the
+// face); the single path passes the grab pivot, the multi path handle_center.
+static quat ui_face_user_rotation(vec3 look_from_world, vec3 handle_center_world) {
+	pose_t head_world = input_head();
+	// On a flat screen, facing the window beats facing the 'user'.
+	if (device_display_get_type() == display_type_flatscreen)
+		return quat_from_angles(0, 180, 0) * head_world.orientation;
+
+	// The head pose sits at the eyes, so nudge back and down to the head center.
+	const float head_center_dist = 5    * cm2m;
+	const float head_height      = 7.5f * cm2m;
+	vec3  head_center_world = head_world.position + head_world.orientation * vec3{0, 0, head_center_dist};
+	vec3  face_point_world  = head_center_world + vec3{0, -head_height, 0};
+
+	float head_xz_lerp = fminf(1, vec2_distance_sq({ face_point_world.x, face_point_world.z }, { look_from_world.x, look_from_world.z }) / 0.1f);
+	vec3  look_from    = vec3_lerp(look_from_world, handle_center_world, head_xz_lerp);
+	return quat_lookat_up(look_from, face_point_world, vec3_up);
+}
+
+///////////////////////////////////////////
+
+bool32_t interaction_handle(id_hash_t id, int32_t priority, pose_t* ref_handle_pose, bounds_t handle_bounds, ui_move_ move_type, ui_gesture_ allowed_gestures, float* opt_ref_scale) {
 	bool result = false;
 
 	local.last_element = id;
 	if (!ui_is_enabled() || move_type == ui_move_none) return false;
+
+	// Scaling (only with multiple interactors) is on whenever a scale pointer is
+	// given; ui_move_exact_noscale and ui_move_pos_only opt out.
+	bool32_t allow_scaling = opt_ref_scale != nullptr && move_type != ui_move_exact_noscale && move_type != ui_move_pos_only;
 
 	matrix to_handle_parent_local = *hierarchy_to_local();
 	matrix handle_parent_to_world = *hierarchy_to_world();
@@ -219,8 +289,17 @@ bool32_t interaction_handle(id_hash_t id, int32_t priority, pose_t* ref_handle_p
 	if (allowed_gestures & ui_gesture_pinch) event_mask = (interactor_event_)(event_mask | interactor_event_pinch);
 	if (allowed_gestures & ui_gesture_grip ) event_mask = (interactor_event_)(event_mask | interactor_event_grip );
 
+	// Collect the interactors grabbing this handle so we can combine their motion.
+	// prev_active_count flags a shrink back to one (which needs a re-baseline).
+	const int32_t  UI_MULTI_MAX_INTERACTORS = 16;
+	_interactor_t* active_actors[UI_MULTI_MAX_INTERACTORS];
+	int32_t        active_count      = 0;
+	int32_t        prev_active_count = 0;
+
 	for (int32_t i = 0; i < local.interactors.count; i++) {
 		_interactor_t* actor_world = &local.interactors[i];
+		if (gen_is_alive(actor_world->generation) && actor_world->active_prev == id)
+			prev_active_count += 1;
 		// Skip this if something else has some focus!
 		if (interactor_is_preoccupied(actor_world, id, event_mask, false))
 			continue;
@@ -244,84 +323,149 @@ bool32_t interaction_handle(id_hash_t id, int32_t priority, pose_t* ref_handle_p
 		}
 
 		if (active & button_state_active) {
-			result = true;
-
-			pose_t head_world     = input_head();
-			quat   dest_rot_world = quat_identity;
-			switch (move_type) {
-			case ui_move_exact: {
-				dest_rot_world = matrix_transform_quat(handle_parent_to_world, actor_world->interaction_start_el.orientation) * quat_difference(actor_world->interaction_start_motion.orientation, actor_world->motion.orientation);
-			} break;
-			case ui_move_face_user: {
-				if (device_display_get_type() == display_type_flatscreen) {
-					// If we're on a flat screen, facing the window is
-					// a better experience than facing the user.
-					dest_rot_world = quat_from_angles(0, 180, 0) * head_world.orientation;
-				} else {
-					// We can't use the head position directly, it's
-					// more of a device position that matches the
-					// center of the eyes, and not the center of the
-					// head.
-					const float head_center_dist = 5    * cm2m; // Quarter head length (20cm front to back)
-					const float head_height      = 7.5f * cm2m; // Almost quarter head height (25cm top to bottom)
-					vec3 eye_center_world  = head_world.position;
-					vec3 head_center_world = eye_center_world + head_world.orientation * vec3{0, 0, head_center_dist};
-					vec3 face_point_world  = head_center_world + vec3{0, -head_height, 0};
-
-					// Previously, facing happened from a point
-					// influenced by the hand-grip position:
-					// vec3 world_handle_center = { handle_pose.position.x, local_pt[i].y, handle_pose.position.z };
-					vec3  world_handle_center = hierarchy_to_world_point(handle_bounds.center);
-					vec3  world_pt            = hierarchy_to_world_point(actor_world->interaction_start_el_pivot);
-
-					float head_xz_lerp        = fminf(1, vec2_distance_sq({ face_point_world.x, face_point_world.z }, { world_pt.x, world_pt.z }) / 0.1f);
-					vec3  look_from_world     = vec3_lerp(world_pt, world_handle_center, head_xz_lerp);
-
-					dest_rot_world = quat_lookat_up(look_from_world, face_point_world, vec3_up);
-				}
-			} break;
-			case ui_move_pos_only: { dest_rot_world = matrix_transform_quat(handle_parent_to_world, actor_world->interaction_start_el.orientation); } break;
-			default:               { dest_rot_world = matrix_transform_quat(handle_parent_to_world, actor_world->interaction_start_el.orientation); log_err("Unimplemented move type!"); } break;
-			}
-
-			// Amplify the movement in and out, so that objects at a
-			// distance can be manipulated easier.
-			const float amplify_push = 1.5f;
-			const float amplify_pull = 2;
-			float       amplify_factor =
-				fmaxf(0.01f, vec3_distance(actor_world->motion.position,                   actor_world->motion_anchor)) /
-				fmaxf(0.01f, vec3_distance(actor_world->interaction_start_motion.position, actor_world->interaction_start_motion_anchor));
-			amplify_factor = powf(amplify_factor, amplify_factor > 1 ? amplify_push : amplify_pull);
-
-			// Find secondary motion from scroll wheels/analog sticks, etc.
-			vec3 secondary_motion = vec3_zero;
-			if      (actor_world->secondary_motion_dimensions == 1) { secondary_motion = actor_world->motion.orientation * vec3{ 0,0, actor_world->interaction_secondary_motion_total.x }; }
-			else if (actor_world->secondary_motion_dimensions == 2) { secondary_motion = actor_world->motion.orientation * vec3{ 0,0,-actor_world->interaction_secondary_motion_total.y }; }
-			else if (actor_world->secondary_motion_dimensions == 3) { secondary_motion = actor_world->motion.orientation * actor_world->interaction_secondary_motion_total; }
-
-			vec3 pivot_new_position_world = matrix_transform_pt(matrix_trs(actor_world->motion.position + secondary_motion, actor_world->motion.orientation, vec3_one * amplify_factor), actor_world->interaction_intersection_local);
-			vec3 handle_offset_world      = dest_rot_world * (matrix_extract_scale(handle_parent_to_world) * -actor_world->interaction_start_el_pivot);
-			vec3 dest_pos_world           = pivot_new_position_world + handle_offset_world;
-
-			// Transform from world space, to the space the handle is in
-			vec3 dest_pos_handle = matrix_transform_pt  (to_handle_parent_local, dest_pos_world);
-			quat dest_rot_handle = matrix_transform_quat(to_handle_parent_local, dest_rot_world);
-
-			ref_handle_pose->position    = vec3_lerp (ref_handle_pose->position,    dest_pos_handle, 0.6f);
-			ref_handle_pose->orientation = quat_slerp(ref_handle_pose->orientation, dest_rot_handle, 0.4f);
-
-			if (actor_world->pinch_state & button_state_just_inactive) {
-				actor_world->active = 0;
-			}
-
-			// Update the focus pose with the updated position
-			actor_world->focus_pose_world = matrix_transform_pose(handle_parent_to_world, *ref_handle_pose);
-			matrix to_local_update = pose_matrix_inv(actor_world->focus_pose_world);
-			vec3   update_at;
-			if (bounds_capsule_intersect(handle_bounds, matrix_transform_pt(to_local_update, actor_world->capsule_start_world), matrix_transform_pt(to_local_update, actor_world->capsule_end_world), actor_world->capsule_radius, &update_at)) {
-				actor_world->focus_intersection_local = update_at - actor_world->focus_bounds_local.center;
-			}
+			if (active_count < UI_MULTI_MAX_INTERACTORS)
+				active_actors[active_count++] = actor_world;
 		}
+	}
+
+	result = active_count > 0;
+
+	// Shrinking back to one interactor: its grab snapshot is stale (the others
+	// moved the handle since), so re-baseline it to the current pose to avoid a snap.
+	if (active_count == 1 && prev_active_count >= 2) {
+		_interactor_t* actor_world = active_actors[0];
+		vec3 world_grab = matrix_transform_pt(pose_matrix(actor_world->motion), actor_world->interaction_intersection_local);
+		actor_world->interaction_start_motion           = actor_world->motion;
+		actor_world->interaction_start_motion_anchor    = actor_world->motion_anchor;
+		actor_world->interaction_start_el               = *ref_handle_pose;
+		actor_world->interaction_start_el_pivot         = hierarchy_to_local_point(world_grab);
+		actor_world->interaction_secondary_motion_total = vec3_zero;
+	}
+
+	if (active_count == 1) {
+		// A single interactor: classic one-handed 6DOF manipulation.
+		_interactor_t* actor_world = active_actors[0];
+
+		quat dest_rot_world = quat_identity;
+		switch (move_type) {
+		case ui_move_exact:
+		case ui_move_exact_noscale: {
+			dest_rot_world = matrix_transform_quat(handle_parent_to_world, actor_world->interaction_start_el.orientation) * quat_difference(actor_world->interaction_start_motion.orientation, actor_world->motion.orientation);
+		} break;
+		case ui_move_face_user: {
+			dest_rot_world = ui_face_user_rotation(hierarchy_to_world_point(actor_world->interaction_start_el_pivot), hierarchy_to_world_point(handle_bounds.center));
+		} break;
+		case ui_move_pos_only: { dest_rot_world = matrix_transform_quat(handle_parent_to_world, actor_world->interaction_start_el.orientation); } break;
+		default:               { dest_rot_world = matrix_transform_quat(handle_parent_to_world, actor_world->interaction_start_el.orientation); log_err("Unimplemented move type!"); } break;
+		}
+
+		// Amplify the movement in and out, so that objects at a
+		// distance can be manipulated easier.
+		const float amplify_push = 1.5f;
+		const float amplify_pull = 2;
+		float       amplify_factor =
+			fmaxf(0.01f, vec3_distance(actor_world->motion.position,                   actor_world->motion_anchor)) /
+			fmaxf(0.01f, vec3_distance(actor_world->interaction_start_motion.position, actor_world->interaction_start_motion_anchor));
+		amplify_factor = powf(amplify_factor, amplify_factor > 1 ? amplify_push : amplify_pull);
+
+		// Find secondary motion from scroll wheels/analog sticks, etc.
+		vec3 secondary_motion = vec3_zero;
+		if      (actor_world->secondary_motion_dimensions == 1) { secondary_motion = actor_world->motion.orientation * vec3{ 0,0, actor_world->interaction_secondary_motion_total.x }; }
+		else if (actor_world->secondary_motion_dimensions == 2) { secondary_motion = actor_world->motion.orientation * vec3{ 0,0,-actor_world->interaction_secondary_motion_total.y }; }
+		else if (actor_world->secondary_motion_dimensions == 3) { secondary_motion = actor_world->motion.orientation * actor_world->interaction_secondary_motion_total; }
+
+		vec3 pivot_new_position_world = matrix_transform_pt(matrix_trs(actor_world->motion.position + secondary_motion, actor_world->motion.orientation, vec3_one * amplify_factor), actor_world->interaction_intersection_local);
+		vec3 handle_offset_world      = dest_rot_world * (matrix_extract_scale(handle_parent_to_world) * -actor_world->interaction_start_el_pivot);
+		vec3 dest_pos_world           = pivot_new_position_world + handle_offset_world;
+
+		// Transform from world space, to the space the handle is in
+		vec3 dest_pos_handle = matrix_transform_pt  (to_handle_parent_local, dest_pos_world);
+		quat dest_rot_handle = matrix_transform_quat(to_handle_parent_local, dest_rot_world);
+
+		ref_handle_pose->position    = vec3_lerp (ref_handle_pose->position,    dest_pos_handle, 0.6f);
+		ref_handle_pose->orientation = quat_slerp(ref_handle_pose->orientation, dest_rot_handle, 0.4f);
+	} else if (active_count >= 2) {
+		// Multiple interactors: solve one incremental translate/rotate/scale that
+		// maps each grab point from its previous- to current-frame world position.
+		// Being a one-frame delta, interactors can join/leave without a snap.
+		vec3 prev_pts[UI_MULTI_MAX_INTERACTORS];
+		vec3 cur_pts [UI_MULTI_MAX_INTERACTORS];
+		vec3 prev_centroid = vec3_zero;
+		vec3 cur_centroid  = vec3_zero;
+		for (int32_t a = 0; a < active_count; a++) {
+			_interactor_t* act = active_actors[a];
+			prev_pts[a]    = matrix_transform_pt(pose_matrix(act->motion_prev), act->interaction_intersection_local);
+			cur_pts [a]    = matrix_transform_pt(pose_matrix(act->motion),      act->interaction_intersection_local);
+			prev_centroid += prev_pts[a];
+			cur_centroid  += cur_pts [a];
+		}
+		prev_centroid = prev_centroid / (float)active_count;
+		cur_centroid  = cur_centroid  / (float)active_count;
+
+		// Rotation comes purely from how the centered grab points move, never the
+		// interactors' own orientations: so a hand circle rotates the handle by
+		// exactly that angle, and incidental hand tilt can't leak into a roll.
+		float m[3][3] = { {0,0,0}, {0,0,0}, {0,0,0} };
+		float spread_num = 0, spread_den = 0;
+		for (int32_t a = 0; a < active_count; a++) {
+			// `from` = previous-frame point, `to` = current-frame point. The
+			// cross-covariance follows Horn's S[j][k] = sum(from_j * to_k)
+			// convention that ui_multi_solve_rotation expects.
+			vec3 from = prev_pts[a] - prev_centroid;
+			vec3 to   = cur_pts [a] - cur_centroid;
+			m[0][0] += from.x*to.x; m[0][1] += from.x*to.y; m[0][2] += from.x*to.z;
+			m[1][0] += from.y*to.x; m[1][1] += from.y*to.y; m[1][2] += from.y*to.z;
+			m[2][0] += from.z*to.x; m[2][1] += from.z*to.y; m[2][2] += from.z*to.z;
+			spread_num += vec3_dot(to,   to);
+			spread_den += vec3_dot(from, from);
+		}
+		quat delta_rot = ui_multi_solve_rotation(m);
+
+		// Uniform scale is the change in how spread out the grab points are
+		// relative to their centroid. Clamped to a sane per-frame range.
+		float delta_scale = 1;
+		if (allow_scaling && spread_den > 1e-8f) {
+			delta_scale = sqrtf(spread_num / spread_den);
+			if (delta_scale < 0.5f) delta_scale = 0.5f;
+			if (delta_scale > 2.0f) delta_scale = 2.0f;
+		}
+
+		// Resolve the applied orientation per move type; swing_rot rotates the
+		// handle's offset about the grab centroid.
+		pose_t handle_world  = matrix_transform_pose(handle_parent_to_world, *ref_handle_pose);
+		quat   swing_rot     = delta_rot;
+		// delta_rot is world-space, so the handle orientation goes on the LEFT;
+		// reversing applies it in the handle's local frame, which inverts axes for
+		// any non-identity rest pose (a 180-turned handle would invert its roll).
+		quat   new_rot_world = quat_mul(handle_world.orientation, delta_rot);
+		if (move_type == ui_move_pos_only) {
+			swing_rot     = quat_identity;
+			new_rot_world = handle_world.orientation;
+		} else if (move_type == ui_move_face_user) {
+			swing_rot = quat_identity;
+			vec3 handle_center = hierarchy_to_world_point(handle_bounds.center);
+			new_rot_world = ui_face_user_rotation(handle_center, handle_center);
+		}
+
+		// Apply the combined transform: scale & rotate the handle about the grab
+		// centroid, then carry it along with the centroid's motion.
+		vec3 new_pos_world = cur_centroid + delta_scale * (swing_rot * (handle_world.position - prev_centroid));
+
+		ref_handle_pose->position    = matrix_transform_pt  (to_handle_parent_local, new_pos_world);
+		ref_handle_pose->orientation = quat_normalize(matrix_transform_quat(to_handle_parent_local, new_rot_world));
+		if (allow_scaling)
+			*opt_ref_scale *= delta_scale;
+	}
+
+	// Whichever path ran, keep each active interactor's focus tracking in sync
+	// with the moved handle.
+	for (int32_t i = 0; i < active_count; i++) {
+		_interactor_t* act = active_actors[i];
+		act->focus_pose_world = matrix_transform_pose(handle_parent_to_world, *ref_handle_pose);
+		matrix to_local_update = pose_matrix_inv(act->focus_pose_world);
+		vec3   update_at;
+		if (bounds_capsule_intersect(handle_bounds, matrix_transform_pt(to_local_update, act->capsule_start_world), matrix_transform_pt(to_local_update, act->capsule_end_world), act->capsule_radius, &update_at))
+			act->focus_intersection_local = update_at - act->focus_bounds_local.center;
 	}
 	hierarchy_pop();
 	return result;

--- a/StereoKitC/ui/interactors.h
+++ b/StereoKitC/ui/interactors.h
@@ -80,7 +80,7 @@ void             interaction_shutdown       ();
 
 void             interaction_1h_box         (id_hash_t id, interactor_event_ event_mask, int32_t priority, vec3 box_unfocused_start, vec3 box_unfocused_size, vec3 box_focused_start, vec3 box_focused_size, button_state_* out_focus_candidacy, interactor_t* out_interactor);
 void             interaction_1h_plate       (id_hash_t id, interactor_event_ event_mask, int32_t priority, vec3 plate_start, vec3 plate_size, button_state_* out_focus_candidacy, interactor_t* out_interactor, vec3* out_interaction_at_local);
-bool32_t         interaction_handle         (id_hash_t id, int32_t priority, pose_t* ref_handle_pose, bounds_t handle_bounds, ui_move_ move_type, ui_gesture_ allowed_gestures);
+bool32_t         interaction_handle         (id_hash_t id, int32_t priority, pose_t* ref_handle_pose, bounds_t handle_bounds, ui_move_ move_type, ui_gesture_ allowed_gestures, float* opt_ref_scale);
 
 _interactor_t*   _interactor_get            (interactor_t interactor);
 bool32_t         interactor_is_preoccupied  (const _interactor_t* interactor, id_hash_t for_el_id, interactor_event_ event_mask, bool32_t include_focused);

--- a/StereoKitC/ui/interactors.h
+++ b/StereoKitC/ui/interactors.h
@@ -54,6 +54,9 @@ struct _interactor_t {
 	vec3                   interaction_secondary_motion_total;
 	// This is local to the motion pose
 	vec3                   interaction_intersection_local;
+	// Flat-screen ui_move_face_user: the grab point's depth in front of the camera at
+	// grab time, so a dragged window can hold a constant depth (interaction_handle).
+	float                  interaction_start_flat_depth;
 
 
 	int32_t                focus_priority;

--- a/StereoKitC/ui/stereokit_ui.cpp
+++ b/StereoKitC/ui/stereokit_ui.cpp
@@ -944,7 +944,7 @@ void ui_window_begin_g(const C *text, pose_t* opt_pose, vec2 window_size, ui_win
 	box_start.z = box_size.z/2;
 
 	// Set up window handle and layout area
-	_ui_handle_begin(hash, pose, { box_start, box_size }, false, move_type, ui_gesture_pinch);
+	_ui_handle_begin(hash, pose, nullptr, { box_start, box_size }, false, move_type, ui_gesture_pinch);
 	ui_layout_window(win_id, { win->prev_size.x / 2,0,0 }, window_size, true);
 
 	// Ensure space for the header text

--- a/StereoKitC/ui/ui_core.cpp
+++ b/StereoKitC/ui/ui_core.cpp
@@ -253,18 +253,29 @@ void ui_slider_behavior(vec3 window_relative_pos, vec2 size, id_hash_t id, vec2*
 ///////////////////////////////////////////
 
 bool32_t _ui_handle_begin(id_hash_t id, pose_t* handle_pose, float* opt_ref_scale, bounds_t handle_bounds, bool32_t draw, ui_move_ move_type, ui_gesture_ allowed_gestures) {
-	bool result = interaction_handle(id, -2, handle_pose, handle_bounds, move_type, allowed_gestures, opt_ref_scale);
+	// When a scale is present, ensure the bounds scale with it
+	bounds_t bounds = handle_bounds;
+	if (opt_ref_scale != nullptr) {
+		bounds.center     = handle_bounds.center     * *opt_ref_scale;
+		bounds.dimensions = handle_bounds.dimensions * *opt_ref_scale;
+	}
+	bool result = interaction_handle(id, -2, handle_pose, bounds, move_type, allowed_gestures, opt_ref_scale);
 	ui_push_surface(*handle_pose);
+
+	if (opt_ref_scale != nullptr) {
+		bounds.center     = handle_bounds.center     * *opt_ref_scale;
+		bounds.dimensions = handle_bounds.dimensions * *opt_ref_scale;
+	}
 
 	float color_blend = 0;
 	if (ui_id_focused(id)) color_blend = 1;
 	if (ui_id_active_state(id) & button_state_just_active)
-		ui_play_sound_on_off(ui_vis_handle, id, handle_bounds.center);
+		ui_play_sound_on_off(ui_vis_handle, id, bounds.center);
 
 	if (draw) {
 		ui_draw_element(ui_vis_handle,
-			handle_bounds.center+handle_bounds.dimensions/2,
-			handle_bounds.dimensions,
+			bounds.center+bounds.dimensions/2,
+			bounds.dimensions,
 			color_blend);
 		ui_nextline();
 	}

--- a/StereoKitC/ui/ui_core.cpp
+++ b/StereoKitC/ui/ui_core.cpp
@@ -252,8 +252,8 @@ void ui_slider_behavior(vec3 window_relative_pos, vec2 size, id_hash_t id, vec2*
 
 ///////////////////////////////////////////
 
-bool32_t _ui_handle_begin(id_hash_t id, pose_t* handle_pose, bounds_t handle_bounds, bool32_t draw, ui_move_ move_type, ui_gesture_ allowed_gestures) {
-	bool result = interaction_handle(id, -2, handle_pose, handle_bounds, move_type, allowed_gestures);
+bool32_t _ui_handle_begin(id_hash_t id, pose_t* handle_pose, float* opt_ref_scale, bounds_t handle_bounds, bool32_t draw, ui_move_ move_type, ui_gesture_ allowed_gestures) {
+	bool result = interaction_handle(id, -2, handle_pose, handle_bounds, move_type, allowed_gestures, opt_ref_scale);
 	ui_push_surface(*handle_pose);
 
 	float color_blend = 0;
@@ -273,11 +273,11 @@ bool32_t _ui_handle_begin(id_hash_t id, pose_t* handle_pose, bounds_t handle_bou
 
 ///////////////////////////////////////////
 
-bool32_t ui_handle_begin(const char *text, pose_t& movement, bounds_t handle, bool32_t draw, ui_move_ move_type, ui_gesture_ allowed_gestures) {
-	return _ui_handle_begin(ui_stack_hash(text), &movement, handle, draw, move_type, allowed_gestures);
+bool32_t ui_handle_begin(const char *text, pose_t& movement, float* opt_ref_scale, bounds_t handle, bool32_t draw, ui_move_ move_type, ui_gesture_ allowed_gestures) {
+	return _ui_handle_begin(ui_stack_hash(text), &movement, opt_ref_scale, handle, draw, move_type, allowed_gestures);
 }
-bool32_t ui_handle_begin_16(const char16_t *text, pose_t& movement, bounds_t handle, bool32_t draw, ui_move_ move_type, ui_gesture_ allowed_gestures) {
-	return _ui_handle_begin(ui_stack_hash_16(text), &movement, handle, draw, move_type, allowed_gestures);
+bool32_t ui_handle_begin_16(const char16_t *text, pose_t& movement, float* opt_ref_scale, bounds_t handle, bool32_t draw, ui_move_ move_type, ui_gesture_ allowed_gestures) {
+	return _ui_handle_begin(ui_stack_hash_16(text), &movement, opt_ref_scale, handle, draw, move_type, allowed_gestures);
 }
 
 ///////////////////////////////////////////

--- a/StereoKitC/ui/ui_core.h
+++ b/StereoKitC/ui/ui_core.h
@@ -10,6 +10,6 @@ inline bounds_t  ui_size_box  (vec3 top_left, vec3 dimensions) { return { top_le
 inline id_hash_t ui_stack_hash(const char16_t* string)         { return ui_stack_hash_16(string); }
 inline id_hash_t ui_push_id   (const char16_t* id)             { return ui_push_id_16(id); }
 
-bool32_t _ui_handle_begin(id_hash_t id, pose_t* handle_pose, bounds_t handle_bounds, bool32_t draw, ui_move_ move_type, ui_gesture_ allowed_gestures);
+bool32_t _ui_handle_begin(id_hash_t id, pose_t* handle_pose, float* opt_ref_scale, bounds_t handle_bounds, bool32_t draw, ui_move_ move_type, ui_gesture_ allowed_gestures);
 
 }


### PR DESCRIPTION
- `UI.Handle` now works with an arbitrary number of interactors simultaneously!
- `UI.Handle` also now takes an optional scale parameter for 2 handed scaling.
- FaceUser on flat screens no longer arcs.
- Secondary motion no longer goes past the hand.
- This also fixes a long standing issue where `FaceUser` windows would spin when too close to the user.
- Handle damping has been removed. Most modern interactor sources are already damped systems side, and it's now trivial to add damping if desired.
- Added a number of interaction and UI element tests.