### PR TITLE
Specialization Constants

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -292,7 +292,7 @@ if (NOT SK_LOCAL_SK_RENDERER)
   CPMAddPackage(
     NAME sk_renderer
     GITHUB_REPOSITORY StereoKit/sk_renderer
-    GIT_TAG v2026.5.28
+    GIT_TAG v2026.7.5
   )
 else()
   # For building directly with in-progress sk_renderer changes, point this to your

--- a/Examples/Assets/Shaders/spec_constant_compute.hlsl
+++ b/Examples/Assets/Shaders/spec_constant_compute.hlsl
@@ -1,0 +1,25 @@
+//--name = app/spec_constant_compute
+// Test compute shader for specialization constants. Each thread writes a value
+// derived entirely from the [[vk::constant_id]] constants into the output
+// buffer, so overriding one (via Compute.SetInt/SetFloat/SetBool/SetUInt)
+// changes the dispatched result without touching any bound resource.
+
+[[vk::constant_id(0)]] const int   ADD_COUNT  = 3;
+[[vk::constant_id(1)]] const float SCALE      = 2.0;
+[[vk::constant_id(2)]] const bool  NEGATE     = false;
+[[vk::constant_id(3)]] const uint  OFFSET     = 10;
+
+RWStructuredBuffer<float> output : register(u0);
+
+[numthreads(1, 1, 1)]
+void cs(uint3 id : SV_DispatchThreadID) {
+	float sum = 0;
+	for (int i = 0; i < ADD_COUNT; i++)
+		sum += 1.0;
+
+	float result = sum * SCALE + (float)OFFSET;
+	if (NEGATE)
+		result = -result;
+
+	output[id.x] = result;
+}

--- a/Examples/Assets/spec_constant_test.hlsl
+++ b/Examples/Assets/spec_constant_test.hlsl
@@ -1,0 +1,47 @@
+#include <stereokit.hlsli>
+
+//--name = app/spec_constant_test
+// Test shader for specialization constants. Each [[vk::constant_id]] constant
+// feeds the output color, so overriding one (via Material.SetInt/SetFloat/
+// SetBool/SetUInt) produces a visibly different pipeline variant.
+
+[[vk::constant_id(0)]] const int   COLOR_STEPS  = 2;
+[[vk::constant_id(1)]] const float BRIGHTNESS   = 0.25;
+[[vk::constant_id(2)]] const bool  USE_TINT     = true;
+[[vk::constant_id(3)]] const uint  BLUE_SCALE   = 4;
+
+struct vsIn {
+	float4 pos  : SV_Position;
+	float3 norm : NORMAL0;
+	float2 uv   : TEXCOORD0;
+	float4 col  : COLOR0;
+};
+struct psIn {
+	float4 pos   : SV_POSITION;
+	float2 uv    : TEXCOORD0;
+	float4 color : COLOR0;
+};
+
+psIn vs(vsIn input, sk_ids_t ids) {
+	psIn o;
+	float4 world = mul(input.pos, sk_inst[ids.inst].world);
+	o.pos        = mul(world,     sk_viewproj[ids.view]);
+	o.uv         = input.uv;
+	o.color      = input.col;
+	return o;
+}
+
+float4 ps(psIn input) : SV_Target {
+	// Fold each spec constant into a channel. The loop count, the float, the
+	// bool branch and the uint are all compile-time constants inside the
+	// baked pipeline.
+	float r = 0;
+	for (int i = 0; i < COLOR_STEPS; i++)
+		r += 0.2;
+
+	float3 col = float3(r, BRIGHTNESS, (float)BLUE_SCALE / 16.0);
+	if (USE_TINT)
+		col *= float3(1, 0.5, 1);
+
+	return float4(col, 1);
+}

