### PR TITLE
Adds the Android trackables spatial anchor backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,7 +209,7 @@ include("cmake/CPM.cmake")
 #### OpenXR - https://www.khronos.org/openxr/ ####
 if (SK_BUILD_OPENXR_LOADER)
   CPMAddPackage( # We're scraping the comment after the NAME for some other scripts
-    NAME openxr_loader # 1.1.49
+    NAME openxr_loader # 1.1.60
     GITHUB_REPOSITORY KhronosGroup/OpenXR-SDK
     GIT_TAG release-1.1.60
     GIT_SHALLOW 1
@@ -560,6 +560,8 @@ set(SK_SRC_XR_EXTS
   StereoKitC/xr_backends/extensions/oculus_audio.cpp
   StereoKitC/xr_backends/extensions/msft_anchors.h
   StereoKitC/xr_backends/extensions/msft_anchors.cpp
+  StereoKitC/xr_backends/extensions/android_anchors.h
+  StereoKitC/xr_backends/extensions/android_anchors.cpp
   StereoKitC/xr_backends/extensions/msft_bridge.h
   StereoKitC/xr_backends/extensions/msft_bridge.cpp
   StereoKitC/xr_backends/extensions/msft_observer.h

--- a/StereoKitC/asset_types/anchor.cpp
+++ b/StereoKitC/asset_types/anchor.cpp
@@ -7,6 +7,7 @@
 #include "../xr_backends/openxr.h"
 #include "../xr_backends/extensions/ext_management.h"
 #include "../xr_backends/extensions/msft_anchors.h"
+#include "../xr_backends/extensions/android_anchors.h"
 #include "../xr_backends/anchor_stage.h"
 
 namespace sk {
@@ -39,6 +40,8 @@ bool anchors_init() {
 
 	if (xr_ext_msft_spatial_anchors_available())
 		anch_sys = anchor_system_openxr_msft;
+	else if (xr_ext_android_spatial_anchors_available())
+		anch_sys = anchor_system_openxr_android;
 	else if (backend_xr_get_type() == backend_xr_type_simulator)
 		anch_sys = anchor_system_stage;
 	else
@@ -46,8 +49,9 @@ bool anchors_init() {
 
 	bool32_t result = false;
 	switch (anch_sys) {
-	case anchor_system_stage:       result = anchor_stage_init(); break;
-	case anchor_system_openxr_msft: result = true;                break;
+	case anchor_system_stage:          result = anchor_stage_init(); break;
+	case anchor_system_openxr_msft:    result = true;                break;
+	case anchor_system_openxr_android: result = true;                break;
 	default: break;
 	}
 
@@ -55,9 +59,10 @@ bool anchors_init() {
 	anch_initialized = true;
 
 	switch (anch_sys) {
-	case anchor_system_openxr_msft: log_diagf("Using MSFT spatial anchors."); break;
-	case anchor_system_stage:       log_diagf("Using fallback stage spatial anchors."); break;
-	default:                        log_diagf("NOT using spatial anchors."); break;
+	case anchor_system_openxr_msft:    log_diagf("Using MSFT spatial anchors."); break;
+	case anchor_system_openxr_android: log_diagf("Using Android spatial anchors."); break;
+	case anchor_system_stage:          log_diagf("Using fallback stage spatial anchors."); break;
+	default:                           log_diagf("NOT using spatial anchors."); break;
 	}
 
 	return true;
@@ -122,8 +127,9 @@ anchor_t anchor_create(pose_t pose) {
 		to_hex(b,4), to_hex(b,5), to_hex(b,6), to_hex(b,7), '\0' };
 
 	switch (anch_sys) {
-	case anchor_system_openxr_msft: return xr_ext_msft_spatial_anchors_create(pose, name);
-	case anchor_system_stage:       return anchor_stage_create               (pose, name);
+	case anchor_system_openxr_msft:    return xr_ext_msft_spatial_anchors_create   (pose, name);
+	case anchor_system_openxr_android: return xr_ext_android_spatial_anchors_create(pose, name);
+	case anchor_system_stage:          return anchor_stage_create                  (pose, name);
 	default: return nullptr;
 	}
 }
@@ -148,7 +154,8 @@ anchor_t anchor_create_manual(anchor_type_id system_id, pose_t pose, const char 
 
 void anchor_destroy(anchor_t anchor) {
 	switch (anch_sys) {
-	case anchor_system_openxr_msft: xr_ext_msft_spatial_anchors_destroy(anchor); break;
+	case anchor_system_openxr_msft:    xr_ext_msft_spatial_anchors_destroy   (anchor); break;
+	case anchor_system_openxr_android: xr_ext_android_spatial_anchors_destroy(anchor); break;
 	//case anchor_system_stage:       anchor_stage_destroy               (anchor); break;
 	default: break;
 	}
@@ -212,8 +219,9 @@ void anchor_update_manual(anchor_t anchor, pose_t pose) {
 
 bool32_t anchor_try_set_persistent(anchor_t anchor, bool32_t persistent) {
 	switch (anch_sys) {
-	case anchor_system_openxr_msft: return xr_ext_msft_spatial_anchors_persist(anchor, persistent);
-	case anchor_system_stage:       return anchor_stage_persist               (anchor, persistent);
+	case anchor_system_openxr_msft:    return xr_ext_msft_spatial_anchors_persist   (anchor, persistent);
+	case anchor_system_openxr_android: return xr_ext_android_spatial_anchors_persist(anchor, persistent);
+	case anchor_system_stage:          return anchor_stage_persist                  (anchor, persistent);
 	default: return false;
 	}
 }
@@ -268,8 +276,9 @@ void anchor_mark_dirty(anchor_t anchor) {
 
 void anchor_clear_stored() {
 	switch (anch_sys) {
-	case anchor_system_openxr_msft: xr_ext_msft_spatial_anchors_clear_stored(); break;
-	case anchor_system_stage:       anchor_stage_clear_stored(); break;
+	case anchor_system_openxr_msft:    xr_ext_msft_spatial_anchors_clear_stored   (); break;
+	case anchor_system_openxr_android: xr_ext_android_spatial_anchors_clear_stored(); break;
+	case anchor_system_stage:          anchor_stage_clear_stored(); break;
 	default: break;
 	}
 }
@@ -278,8 +287,9 @@ void anchor_clear_stored() {
 
 anchor_caps_ anchor_get_capabilities() {
 	switch (anch_sys) {
-	case anchor_system_openxr_msft: return xr_ext_msft_spatial_anchors_capabilities();
-	case anchor_system_stage:       return anchor_caps_storable;
+	case anchor_system_openxr_msft:    return xr_ext_msft_spatial_anchors_capabilities();
+	case anchor_system_openxr_android: return xr_ext_android_spatial_anchors_capabilities();
+	case anchor_system_stage:          return anchor_caps_storable;
 	default: return (anchor_caps_)0;
 	}
 }

--- a/StereoKitC/asset_types/anchor.h
+++ b/StereoKitC/asset_types/anchor.h
@@ -22,6 +22,7 @@ typedef enum anchor_system_ {
 	anchor_system_none,
 	anchor_system_stage,
 	anchor_system_openxr_msft,
+	anchor_system_openxr_android,
 } anchor_system_;
 
 void           anchor_destroy         (anchor_t anchor);

--- a/StereoKitC/xr_backends/extensions/_registration.cpp
+++ b/StereoKitC/xr_backends/extensions/_registration.cpp
@@ -12,6 +12,7 @@
 #include "ext_management.h"
 #include "_registration.h"
 
+#include "android_anchors.h"
 #include "composition_depth.h"
 #include "debug_utils.h"
 #include "meta_environment_depth.h"
@@ -61,6 +62,7 @@ bool ext_registration() {
 	xr_ext_msft_hand_mesh_register();
 	xr_ext_msft_scene_understanding_register();
 	xr_ext_msft_spatial_anchors_register();
+	xr_ext_android_spatial_anchors_register();
 	xr_ext_fb_colorspace_register();
 	xr_ext_msft_observer_register();
 	xr_ext_composition_depth_register();

--- a/StereoKitC/xr_backends/extensions/android_anchors.cpp
+++ b/StereoKitC/xr_backends/extensions/android_anchors.cpp
@@ -1,0 +1,157 @@
+/* SPDX-License-Identifier: MIT */
+/* The authors below grant copyright rights under the MIT license:
+ * Copyright (c) 2026 Nick Klingensmith
+ */
+
+// This implements XR_ANDROID_trackables anchor spaces
+// https://registry.khronos.org/OpenXR/specs/1.1/html/xrspec.html#XR_ANDROID_trackables
+
+#include "android_anchors.h"
+#include "ext_management.h"
+
+#include "../../stereokit.h"
+#include "../../asset_types/anchor.h"
+#include "../../systems/input.h"
+
+#define XR_EXT_ANCHOR_FUNCTIONS( X ) \
+	X(xrCreateAnchorSpaceANDROID)
+OPENXR_DEFINE_FN_STATIC(XR_EXT_ANCHOR_FUNCTIONS);
+
+///////////////////////////////////////////
+
+namespace sk {
+
+///////////////////////////////////////////
+
+typedef struct xr_android_anchors_state_t {
+	bool              available;
+	anchor_type_id    id;
+	array_t<anchor_t> anchors;
+} xr_android_anchors_state_t;
+static xr_android_anchors_state_t local = { };
+
+typedef struct oxr_android_world_anchor_t {
+	XrSpace space;
+} oxr_android_world_anchor_t;
+
+///////////////////////////////////////////
+
+xr_system_ xr_ext_android_spatial_anchors_initialize(void*);
+void       xr_ext_android_spatial_anchors_step_begin(void*);
+void       xr_ext_android_spatial_anchors_shutdown  (void*);
+
+///////////////////////////////////////////
+
+void xr_ext_android_spatial_anchors_register() {
+	xr_system_t sys = {};
+	sys.request_exts[sys.request_ext_count++] = XR_ANDROID_TRACKABLES_EXTENSION_NAME;
+	sys.evt_initialize = { xr_ext_android_spatial_anchors_initialize };
+	sys.evt_step_begin = { xr_ext_android_spatial_anchors_step_begin };
+	sys.evt_shutdown   = { xr_ext_android_spatial_anchors_shutdown };
+	ext_management_sys_register(sys);
+}
+
+///////////////////////////////////////////
+
+xr_system_ xr_ext_android_spatial_anchors_initialize(void*) {
+	if (!backend_openxr_ext_enabled(XR_ANDROID_TRACKABLES_EXTENSION_NAME))
+		return xr_system_fail;
+
+	OPENXR_LOAD_FN_RETURN(XR_EXT_ANCHOR_FUNCTIONS, xr_system_fail);
+
+	local.available = true;
+	return xr_system_succeed;
+}
+
+///////////////////////////////////////////
+
+void xr_ext_android_spatial_anchors_shutdown(void*) {
+	for (int32_t i = local.anchors.count - 1; i >= 0; i--)
+		anchor_release(local.anchors[i]);
+
+	local.anchors.free();
+	local = {};
+
+	OPENXR_CLEAR_FN(XR_EXT_ANCHOR_FUNCTIONS);
+}
+
+///////////////////////////////////////////
+
+void xr_ext_android_spatial_anchors_step_begin(void*) {
+	for (int32_t i = 0; i < local.anchors.count; i += 1) {
+		anchor_t                    anchor = local.anchors[i];
+		oxr_android_world_anchor_t* data   = (oxr_android_world_anchor_t*)anchor->data;
+
+		anchor->tracked = button_make_state(
+			(anchor->tracked & button_state_active) != 0,
+			openxr_get_space(data->space, &anchor->pose));
+	}
+}
+
+///////////////////////////////////////////
+
+bool xr_ext_android_spatial_anchors_available() {
+	return local.available;
+}
+
+///////////////////////////////////////////
+
+anchor_caps_ xr_ext_android_spatial_anchors_capabilities() {
+	anchor_caps_ result = {};
+	if (local.available) result |= anchor_caps_stability;
+	return result;
+}
+
+///////////////////////////////////////////
+
+void xr_ext_android_spatial_anchors_clear_stored() {
+}
+
+///////////////////////////////////////////
+
+anchor_t xr_ext_android_spatial_anchors_create(pose_t pose, const char* name_utf8) {
+	XrAnchorSpaceCreateInfoANDROID info = { XR_TYPE_ANCHOR_SPACE_CREATE_INFO_ANDROID };
+	memcpy(&info.pose.position,    &pose.position,    sizeof(vec3));
+	memcpy(&info.pose.orientation, &pose.orientation, sizeof(quat));
+	info.space     = xr_app_space;
+	info.time      = xr_time;
+	info.trackable = XR_NULL_TRACKABLE_ANDROID;
+
+	XrSpace  space;
+	XrResult result = xrCreateAnchorSpaceANDROID(xr_session, &info, &space);
+	if (XR_FAILED(result)) {
+		log_warnf("xrCreateAnchorSpaceANDROID failed: %s", openxr_string(result));
+		return nullptr;
+	}
+
+	bool32_t tracked = openxr_get_space(space, &pose);
+
+	oxr_android_world_anchor_t* anchor_data = sk_malloc_t(oxr_android_world_anchor_t, 1);
+	anchor_data->space = space;
+	anchor_t sk_anchor = anchor_create_manual(local.id, pose, name_utf8, (void*)anchor_data);
+	sk_anchor->tracked = tracked ? button_state_active : button_state_inactive;
+	local.anchors.add(sk_anchor);
+	anchor_addref(sk_anchor);
+	return sk_anchor;
+}
+
+///////////////////////////////////////////
+
+void xr_ext_android_spatial_anchors_destroy(anchor_t anchor) {
+	int32_t idx = local.anchors.index_of(anchor);
+	if (idx >= 0) local.anchors.remove(idx);
+
+	oxr_android_world_anchor_t* data = (oxr_android_world_anchor_t*)anchor->data;
+	xrDestroySpace(data->space);
+	sk_free(data);
+}
+
+///////////////////////////////////////////
+
+bool32_t xr_ext_android_spatial_anchors_persist(anchor_t anchor, bool32_t persist) {
+	return anchor->persisted == persist;
+}
+
+///////////////////////////////////////////
+
+} // namespace sk

--- a/StereoKitC/xr_backends/extensions/android_anchors.h
+++ b/StereoKitC/xr_backends/extensions/android_anchors.h
@@ -1,0 +1,21 @@
+/* SPDX-License-Identifier: MIT */
+/* The authors below grant copyright rights under the MIT license:
+ * Copyright (c) 2026 Nick Klingensmith
+ */
+
+#pragma once
+
+#include "../../stereokit.h"
+
+namespace sk {
+
+void         xr_ext_android_spatial_anchors_register    ();
+bool         xr_ext_android_spatial_anchors_available   ();
+
+anchor_t     xr_ext_android_spatial_anchors_create      (pose_t pose, const char* name_utf8);
+void         xr_ext_android_spatial_anchors_destroy     (anchor_t anchor);
+void         xr_ext_android_spatial_anchors_clear_stored();
+bool32_t     xr_ext_android_spatial_anchors_persist     (anchor_t anchor, bool32_t persist);
+anchor_caps_ xr_ext_android_spatial_anchors_capabilities();
+
+}


### PR DESCRIPTION
Adds an Android spatial anchor backend (`anchor_system_openxr_android`) built on `XR_ANDROID_trackables` (`xrCreateAnchorSpaceANDROID`). It mirrors the existing `msft_anchors` backend almost 1:1, so StereoKit's `Anchor` API now works on Android XR.

## Why this extension

`xrCreateAnchorSpaceANDROID` is the structural twin of MSFT's `xrCreateSpatialAnchorMSFT` + `xrCreateSpatialAnchorSpaceMSFT`: create a free-pose anchor (`trackable = XR_NULL_TRACKABLE_ANDROID`), get an `XrSpace`, and locate it each frame. It slots straight into the `anchor_system_` switch. The cross-vendor `XR_EXT_spatial_entity` path (upstream `feature/spatial_entities`) is a larger, unmerged rewrite.

## Scope
`android_anchors.cpp/.h` (new), `anchor.cpp/.h`, `_registration.cpp`, and a `CMakeLists.txt` bump of the OpenXR loader **1.1.49 → 1.1.60** (the trackables symbols are absent before 1.1.57).

## Limitations
Free anchors have no persistence (`XR_ANDROID_device_anchor_persistence` is separate), so `Capabilities` reports `Stability` only; `persist`/`clear_stored` are no-ops - matching the MSFT backend's no-persistence branch.