### PR TITLE
Allow buttons to cancel by moving the interactor away

### DIFF
--- a/Examples/StereoKitTest/Tests/TestInteractorCancel.cs
+++ b/Examples/StereoKitTest/Tests/TestInteractorCancel.cs
@@ -1,0 +1,100 @@
+using StereoKit;
+
+// Verifies button activation CANCELLATION. A pinch/ray button fires on release -
+// unless the interactor is pulled far (>15cm) from the button first, which cancels
+// the press so it never fires. Under -test, two ray interactors run the same
+// press/release in parallel: one stays on its button (fires), one is swung far
+// away mid-press (cancels), so the cancel motion is the only difference between
+// them. Outside -test the default interactors stay on, so you can try it by hand.
+class TestInteractorCancel : ITest
+{
+	Pose windowPose = new Pose(0, 0, -0.5f, Quat.LookDir(0, 0, 1));
+
+	DefaultInteractors oldInteractors;
+	Interactor         rayClick, rayCancel;
+	Vec3               rayOrigin = V.XYZ(0.05f, -0.2f, -0.35f);
+	Vec3               clickTarget, cancelTarget;
+	int                frame = 0;
+
+	bool[] clickFired  = new bool[5];
+	bool[] cancelFired = new bool[5];
+
+	public void Initialize()
+	{
+		oldInteractors = Interaction.DefaultInteractors;
+		if (!Tests.IsTesting) return; // leave the default interactors on to try by hand
+
+		Interaction.DefaultInteractors = DefaultInteractors.None;
+		// Unique sources so the two interactors never preoccupy each other.
+		rayClick     = Interactor.Create(InteractorType.Line, InteractorEvent.Pinch | InteractorEvent.Poke, InteractorActivation.State, InteractorSource.Unique, 0.01f, 0);
+		rayCancel    = Interactor.Create(InteractorType.Line, InteractorEvent.Pinch | InteractorEvent.Poke, InteractorActivation.State, InteractorSource.Unique, 0.01f, 0);
+		clickTarget  = windowPose.position + V.XYZ(0, -0.04f, 0); // guesses at each button, refined once focused
+		cancelTarget = windowPose.position + V.XYZ(0, -0.08f, 0);
+
+		Tests.RunForFrames(5);
+	}
+
+	public void Step()
+	{
+		bool scripted = Tests.IsTesting && frame < clickFired.Length;
+		if (scripted)
+		{
+			// frame 0 warm-up, 1 focus, 2 press, 3 hold, 4 release.
+			BtnState pinch = frame switch {
+				0 => BtnState.Inactive,
+				1 => BtnState.Inactive,
+				2 => BtnState.Active | BtnState.JustActive,
+				3 => BtnState.Active,
+				_ => BtnState.JustInactive };
+			// The click ray stays on its button; the cancel ray runs the same
+			// press, then on frame 3 jumps ~1m aside pointing away, so by release
+			// it's well past the cancel distance.
+			Aim(rayClick, rayOrigin, clickTarget, pinch);
+			if (frame < 3) Aim(rayCancel, rayOrigin, cancelTarget, pinch);
+			else           Aim(rayCancel, V.XYZ(1, 0, -0.35f), V.XYZ(2, 0, -0.35f), pinch);
+		}
+
+		UI.WindowBegin("Cancel", ref windowPose);
+		if (!Tests.IsTesting) UI.Text("Pinch a button and pull away to cancel it", Align.Center);
+		bool clickHit  = UI.Button("Click");
+		bool cancelHit = UI.Button("Cancel");
+		UI.WindowEnd();
+
+		if (scripted)
+		{
+			clickFired [frame] = clickHit;
+			cancelFired[frame] = cancelHit;
+			Log.Info($"frame {frame}: click fired={clickHit}  cancel fired={cancelHit}");
+
+			if (             rayClick .TryGetFocusBounds(out Pose cp, out Bounds cb, out _)) clickTarget  = cp.ToMatrix().Transform(cb.center);
+			if (frame < 3 && rayCancel.TryGetFocusBounds(out Pose xp, out Bounds xb, out _)) cancelTarget = xp.ToMatrix().Transform(xb.center);
+
+			if (frame == 4)
+			{
+				Tests.Test(ClickFires);
+				Tests.Test(CancelDoesNotFire);
+			}
+		}
+		else if (clickHit || cancelHit)
+			Log.Info("Button fired!");
+
+		frame++;
+	}
+
+	void Aim(Interactor ray, Vec3 origin, Vec3 target, BtnState pinch)
+	{
+		Vec3 dir = (target - origin).Normalized;
+		ray.Update(origin, origin + dir * 100, new Pose(origin, Quat.LookDir(dir)), origin, Vec3.Zero, pinch, BtnState.Active);
+	}
+
+	// The control button releases on its button, so it fires exactly on frame 4.
+	bool ClickFires() => clickFired[4] && !clickFired[0] && !clickFired[1] && !clickFired[2] && !clickFired[3];
+	// The canceled button never fires, despite the identical press and release.
+	bool CancelDoesNotFire() { for (int i = 0; i < cancelFired.Length; i++) if (cancelFired[i]) return false; return true; }
+
+	public void Shutdown()
+	{
+		if (Tests.IsTesting) { rayClick.Destroy(); rayCancel.Destroy(); }
+		Interaction.DefaultInteractors = oldInteractors;
+	}
+}