--- a/Examples/StereoKitTest/Docs/DocSpecConstants.cs
+++ b/Examples/StereoKitTest/Docs/DocSpecConstants.cs
@@ -1,0 +1,47 @@
+using StereoKit;
+
+class DocSpecConstants : ITest
+{
+	/// :CodeSample: Material.SetInt Material.SetFloat Material.SetBool Material.SetUInt
+	/// ### Specialization constants
+	/// If a shader declares specialization constants with HLSL's
+	/// `[[vk::constant_id(N)]]`, StereoKit exposes them through the ordinary
+	/// scalar setters. The name you pass must match the HLSL variable name.
+	///
+	/// ```hlsl
+	/// [[vk::constant_id(0)]] const int   COLOR_STEPS = 2;
+	/// [[vk::constant_id(1)]] const float BRIGHTNESS  = 0.25;
+	/// [[vk::constant_id(2)]] const bool  USE_TINT    = true;
+	/// [[vk::constant_id(3)]] const uint  BLUE_SCALE  = 4;
+	/// ```
+	///
+	/// Unlike a normal material parameter, a spec constant is baked into the
+	/// shader pipeline. Setting one to a new value rebuilds that pipeline (a
+	/// heavier operation than a uniform write), so prefer setting them at
+	/// load time rather than every frame. Re-setting the same value is free.
+	/// Two materials sharing one shader with different spec-constant values are
+	/// distinct pipeline variants — handy for feature toggles or loop/array
+	/// sizes the driver can then fold at compile time.
+	Material variantA;
+	Material variantB;
+	public void Initialize()
+	{
+		Shader shader = Shader.FromFile("spec_constant_test.hlsl");
+
+		variantA = new Material(shader); // uses the HLSL defaults
+
+		variantB = new Material(shader);
+		variantB.SetInt  ("COLOR_STEPS", 4);
+		variantB.SetFloat("BRIGHTNESS",  0.6f);
+		variantB.SetBool ("USE_TINT",    false);
+		variantB.SetUInt ("BLUE_SCALE",  12);
+	}
+	/// :End:
+
+	public void Shutdown() { }
+	public void Step()
+	{
+		Mesh.Sphere.Draw(variantA, Matrix.TS(-0.15f, 0, -0.5f, 0.2f));
+		Mesh.Sphere.Draw(variantB, Matrix.TS( 0.15f, 0, -0.5f, 0.2f));
+	}
+}

