### PR TITLE
A couple improvements for Android builds

### DIFF
--- a/Examples/StereoKitTest/StereoKitTest_NetAndroid/AndroidManifest.xml
+++ b/Examples/StereoKitTest/StereoKitTest_NetAndroid/AndroidManifest.xml
@@ -36,7 +36,7 @@
 
 	<!-- AndroidXR items -->
 	<!-- https://developer.android.com/develop/xr/get-started#designing-xr -->
-	<uses-feature    android:name="android.software.xr.immersive"           android:required="true"  />
+	<uses-feature    android:name="android.software.xr.immersive"           android:required="false" />
 	<uses-feature    android:name="android.hardware.xr.input.hand_tracking" android:required="false" />
 	<uses-feature    android:name="android.hardware.xr.input.controller"    android:required="false" />
 	<uses-feature    android:name="android.hardware.xr.input.eye_tracking"  android:required="false" />

--- a/Examples/StereoKitTest/StereoKitTest_NetAndroid/MainActivity.cs
+++ b/Examples/StereoKitTest/StereoKitTest_NetAndroid/MainActivity.cs
@@ -14,7 +14,8 @@ using System.Threading;
 [IntentFilter(new[] { Intent.ActionMain }, Categories = new[] { "org.khronos.openxr.intent.category.IMMERSIVE_HMD", "com.oculus.intent.category.VR", Intent.CategoryLauncher })]
 public class MainActivity : Activity, ISurfaceHolderCallback2
 {
-	View surface;
+	View   surface;
+	Thread skThread;
 
 	protected override void OnCreate(Bundle savedInstanceState)
 	{
@@ -35,7 +36,12 @@ public class MainActivity : Activity, ISurfaceHolderCallback2
 	{
 		// Quit, but not if Destroy is just a rotation or resize
 		if (IsChangingConfigurations == false)
+		{
+			// SK.Quit only signals; wait for the SK thread to finish its OpenXR
+			// teardown before Android tears us down.
 			SK.Quit();
+			skThread?.Join();
+		}
 
 		base.OnDestroy();
 	}
@@ -55,10 +61,11 @@ public class MainActivity : Activity, ISurfaceHolderCallback2
 		SK.AndroidJavaVM   = Java.Interop.JniEnvironment.Runtime.InvocationPointer;
 
 		// Task.Run will eat exceptions, but Thread.Start doesn't seem to.
-		new Thread(InvokeStereoKit).Start();
+		skThread = new Thread(InvokeStereoKit);
+		skThread.Start();
 	}
 
-	static void InvokeStereoKit()
+	void InvokeStereoKit()
 	{
 		Type       entryClass = typeof(Program);
 		MethodInfo entryPoint = entryClass?.GetMethod("Main", BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
@@ -81,6 +88,9 @@ public class MainActivity : Activity, ISurfaceHolderCallback2
 		}
 		else throw new Exception("Couldn't invoke Program.Main!");
 
+		// SK has fully shut down. Finish the Activity so Android's task state is
+		// tidy, then kill the process so the next launch re-inits SK from scratch.
+		Finish();
 		Process.KillProcess(Process.MyPid());
 	}
 

--- a/StereoKit/BuildStereoKitSDK.targets
+++ b/StereoKit/BuildStereoKitSDK.targets
@@ -95,14 +95,26 @@
 		<None Visible="false" CopyToOutputDirectory="PreserveNewest" Link="runtimes\$(SKSDKRID)\native\libMoltenVK.dylib" Include="$(SKSDKBinDir)libMoltenVK.dylib" />
 	</ItemGroup>
 
-	<!-- Android binaries are included differently. -->
+	<!-- Android binaries are included differently. libStereoKitC.so and the jar
+	     are literal paths, so MSBuild keeps them in the item list even before the
+	     native build produces them. -->
 	<ItemGroup Condition="'$(SKSDKBuildOS)'=='Android'">
 		<!-- <None                 Visible="false" CopyToOutputDirectory="PreserveNewest" Abi="$(SKSDKBuildAbi)" Include="$(SKSDKDbgPath)" /> -->
 		<AndroidNativeLibrary Visible="false" CopyToOutputDirectory="PreserveNewest" Abi="$(SKSDKBuildAbi)" Include="$(SKSDKLibPath)" />
-		<AndroidNativeLibrary Visible="false" CopyToOutputDirectory="PreserveNewest" Abi="$(SKSDKBuildAbi)" Include="$(SKSDKBinDir)$(SKOpenXRLoader.ToLower())/*.so" />
-		<AndroidNativeLibrary Visible="false" CopyToOutputDirectory="PreserveNewest" Abi="$(SKSDKBuildAbi)" Include="$(SKOpenXRLoaderFolder)/$(SKOpenXRLoader)/$(SKSDKBuildMode.ToLower())/*.so" />
 		<AndroidJavaLibrary   Visible="false" Include="$(SKSDKFolder)\bin\distribute\bin\Android\sk_app.jar" />
 	</ItemGroup>
+
+	<!-- Resolve the OpenXR loader wildcards in a target, so they expand after the
+	     native build instead of at evaluation time (when the .so doesn't exist yet). -->
+	<Target Name="StereoKit_AddAndroidNativeLibraries"
+	        Condition="'$(SKSDKBuildOS)'=='Android'"
+	        AfterTargets="StereoKit_BuildNative"
+	        BeforeTargets="BeforeBuild">
+		<ItemGroup>
+			<AndroidNativeLibrary Visible="false" CopyToOutputDirectory="PreserveNewest" Abi="$(SKSDKBuildAbi)" Include="$(SKSDKBinDir)$(SKOpenXRLoader.ToLower())/*.so" />
+			<AndroidNativeLibrary Visible="false" CopyToOutputDirectory="PreserveNewest" Abi="$(SKSDKBuildAbi)" Include="$(SKOpenXRLoaderFolder)/$(SKOpenXRLoader)/$(SKSDKBuildMode.ToLower())/*.so" />
+		</ItemGroup>
+	</Target>
 
 	<!-- Full rebuilds of this project should also be full rebuilds of StereoKit. -->
 	<Target Name="SKSDKRebuild" AfterTargets="Clean">


### PR DESCRIPTION
Quest experience has been really buggy lately. After some investigation, it seems like these bugs are just HorizonOS issues. These changes come from that investigation, and does improve a few things anyhow.

- Fix for Android builds via `BuildStereoKitSDK.targets` not finding the OpenXR Loader on the first build, due to the library not existing yet during build script execution.
- Add some extra calls to MainActivity shutdown path, likely won't change anything, but this draws out shutdown a little longer to make exit slightly more graceful.
- AndroidXR feature was incorrectly listed as required.