--- a/Examples/StereoKitTest/Tests/TestUIFocus.cs
+++ b/Examples/StereoKitTest/Tests/TestUIFocus.cs
@@ -30,6 +30,8 @@ class TestUIFocus : ITest
 	public void Initialize()
 	{
 		oldInteractors = Interaction.DefaultInteractors;
+		if (!Tests.IsTesting) return; // leave the default interactors on to try by hand
+
 		Interaction.DefaultInteractors = DefaultInteractors.None;
 
 		// Unique sources so the two interactors never preoccupy each other.
@@ -43,40 +45,45 @@ class TestUIFocus : ITest
 
 	public void Step()
 	{
-		// frame 0 warm-up, 1 establishes focus, 2 is the one-frame JustActive that
-		// activates, 3 holds Active - same drive for both interactors.
-		BtnState pinch = frame switch {
-			0 => BtnState.Inactive,
-			1 => BtnState.Inactive,
-			2 => BtnState.Active | BtnState.JustActive,
-			_ => BtnState.Active };
-		Aim(raySlider, sliderTarget, pinch);
-		Aim(rayButton, buttonTarget, pinch);
+		bool scripted = Tests.IsTesting && frame < sliderFocused.Length;
+		if (scripted)
+		{
+			// frame 0 warm-up, 1 establishes focus, 2 is the one-frame JustActive
+			// that activates, 3 holds Active - same drive for both interactors.
+			BtnState pinch = frame switch {
+				0 => BtnState.Inactive,
+				1 => BtnState.Inactive,
+				2 => BtnState.Active | BtnState.JustActive,
+				_ => BtnState.Active };
+			Aim(raySlider, sliderTarget, pinch);
+			Aim(rayButton, buttonTarget, pinch);
+		}
 
 		UI.WindowBegin("UI Focus", ref windowPose);
-
 		UI.HSlider("Slider", ref sliderVal, 0, 1, 0.1f, 0, UIConfirm.Pinch);
-		sliderFocused[frame] = UI.LastElementFocused; sliderActive[frame] = UI.LastElementActive;
-
+		BtnState sf = UI.LastElementFocused, sa = UI.LastElementActive;
 		UI.Button("Button");
-		buttonFocused[frame] = UI.LastElementFocused; buttonActive[frame] = UI.LastElementActive;
-
+		BtnState bf = UI.LastElementFocused, ba = UI.LastElementActive;
 		UI.WindowEnd();
 
-		Log.Info($"frame {frame}: pinch=[{pinch}]");
-		Log.Info($"  slider: UI.Focused=[{sliderFocused[frame]}] UI.Active=[{sliderActive[frame]}]  (interactor focused={raySlider.Focused != IdHash.None} active={raySlider.Active != IdHash.None})");
-		Log.Info($"  button: UI.Focused=[{buttonFocused[frame]}] UI.Active=[{buttonActive[frame]}]  (interactor focused={rayButton.Focused != IdHash.None} active={rayButton.Active != IdHash.None})");
-
-		// Keep each ray aimed at its element once it's focused it.
-		if (raySlider.TryGetFocusBounds(out Pose sp, out Bounds sb, out _)) sliderTarget = sp.ToMatrix().Transform(sb.center);
-		if (rayButton.TryGetFocusBounds(out Pose bp, out Bounds bb, out _)) buttonTarget = bp.ToMatrix().Transform(bb.center);
-
-		// Once the full sequence is recorded, check it.
-		if (frame == 3)
+		if (scripted)
 		{
-			Tests.Test(SliderLifecycle);
-			Tests.Test(ButtonLifecycle);
-			Tests.Test(ButtonMatchesSlider);
+			sliderFocused[frame] = sf; sliderActive[frame] = sa;
+			buttonFocused[frame] = bf; buttonActive[frame] = ba;
+			Log.Info($"frame {frame}:");
+			Log.Info($"  slider: UI.Focused=[{sf}] UI.Active=[{sa}]  (interactor focused={raySlider.Focused != IdHash.None} active={raySlider.Active != IdHash.None})");
+			Log.Info($"  button: UI.Focused=[{bf}] UI.Active=[{ba}]  (interactor focused={rayButton.Focused != IdHash.None} active={rayButton.Active != IdHash.None})");
+
+			// Keep each ray aimed at its element once it's focused it.
+			if (raySlider.TryGetFocusBounds(out Pose sp, out Bounds sb, out _)) sliderTarget = sp.ToMatrix().Transform(sb.center);
+			if (rayButton.TryGetFocusBounds(out Pose bp, out Bounds bb, out _)) buttonTarget = bp.ToMatrix().Transform(bb.center);
+
+			if (frame == 3)
+			{
+				Tests.Test(SliderLifecycle);
+				Tests.Test(ButtonLifecycle);
+				Tests.Test(ButtonMatchesSlider);
+			}
 		}
 		frame++;
 	}
@@ -112,8 +119,7 @@ class TestUIFocus : ITest
 
 	public void Shutdown()
 	{
-		raySlider.Destroy();
-		rayButton.Destroy();
+		if (Tests.IsTesting) { raySlider.Destroy(); rayButton.Destroy(); }
 		Interaction.DefaultInteractors = oldInteractors;
 	}
 }