--- a/Examples/StereoKitTest/Tests/TestSpecConstants.cs
+++ b/Examples/StereoKitTest/Tests/TestSpecConstants.cs
@@ -1,0 +1,112 @@
+using StereoKit;
+using System;
+
+// Verifies specialization constants routed through the ordinary scalar
+// setters/getters: default values, overrides, persistence across pipeline
+// rebuilds, Material.Copy, shader swaps, and compute dispatch.
+class TestSpecConstants : ITest
+{
+	Material             _matDefault;
+	Material             _matOverride;
+	Compute              _compute;
+	ComputeBuffer<float> _computeBuf;
+	int                  _frame;
+
+	static bool Near(float a, float b) => Math.Abs(a - b) < 0.001f;
+
+	public void Initialize()
+	{
+		Shader shader = Shader.FromFile("spec_constant_test.hlsl");
+
+		// Defaults come straight from the HLSL declarations.
+		_matDefault = new Material(shader);
+		Tests.Test(() => _matDefault.GetInt  ("COLOR_STEPS") == 2);
+		Tests.Test(() => Near(_matDefault.GetFloat("BRIGHTNESS"), 0.25f));
+		Tests.Test(() => _matDefault.GetBool ("USE_TINT")    == true);
+		Tests.Test(() => _matDefault.GetUInt ("BLUE_SCALE")  == 4);
+
+		// Overriding a spec constant via the normal setters bakes a new
+		// pipeline; the getter reports the effective value.
+		_matOverride = new Material(shader);
+		_matOverride.SetInt  ("COLOR_STEPS", 4);
+		_matOverride.SetFloat("BRIGHTNESS",  0.6f);
+		_matOverride.SetBool ("USE_TINT",    false);
+		_matOverride.SetUInt ("BLUE_SCALE",  12);
+		Tests.Test(() => _matOverride.GetInt  ("COLOR_STEPS") == 4);
+		Tests.Test(() => Near(_matOverride.GetFloat("BRIGHTNESS"), 0.6f));
+		Tests.Test(() => _matOverride.GetBool ("USE_TINT")    == false);
+		Tests.Test(() => _matOverride.GetUInt ("BLUE_SCALE")  == 12);
+
+		// Regression: overrides must survive an unrelated pipeline-state change
+		// (cull/transparency both rebuild the pipeline via material_build_info).
+		_matOverride.FaceCull     = Cull.Front;
+		_matOverride.Transparency = Transparency.Blend;
+		Tests.Test(() => _matOverride.GetInt ("COLOR_STEPS") == 4);
+		Tests.Test(() => _matOverride.GetUInt("BLUE_SCALE")  == 12);
+
+		// Material.Copy carries spec overrides.
+		Material copy = _matOverride.Copy();
+		Tests.Test(() => copy.GetInt  ("COLOR_STEPS") == 4);
+		Tests.Test(() => copy.GetBool ("USE_TINT")    == false);
+
+		// Swapping to a shader without the constant drops the override; swapping
+		// back yields the HLSL default rather than the stale override.
+		Material swap = new Material(shader);
+		swap.SetInt("COLOR_STEPS", 5);
+		swap.Shader = Shader.Unlit;
+		swap.Shader = shader;
+		Tests.Test(() => swap.GetInt("COLOR_STEPS") == 2);
+
+		// Compute getters already prove reflection + override storage + resolve;
+		// the dispatch output is checked across frames in Step (see below).
+		_compute    = new Compute(Shader.FromFile("Shaders/spec_constant_compute.hlsl"));
+		_computeBuf = new ComputeBuffer<float>(ComputeBufferType.ReadWrite, 1);
+		_compute.SetStorage("output", _computeBuf);
+		Tests.Test(() => Near(_compute.GetFloat("SCALE"),    2.0f));
+		Tests.Test(() => _compute.GetInt("ADD_COUNT")     == 3);
+
+		// Give the compute dispatch/readback state machine room to run — reads
+		// happen several frames after each dispatch so the GPU work completes
+		// (skr_buffer_get does no GPU sync, DispatchNow submits at frame end).
+		Tests.RunForFrames(11);
+	}
+
+	public void Shutdown() { }
+
+	public void Step()
+	{
+		// Compute dispatch needs an active frame; read back with a gap so the
+		// dispatched frame has been submitted and completed.
+		switch (_frame)
+		{
+			// Default: ADD_COUNT(3) * SCALE(2) + OFFSET(10) = 16
+			case 0: _compute.DispatchNow(1, 1, 1); break;
+			case 3:
+				Tests.Test(() => Near(_computeBuf.GetData()[0], 16.0f));
+				// Override SCALE; the already-bound buffer must persist across
+				// the pipeline rebuild (no re-bind here). 3 * 3 + 10 = 19
+				_compute.SetFloat("SCALE", 3.0f);
+				_compute.DispatchNow(1, 1, 1);
+				break;
+			case 6:
+				Tests.Test(() => Near(_computeBuf.GetData()[0], 19.0f));
+				// Toggling the bool spec constant negates: -(3 * 3 + 10) = -19
+				_compute.SetBool("NEGATE", true);
+				_compute.DispatchNow(1, 1, 1);
+				break;
+			case 9:
+				Tests.Test(() => Near(_computeBuf.GetData()[0], -19.0f));
+				Tests.Test(() => Near(_compute.GetFloat("SCALE"), 3.0f));
+				Tests.Test(() => _compute.GetBool("NEGATE") == true);
+				break;
+		}
+		_frame++;
+
+		// Two materials sharing one shader, distinct spec-constant pipeline
+		// variants, rendered side by side.
+		Mesh.Sphere.Draw(_matDefault,  Matrix.TS(new Vec3(-0.1f, 0, 0), 0.16f));
+		Mesh.Sphere.Draw(_matOverride, Matrix.TS(new Vec3( 0.1f, 0, 0), 0.16f));
+
+		Tests.Screenshot("Tests/SpecConstants.jpg", 400, 200, 55, new Vec3(0, 0, 0.35f), Vec3.Zero);
+	}
+}

--- a/StereoKitC/asset_types/compute.cpp
+++ b/StereoKitC/asset_types/compute.cpp
@@ -9,7 +9,102 @@
 #include "assets.h"
 #include "../systems/render.h"
 