--- a/StereoKit/Native/NativeEnums.cs
+++ b/StereoKit/Native/NativeEnums.cs
@@ -1401,8 +1401,10 @@ namespace StereoKit
 		JustInactive = 1 << 1,
 		/// <summary>Has the button just been pressed? Only true for a single frame.</summary>
 		JustActive   = 1 << 2,
-		/// <summary>Has the button just changed state this frame?</summary>
-		Changed      = JustInactive | JustActive,
+		/// <summary>Was a button activation just canceled this frame, ending without firing because the interactor moved too far away? Only true for a single frame.</summary>
+		JustCanceled = 1 << 3,
+		/// <summary>Has the button just changed state this frame? Includes presses, releases, and canceled activations.</summary>
+		Changed      = JustInactive | JustActive | JustCanceled,
 		/// <summary>Matches with all states!</summary>
 		Any          = 0x7FFFFFFF,
 	}

--- a/StereoKit/Native/NativeTypes.Custom.cs
+++ b/StereoKit/Native/NativeTypes.Custom.cs
@@ -310,6 +310,10 @@ namespace StereoKit
 		/// <summary>Has the button just been released this frame?</summary>
 		/// <returns>True if released, false if not.</returns>
 		public static bool IsJustInactive(this BtnState state) => (state & BtnState.JustInactive) > 0;
+		/// <summary>Was a button activation just canceled this frame, ending
+		/// without firing because the interactor moved too far away?</summary>
+		/// <returns>True if just canceled, false if not.</returns>
+		public static bool IsJustCanceled(this BtnState state) => (state & BtnState.JustCanceled) > 0;
 		/// <summary>Was the button either presses or released this frame?
 		/// </summary>
 		/// <returns>True if the state just changed this frame, false if not.

--- a/StereoKitC/stereokit.h
+++ b/StereoKitC/stereokit.h
@@ -2500,8 +2500,10 @@ typedef enum button_state_ {
 	button_state_just_inactive = 1 << 1,
 	/*Has the button just been pressed? Only true for a single frame.*/
 	button_state_just_active   = 1 << 2,
-	/*Has the button just changed state this frame?*/
-	button_state_changed       = button_state_just_inactive | button_state_just_active,
+	/*Was a button activation just canceled this frame, ending without firing because the interactor moved too far away? Only true for a single frame.*/
+	button_state_just_canceled = 1 << 3,
+	/*Has the button just changed state this frame? Includes presses, releases, and canceled activations.*/
+	button_state_changed       = button_state_just_inactive | button_state_just_active | button_state_just_canceled,
 	/*Matches with all states!*/
 	button_state_any           = 0x7FFFFFFF,
 } button_state_;