+#include <string.h>
+
 namespace sk {
+
+///////////////////////////////////////////
+
+static skr_compute_info_t compute_build_info(compute_t compute) {
+	skr_compute_info_t info = {};
+	info.spec_constants      = compute->spec_overrides;
+	info.spec_constant_count = compute->spec_override_count;
+	return info;
+}
+
+///////////////////////////////////////////
+
+static void compute_recreate_gpu(compute_t compute) {
+	skr_compute_set_pipeline(&compute->gpu_compute, compute_build_info(compute));
+}
+
+///////////////////////////////////////////
+// Spec constant routing. A scalar setter whose name matches a shader's
+// [[vk::constant_id]] constant persists a name-keyed override and rebuilds the
+// pipeline, instead of writing a cbuffer uniform. Unlike materials, skr_compute_t
+// exposes no resolved value array, so we resolve override-or-default locally.
+
+// Convert a value to the constant's declared 32-bit bit pattern, mirroring
+// sk_renderer's _skr_shader_resolve_spec_constants (bools resolve as int).
+static uint32_t spec_constant_to_bits(const sksc_shader_spec_constant_t *sc, double value) {
+	uint32_t bits = 0;
+	switch (sc->type) {
+	case sksc_shader_var_uint:  { uint32_t v = (uint32_t)value; memcpy(&bits, &v, sizeof(v)); } break;
+	case sksc_shader_var_float: { float    v = (float   )value; memcpy(&bits, &v, sizeof(v)); } break;
+	default:                    { int32_t  v = (int32_t )value; memcpy(&bits, &v, sizeof(v)); } break;
+	}
+	return bits;
+}
+
+// Reinterpret a resolved bit pattern as a double, per the constant's type.
+static double spec_constant_from_bits(const sksc_shader_spec_constant_t *sc, uint32_t bits) {
+	switch (sc->type) {
+	case sksc_shader_var_uint:  { uint32_t v; memcpy(&v, &bits, sizeof(v)); return (double)v; }
+	case sksc_shader_var_float: { float    v; memcpy(&v, &bits, sizeof(v)); return (double)v; }
+	default:                    { int32_t  v; memcpy(&v, &bits, sizeof(v)); return (double)v; }
+	}
+}
+
+// Meta index of a spec constant matching `name`, or -1. Capped to the
+// resolvable range (SKR_MAX_SPEC_CONSTANTS).
+static int32_t compute_find_spec_constant(compute_t compute, const char *name) {
+	const sksc_shader_meta_t *meta = &compute->shader->gpu_shader.meta;
+	if (meta->spec_constant_count == 0) return -1;
+	uint32_t count = meta->spec_constant_count < SKR_MAX_SPEC_CONSTANTS ? meta->spec_constant_count : SKR_MAX_SPEC_CONSTANTS;
+	uint64_t hash  = skr_hash(name);
+	for (uint32_t i = 0; i < count; i++)
+		if (meta->spec_constants[i].name_hash == hash) return (int32_t)i;
+	return -1;
+}
+
+// Effective (override or default) bit pattern of a spec constant.
+static uint32_t compute_resolved_spec_bits(compute_t compute, int32_t meta_idx) {
+	const sksc_shader_spec_constant_t *sc = &compute->shader->gpu_shader.meta.spec_constants[meta_idx];
+	for (int32_t i = 0; i < compute->spec_override_count; i++)
+		if (compute->spec_overrides[i].name == sc->name)
+			return spec_constant_to_bits(sc, compute->spec_overrides[i].value);
+	return sc->default_value;
+}
+
+// Persist a name-keyed override (append or update). The stored name points into
+// the shader meta, which outlives the override store.
+static void compute_store_spec_override(compute_t compute, int32_t meta_idx, double value) {
+	const sksc_shader_spec_constant_t *sc = &compute->shader->gpu_shader.meta.spec_constants[meta_idx];
+	for (int32_t i = 0; i < compute->spec_override_count; i++) {
+		if (compute->spec_overrides[i].name == sc->name) {
+			compute->spec_overrides[i].value = value;
+			return;
+		}
+	}
+	compute->spec_overrides[compute->spec_override_count].name  = sc->name;
+	compute->spec_overrides[compute->spec_override_count].value = value;
+	compute->spec_override_count++;
+}
+
+// Rebuild the pipeline only when the resolved value actually changes.
+static void compute_set_spec_constant(compute_t compute, int32_t meta_idx, double value) {
+	const sksc_shader_spec_constant_t *sc = &compute->shader->gpu_shader.meta.spec_constants[meta_idx];
+	if (compute_resolved_spec_bits(compute, meta_idx) == spec_constant_to_bits(sc, value))
+		return;
+	compute_store_spec_override(compute, meta_idx, value);
+	compute_recreate_gpu       (compute);
+}
+
+// Effective (override or default) value of a spec constant, as a double.
+static double compute_get_spec_constant(compute_t compute, int32_t meta_idx) {
+	const sksc_shader_spec_constant_t *sc = &compute->shader->gpu_shader.meta.spec_constants[meta_idx];
+	return spec_constant_from_bits(sc, compute_resolved_spec_bits(compute, meta_idx));
+}
 
 ///////////////////////////////////////////
 
@@ -23,7 +118,7 @@ compute_t compute_create(shader_t shader) {
 	shader_addref(shader);
 	result->shader = shader;
 
-	if (skr_compute_create(&shader->gpu_shader, &result->gpu_compute) != skr_err_success) {
+	if (skr_compute_create(&shader->gpu_shader, compute_build_info(result), &result->gpu_compute) != skr_err_success) {
 		log_err("compute_create: failed to create GPU compute object");
 		shader_release(shader);
 		result->shader = nullptr;
@@ -81,18 +176,24 @@ shader_t compute_get_shader(const compute_t compute) {
 ///////////////////////////////////////////
 
 void compute_set_float(compute_t compute, const char *name, float value) {
+	int32_t spec_idx = compute_find_spec_constant(compute, name);
+	if (spec_idx >= 0) { compute_set_spec_constant(compute, spec_idx, (double)value); return; }
 	skr_compute_set_param(&compute->gpu_compute, name, sksc_shader_var_float, 1, &value);
 }
 
 ///////////////////////////////////////////
 
 void compute_set_int(compute_t compute, const char *name, int32_t value) {
+	int32_t spec_idx = compute_find_spec_constant(compute, name);
+	if (spec_idx >= 0) { compute_set_spec_constant(compute, spec_idx, (double)value); return; }
 	skr_compute_set_param(&compute->gpu_compute, name, sksc_shader_var_int, 1, &value);
 }
 
 ///////////////////////////////////////////
 
 void compute_set_uint(compute_t compute, const char *name, uint32_t value) {
+	int32_t spec_idx = compute_find_spec_constant(compute, name);
+	if (spec_idx >= 0) { compute_set_spec_constant(compute, spec_idx, (double)value); return; }
 	skr_compute_set_param(&compute->gpu_compute, name, sksc_shader_var_uint, 1, &value);
 }
 
@@ -124,6 +225,8 @@ void compute_set_color(compute_t compute, const char *name, color128 color_gamma
 ///////////////////////////////////////////
 
 void compute_set_bool(compute_t compute, const char *name, bool32_t value) {
+	int32_t spec_idx = compute_find_spec_constant(compute, name);
+	if (spec_idx >= 0) { compute_set_spec_constant(compute, spec_idx, value ? 1.0 : 0.0); return; }
 	uint32_t val = value ? 1 : 0;
 	skr_compute_set_param(&compute->gpu_compute, name, sksc_shader_var_uint, 1, &val);
 }
@@ -137,6 +240,8 @@ void compute_set_matrix(compute_t compute, const char *name, matrix value) {
 ///////////////////////////////////////////
 
 float compute_get_float(compute_t compute, const char *name) {
+	int32_t spec_idx = compute_find_spec_constant(compute, name);
+	if (spec_idx >= 0) return (float)compute_get_spec_constant(compute, spec_idx);
 	float result = 0.0f;
 	skr_compute_get_param(&compute->gpu_compute, name, sksc_shader_var_float, 1, &result);
 	return result;
@@ -145,6 +250,8 @@ float compute_get_float(compute_t compute, const char *name) {
 ///////////////////////////////////////////
 
 int32_t compute_get_int(compute_t compute, const char *name) {
+	int32_t spec_idx = compute_find_spec_constant(compute, name);
+	if (spec_idx >= 0) return (int32_t)compute_get_spec_constant(compute, spec_idx);
 	int32_t result = 0;
 	skr_compute_get_param(&compute->gpu_compute, name, sksc_shader_var_int, 1, &result);
 	return result;
@@ -153,6 +260,8 @@ int32_t compute_get_int(compute_t compute, const char *name) {
 ///////////////////////////////////////////
 
 uint32_t compute_get_uint(compute_t compute, const char *name) {
+	int32_t spec_idx = compute_find_spec_constant(compute, name);
+	if (spec_idx >= 0) return (uint32_t)compute_get_spec_constant(compute, spec_idx);
 	uint32_t result = 0;
 	skr_compute_get_param(&compute->gpu_compute, name, sksc_shader_var_uint, 1, &result);
 	return result;
@@ -185,6 +294,8 @@ vec4 compute_get_vector4(compute_t compute, const char *name) {
 ///////////////////////////////////////////
 
 bool32_t compute_get_bool(compute_t compute, const char *name) {
+	int32_t spec_idx = compute_find_spec_constant(compute, name);
+	if (spec_idx >= 0) return compute_get_spec_constant(compute, spec_idx) != 0;
 	uint32_t result = 0;
 	skr_compute_get_param(&compute->gpu_compute, name, sksc_shader_var_uint, 1, &result);
 	return result != 0;

--- a/StereoKitC/asset_types/compute.h
+++ b/StereoKitC/asset_types/compute.h
@@ -15,6 +15,11 @@ struct _compute_t {
 	int32_t           texture_count;
 	compute_buffer_t* buffers;
 	int32_t           buffer_count;
+
+	// Name-keyed [[vk::constant_id]] overrides, re-fed through every pipeline
+	// rebuild. Names point into the shader meta, which outlives the compute.
+	skr_spec_constant_t spec_overrides[SKR_MAX_SPEC_CONSTANTS];
+	int32_t             spec_override_count;
 };
 
 void compute_destroy(compute_t compute);

--- a/StereoKitC/asset_types/material.cpp
+++ b/StereoKitC/asset_types/material.cpp
@@ -38,6 +38,11 @@ skr_material_info_t material_build_info(material_t material) {
 
 	info.alpha_to_coverage = material->alpha_mode == transparency_msaa;
 	info.queue_offset      = material->gpu_mat.queue_offset;
+
+	// Spec constant overrides survive every pipeline rebuild by being re-fed
+	// here; sk_renderer resolves them into gpu_mat.key.spec_constant_values.
+	info.spec_constants      = material->spec_overrides;
+	info.spec_constant_count = material->spec_override_count;
 	return info;
 }
 
@@ -46,6 +51,75 @@ skr_material_info_t material_build_info(material_t material) {
 void material_recreate_gpu(material_t material) {
 	skr_material_info_t info = material_build_info(material);
 	skr_material_set_pipeline(&material->gpu_mat, info);
+}
+
+///////////////////////////////////////////
+// Spec constant routing. A scalar setter whose name matches a shader's
+// [[vk::constant_id]] constant persists a name-keyed override and rebuilds the
+// pipeline, instead of writing a cbuffer uniform.
+
+// Convert a value to the constant's declared 32-bit bit pattern, mirroring
+// sk_renderer's _skr_shader_resolve_spec_constants (bools resolve as int).
+static uint32_t spec_constant_to_bits(const sksc_shader_spec_constant_t *sc, double value) {
+	uint32_t bits = 0;
+	switch (sc->type) {
+	case sksc_shader_var_uint:  { uint32_t v = (uint32_t)value; memcpy(&bits, &v, sizeof(v)); } break;
+	case sksc_shader_var_float: { float    v = (float   )value; memcpy(&bits, &v, sizeof(v)); } break;
+	default:                    { int32_t  v = (int32_t )value; memcpy(&bits, &v, sizeof(v)); } break;
+	}
+	return bits;
+}
+
+// Reinterpret a resolved bit pattern as a double, per the constant's type.
+static double spec_constant_from_bits(const sksc_shader_spec_constant_t *sc, uint32_t bits) {
+	switch (sc->type) {
+	case sksc_shader_var_uint:  { uint32_t v; memcpy(&v, &bits, sizeof(v)); return (double)v; }
+	case sksc_shader_var_float: { float    v; memcpy(&v, &bits, sizeof(v)); return (double)v; }
+	default:                    { int32_t  v; memcpy(&v, &bits, sizeof(v)); return (double)v; }
+	}
+}
+
+// Meta index of a spec constant matching `name`, or -1. Capped to the
+// resolvable range, which bounds gpu_mat.key.spec_constant_values.
+static int32_t material_find_spec_constant(material_t material, const char *name) {
+	const sksc_shader_meta_t *meta = &material->shader->gpu_shader.meta;
+	if (meta->spec_constant_count == 0) return -1;
+	uint32_t count = meta->spec_constant_count < SKR_MAX_SPEC_CONSTANTS ? meta->spec_constant_count : SKR_MAX_SPEC_CONSTANTS;
+	uint64_t hash  = skr_hash(name);
+	for (uint32_t i = 0; i < count; i++)
+		if (meta->spec_constants[i].name_hash == hash) return (int32_t)i;
+	return -1;
+}
+
+// Persist a name-keyed override (append or update). The stored name points into
+// the shader meta, which outlives the override store.
+static void material_store_spec_override(material_t material, int32_t meta_idx, double value) {
+	const sksc_shader_spec_constant_t *sc = &material->shader->gpu_shader.meta.spec_constants[meta_idx];
+	for (int32_t i = 0; i < material->spec_override_count; i++) {
+		if (material->spec_overrides[i].name == sc->name) {
+			material->spec_overrides[i].value = value;
+			return;
+		}
+	}
+	material->spec_overrides[material->spec_override_count].name  = sc->name;
+	material->spec_overrides[material->spec_override_count].value = value;
+	material->spec_override_count++;
+}
+
+// Rebuild the pipeline only when the resolved value actually changes, so
+// steady-state re-sets are free.
+static void material_set_spec_constant(material_t material, int32_t meta_idx, double value) {
+	const sksc_shader_spec_constant_t *sc = &material->shader->gpu_shader.meta.spec_constants[meta_idx];
+	if (material->gpu_mat.key.spec_constant_values[meta_idx] == spec_constant_to_bits(sc, value))
+		return;
+	material_store_spec_override(material, meta_idx, value);
+	material_recreate_gpu       (material);
+}
+
+// Effective (override or default) value of a spec constant, as a double.
+static double material_get_spec_constant(material_t material, int32_t meta_idx) {
+	const sksc_shader_spec_constant_t *sc = &material->shader->gpu_shader.meta.spec_constants[meta_idx];
+	return spec_constant_from_bits(sc, material->gpu_mat.key.spec_constant_values[meta_idx]);
 }
 
 ///////////////////////////////////////////
@@ -212,6 +286,12 @@ material_t material_copy(material_t material) {
 	// Add references to shared assets
 	shader_addref(material->shader);
 	result->shader = material->shader;
+
+	// Carry spec overrides so future pipeline rebuilds keep them; names point
+	// into the shared shader meta and stay valid.
+	memcpy(result->spec_overrides, material->spec_overrides, sizeof(result->spec_overrides));
+	result->spec_override_count = material->spec_override_count;
+
 	if (result->chain != nullptr) material_addref(result->chain);
 	for (int32_t i = 0; i < (int32_t)_countof(result->variants); i++) {
 		if (result->variants[i] != nullptr)
@@ -365,6 +445,29 @@ void material_set_shader(material_t material, shader_t shader) {
 	// material_recreate_gpu (pipeline-only), changing shaders requires
 	// reallocating the param buffer and bind pool.
 	material->shader = shader;
+
+	// Prune spec overrides to constants present in the new shader, re-pointing
+	// their names into the new meta (the old meta is about to be released).
+	{
+		const sksc_shader_meta_t *new_meta   = &shader->gpu_shader.meta;
+		uint32_t                  new_count  = new_meta->spec_constant_count < SKR_MAX_SPEC_CONSTANTS ? new_meta->spec_constant_count : SKR_MAX_SPEC_CONSTANTS;
+		skr_spec_constant_t       kept[SKR_MAX_SPEC_CONSTANTS];
+		int32_t                   kept_count = 0;
+		for (int32_t i = 0; i < material->spec_override_count; i++) {
+			uint64_t hash = skr_hash(material->spec_overrides[i].name);
+			for (uint32_t j = 0; j < new_count; j++) {
+				if (new_meta->spec_constants[j].name_hash == hash) {
+					kept[kept_count].name  = new_meta->spec_constants[j].name;
+					kept[kept_count].value = material->spec_overrides[i].value;
+					kept_count++;
+					break;
+				}
+			}
+		}
+		memcpy(material->spec_overrides, kept, sizeof(kept));
+		material->spec_override_count = kept_count;
+	}
+
 	skr_material_destroy(&material->gpu_mat);
 	skr_material_info_t info = material_build_info(material);
 	skr_material_create(info, &material->gpu_mat);
@@ -599,6 +702,8 @@ material_t material_get_variant(material_t material, int32_t variant_idx) {
 ///////////////////////////////////////////
 
 void material_set_float(material_t material, const char *name, float value) {
+	int32_t spec_idx = material_find_spec_constant(material, name);
+	if (spec_idx >= 0) { material_set_spec_constant(material, spec_idx, (double)value); return; }
 	skr_material_set_param(&material->gpu_mat, name, sksc_shader_var_float, 1, &value);
 }
 
@@ -637,6 +742,8 @@ void material_set_vector2(material_t material, const char *name, vec2 value) {
 ///////////////////////////////////////////
 
 void material_set_int(material_t material, const char *name, int32_t value) {
+	int32_t spec_idx = material_find_spec_constant(material, name);
+	if (spec_idx >= 0) { material_set_spec_constant(material, spec_idx, (double)value); return; }
 	skr_material_set_param(&material->gpu_mat, name, sksc_shader_var_int, 1, &value);
 }
 
@@ -664,6 +771,8 @@ void material_set_int4(material_t material, const char *name, int32_t value1, in
 ///////////////////////////////////////////
 
 void material_set_bool(material_t material, const char *name, bool32_t value) {
+	int32_t spec_idx = material_find_spec_constant(material, name);
+	if (spec_idx >= 0) { material_set_spec_constant(material, spec_idx, value > 0 ? 1.0 : 0.0); return; }
 	uint32_t v = value > 0 ? 1 : 0;
 	skr_material_set_param(&material->gpu_mat, name, sksc_shader_var_uint, 1, &v);
 }
@@ -671,6 +780,8 @@ void material_set_bool(material_t material, const char *name, bool32_t value) {
 ///////////////////////////////////////////
 
 void material_set_uint(material_t material, const char *name, uint32_t value) {
+	int32_t spec_idx = material_find_spec_constant(material, name);
+	if (spec_idx >= 0) { material_set_spec_constant(material, spec_idx, (double)value); return; }
 	skr_material_set_param(&material->gpu_mat, name, sksc_shader_var_uint, 1, &value);
 }
 
@@ -789,6 +900,8 @@ bool32_t material_set_constant(material_t material, const char *name, material_b
 ///////////////////////////////////////////
 
 float material_get_float(material_t material, const char* name) {
+	int32_t spec_idx = material_find_spec_constant(material, name);
+	if (spec_idx >= 0) return (float)material_get_spec_constant(material, spec_idx);
 	float result = 0.0f;
 	skr_material_get_param(&material->gpu_mat, name, sksc_shader_var_float, 1, &result);
 	return result;
@@ -829,6 +942,8 @@ vec4 material_get_vector4(material_t material, const char* name) {
 ///////////////////////////////////////////
 
 int32_t material_get_int(material_t material, const char* name) {
+	int32_t spec_idx = material_find_spec_constant(material, name);
+	if (spec_idx >= 0) return (int32_t)material_get_spec_constant(material, spec_idx);
 	int32_t result = 0;
 	skr_material_get_param(&material->gpu_mat, name, sksc_shader_var_int, 1, &result);
 	return result;
@@ -837,6 +952,8 @@ int32_t material_get_int(material_t material, const char* name) {
 ///////////////////////////////////////////
 
 bool32_t material_get_bool(material_t material, const char* name) {
+	int32_t spec_idx = material_find_spec_constant(material, name);
+	if (spec_idx >= 0) return material_get_spec_constant(material, spec_idx) != 0;
 	uint32_t result = 0;
 	skr_material_get_param(&material->gpu_mat, name, sksc_shader_var_uint, 1, &result);
 	return result != 0;
@@ -845,6 +962,8 @@ bool32_t material_get_bool(material_t material, const char* name) {
 ///////////////////////////////////////////
 
 uint32_t material_get_uint(material_t material, const char* name) {
+	int32_t spec_idx = material_find_spec_constant(material, name);
+	if (spec_idx >= 0) return (uint32_t)material_get_spec_constant(material, spec_idx);
 	uint32_t result = 0;
 	skr_material_get_param(&material->gpu_mat, name, sksc_shader_var_uint, 1, &result);
 	return result;

--- a/StereoKitC/asset_types/material.h
+++ b/StereoKitC/asset_types/material.h
@@ -13,7 +13,12 @@ struct _material_t {
 
 	// Cached state - most pipeline state now in gpu_mat.key (single source of truth)
 	transparency_     alpha_mode;  // Higher-level abstraction mapping to blend_state + alpha_to_coverage
-	
+
+	// Name-keyed [[vk::constant_id]] overrides, re-fed through every pipeline
+	// rebuild. Names point into the shader meta, which outlives the material.
+	skr_spec_constant_t spec_overrides[SKR_MAX_SPEC_CONSTANTS];
+	int32_t             spec_override_count;
+
 	// Per-resource tracking — single allocation, pointers index into it.
 	// Layout: [tex_t * N][uint64_t * N][compute_buffer_t * N]
 	tex_t*            textures;            // owns the allocation

--- a/StereoKitC/asset_types/texture.cpp
+++ b/StereoKitC/asset_types/texture.cpp
@@ -1074,8 +1074,9 @@ void tex_compute_sh(tex_t texture, bool end_cmd) {
 	skr_buffer_t sh_buffer = {};
 	skr_buffer_create(nullptr, 1, sizeof(spherical_harmonics_t), skr_buffer_type_storage, (skr_use_)(skr_use_dynamic | skr_use_compute_write), &sh_buffer);
 
-	skr_compute_t sh_compute = {};
-	skr_compute_create(&sk_default_shader_sh_compute->gpu_shader, &sh_compute);
+	skr_compute_t      sh_compute = {};
+	skr_compute_info_t sh_info    = {};
+	skr_compute_create(&sk_default_shader_sh_compute->gpu_shader, sh_info, &sh_compute);
 
 	uint32_t params[4] = { (uint32_t)mip_size.x, (uint32_t)mip_level, 0, 0 };
 	skr_compute_set_params(&sh_compute, params, sizeof(params));


### PR DESCRIPTION
Specialization constants are shader performance tools! When changing these values, the shader will re-compile to a new graphics pipeline, specializing the code around the new value. This prevents batching with other instances of the shader, but can allow for faster variants of shaders built into the same code! It's like a #define constant, but nicer :)

Use it like this, and then treat it like a regular shader parameter!
```cpp
[[vk::constant_id(0)]] const int MODE = 3;
```