--- a/StereoKitC/ui/interactors.cpp
+++ b/StereoKitC/ui/interactors.cpp
@@ -126,10 +126,11 @@ inline bounds_t size_box(vec3 top_left, vec3 dimensions) {
 
 ///////////////////////////////////////////
 
-void interaction_1h_plate(id_hash_t id, interactor_event_ event_mask, int32_t priority, vec3 plate_start, vec3 plate_size, button_state_ *out_focus_candidacy, interactor_t* out_interactor, vec3 *out_interaction_at_local) {
+void interaction_1h_plate(id_hash_t id, interactor_event_ event_mask, int32_t priority, vec3 plate_start, vec3 plate_size, button_state_ *out_focus_candidacy, interactor_t* out_interactor, vec3 *out_interaction_at_local, float* out_cancel_dist) {
 	*out_interactor           = -1;
 	*out_focus_candidacy      = button_state_inactive;
 	*out_interaction_at_local = vec3_zero;
+	*out_cancel_dist          = 0;
 
 	local.last_element = id;
 	if (!ui_is_enabled()) return;
@@ -168,6 +169,16 @@ void interaction_1h_plate(id_hash_t id, interactor_event_ event_mask, int32_t pr
 			*out_interactor           = gen_id_make(i, actor->generation);
 			*out_focus_candidacy      = focus;
 			*out_interaction_at_local = interact_at;
+
+			// Distance from the interactor's ray/point to the plate, valid even
+			// when it's no longer pointing at it (interactor_check_box returns
+			// nothing off-box). Used to cancel a button activation.
+			vec3  cap_start = hierarchy_to_local_point(actor->capsule_start_world);
+			vec3  cap_end   = hierarchy_to_local_point(actor->capsule_end_world);
+			vec3  seg_dir   = cap_end - cap_start;
+			float seg_len2  = vec3_dot(seg_dir, seg_dir);
+			float seg_t     = seg_len2 < 1e-9f ? 0 : fminf(1, fmaxf(0, vec3_dot(bounds.center - cap_start, seg_dir) / seg_len2));
+			*out_cancel_dist = bounds_sdf(bounds, cap_start + seg_dir * seg_t);
 		}
 	}
 }

--- a/StereoKitC/ui/interactors.h
+++ b/StereoKitC/ui/interactors.h
@@ -82,7 +82,7 @@ void             interaction_update         ();
 void             interaction_shutdown       ();
 
 void             interaction_1h_box         (id_hash_t id, interactor_event_ event_mask, int32_t priority, vec3 box_unfocused_start, vec3 box_unfocused_size, vec3 box_focused_start, vec3 box_focused_size, button_state_* out_focus_candidacy, interactor_t* out_interactor);
-void             interaction_1h_plate       (id_hash_t id, interactor_event_ event_mask, int32_t priority, vec3 plate_start, vec3 plate_size, button_state_* out_focus_candidacy, interactor_t* out_interactor, vec3* out_interaction_at_local);
+void             interaction_1h_plate       (id_hash_t id, interactor_event_ event_mask, int32_t priority, vec3 plate_start, vec3 plate_size, button_state_* out_focus_candidacy, interactor_t* out_interactor, vec3* out_interaction_at_local, float* out_cancel_dist);
 bool32_t         interaction_handle         (id_hash_t id, int32_t priority, pose_t* ref_handle_pose, bounds_t handle_bounds, ui_move_ move_type, ui_gesture_ allowed_gestures, float* opt_ref_scale);
 
 _interactor_t*   _interactor_get            (interactor_t interactor);

--- a/StereoKitC/ui/ui_core.cpp
+++ b/StereoKitC/ui/ui_core.cpp
@@ -81,6 +81,10 @@ void ui_button_behavior(vec3 window_relative_pos, vec2 size, id_hash_t id, float
 
 ///////////////////////////////////////////
 
+// A pinch/ray button activation cancels (ends without firing) once the
+// interactor moves more than this far from the button.
+static const float skui_button_cancel_dist = 15 * cm2m;
+
 void ui_button_behavior_depth(vec3 window_relative_pos, vec2 size, id_hash_t id, float button_depth, float button_activation_depth, float &out_finger_offset, button_state_ &out_button_state, button_state_ &out_focus_state, interactor_t* out_opt_interactor) {
 	out_button_state  = button_state_inactive;
 	out_focus_state   = button_state_inactive;
@@ -88,16 +92,18 @@ void ui_button_behavior_depth(vec3 window_relative_pos, vec2 size, id_hash_t id,
 
 	int32_t       interactor = -1;
 	vec3          interaction_at;
+	float         cancel_dist = 0;
 	button_state_ focus_candidacy = button_state_inactive;
 	interaction_1h_plate(id, interactor_event_poke, 0,
 		{ window_relative_pos.x, window_relative_pos.y, window_relative_pos.z - button_depth }, { size.x, size.y, button_depth },
-		&focus_candidacy, &interactor, &interaction_at);
+		&focus_candidacy, &interactor, &interaction_at, &cancel_dist);
 
 	// If a hand is interacting, adjust the button surface accordingly
 	_interactor_t* actor = _interactor_get(interactor);
 	if (actor) {
 		if (focus_candidacy & button_state_active) {
 			bool pressed;
+			bool canceled = false;
 			if (actor->activation_type == interactor_activation_position) {
 				out_finger_offset = -(interaction_at.z + actor->capsule_radius) - window_relative_pos.z;
 				pressed = out_finger_offset < button_activation_depth;
@@ -105,10 +111,15 @@ void ui_button_behavior_depth(vec3 window_relative_pos, vec2 size, id_hash_t id,
 				pressed = (actor->pinch_state & button_state_just_active) ||
 				          (actor->pinch_state & button_state_active && actor->active_prev == id);
 				if (pressed) out_finger_offset = 0;
+				// A pinch/ray pulled too far cancels: the activation ends and won't
+				// fire on release.
+				canceled = pressed && cancel_dist > skui_button_cancel_dist;
+				if (canceled) out_finger_offset = button_depth;
 			}
 			const float min_press_depth = 2 * mm2m;
 			out_finger_offset = fminf(fmaxf(min_press_depth, out_finger_offset), button_depth);
-			out_button_state  = interactor_set_active(actor, id, pressed);
+			out_button_state  = interactor_set_active(actor, id, pressed && !canceled);
+			if (canceled) out_button_state = button_state_just_canceled;
 		} else if (focus_candidacy & button_state_just_inactive) {
 			out_button_state = interactor_set_active(actor, id, false);
 		}


### PR DESCRIPTION
This adds `BtnState.JustCanceled` and `BtnState.IsJustCancelled()`. `JustCancelled` now fires instead of `JustInactive` when the user cancels an interaction instead of confirming it.