### PR TITLE
Enable SVSL backend for shader compile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,7 @@ set(SK_LOCAL_SK_RENDERER            OFF CACHE BOOL "Build using a local version 
 set(SK_LOCAL_SK_APP                 OFF CACHE BOOL "Build using a local version of sk_app, instead of the latest release. This is useful for testing in-progress changes to sk_app.")
 set(SK_PROFILE                      OFF CACHE BOOL "Build with Tracy profiler enabled.")
 set(SK_STRIP_DEBUG_SYMBOLS          ON  CACHE BOOL "Strip debug symbols from the shared library. Disable on Android to keep symbols embedded for native debugging.")
+set(SK_USE_SVSL                     OFF CACHE BOOL "Compile shaders with skshaderc's SVSL backend instead of the glslang HLSL pipeline.")
 set(FORCE_COLORED_OUTPUT            OFF CACHE BOOL "Always produce ANSI-colored output (GNU/Clang only).")
 
 ###########################################
@@ -106,6 +107,11 @@ endif()
 set(SK_SHADER_VERBOSITY "-si")
 if(CMAKE_VERBOSE_MAKEFILE)
   set(SK_SHADER_VERBOSITY "")
+endif()
+
+set(SK_SHADER_SVSL "")
+if(SK_USE_SVSL)
+  set(SK_SHADER_SVSL "-svsl")
 endif()
 
 ###########################################
@@ -288,11 +294,18 @@ endif()
 #### sk_renderer - https://github.com/StereoKit/sk_renderer ####
 set(SKR_ENABLE_STATIC_ANALYSIS OFF CACHE PATH "Faster build" FORCE)
 set(SKR_BUILD_EXAMPLES OFF CACHE PATH "Faster build" FORCE)
+# If we're only using the SVSL shader compiler, we can drop glslang from
+# skshaderc and save ourselves a lot of binary size and build time!
+if (SK_USE_SVSL)
+  set(SKSHADERC_ENABLE_GLSLANG OFF CACHE BOOL "Not needed with SVSL" FORCE)
+else()
+  set(SKSHADERC_ENABLE_GLSLANG ON  CACHE BOOL "Required for HLSL shaders" FORCE)
+endif()
 if (NOT SK_LOCAL_SK_RENDERER)
   CPMAddPackage(
     NAME sk_renderer
     GITHUB_REPOSITORY StereoKit/sk_renderer
-    GIT_TAG v2026.7.5
+    GIT_TAG v2026.7.8
   )
 else()
   # For building directly with in-progress sk_renderer changes, point this to your
@@ -631,7 +644,7 @@ endif()
 
 skshaderc_compile_headers(StereoKitC
   ${CMAKE_BINARY_DIR}/shaders/
-  "-e -O3 -f -z ${SK_SHADER_VERBOSITY} -i ${CMAKE_CURRENT_SOURCE_DIR}/tools/include"
+  "-e -O3 -f -z ${SK_SHADER_SVSL} ${SK_SHADER_VERBOSITY} -i ${CMAKE_CURRENT_SOURCE_DIR}/tools/include"
   StereoKitC/shaders_builtin/shader_builtin_blit.hlsl
   StereoKitC/shaders_builtin/shader_builtin_default.hlsl
   StereoKitC/shaders_builtin/shader_builtin_equirect.hlsl
@@ -936,7 +949,7 @@ if (SK_BUILD_TESTS)
 
   skshaderc_compile_headers( StereoKitCTest
     ${CMAKE_BINARY_DIR}/shaders/
-    "-e -O3 -f ${SK_SHADER_VERBOSITY} -i ${CMAKE_CURRENT_SOURCE_DIR}/tools/include"
+    "-e -O3 -f ${SK_SHADER_SVSL} ${SK_SHADER_VERBOSITY} -i ${CMAKE_CURRENT_SOURCE_DIR}/tools/include"
     Examples/StereoKitCTest/Shaders/blit.hlsl
     Examples/StereoKitCTest/Shaders/skt_default_lighting.hlsl
     Examples/StereoKitCTest/Shaders/skt_light_only.hlsl

--- a/Examples/StereoKitTest/StereoKitTest.csproj
+++ b/Examples/StereoKitTest/StereoKitTest.csproj
@@ -12,6 +12,7 @@
 		<SKAssetFolder>..\Assets</SKAssetFolder>
 		<SKAssetDestination>Assets</SKAssetDestination>
 		<SKShowDebugVars>true</SKShowDebugVars>
+		<SKUseSVSL>true</SKUseSVSL>
 
 		<NoWarn>CS1587</NoWarn>
 	</PropertyGroup>

--- a/StereoKit/SKShaders.targets
+++ b/StereoKit/SKShaders.targets
@@ -24,6 +24,8 @@
 		<!-- Needs to be normalized for Linux, also a trailing '\' will act
 		     as an escape character for quotes. -->
 		<IncludeFolderNormalized Condition="'$(SKShaderStandardInclude)'!=''">$([MSBuild]::NormalizeDirectory('$(SKShaderStandardInclude)').TrimEnd('\'))</IncludeFolderNormalized>
+		<!-- Compile shaders with skshaderc's SVSL backend instead of glslang. -->
+		<SKShaderSVSL Condition="'$(SKUseSVSL)'=='true'">-svsl</SKShaderSVSL>
 	</PropertyGroup>
 
 	<!-- Automatically include shaders, library projects should not compile
@@ -50,7 +52,7 @@
 		<!-- Setup metadata for custom build tool -->
 		<ItemGroup>
 			<SKShader Condition="'%(SKShader.RelFile)'!=''">
-				<Command>"$(SKShadercPath)" $(SKOpt) -e -i "$(IncludeFolderNormalized)" -o "$([System.String]::Copy('$(IntermediateOutputPath)$(SKAssetDestination)/%(SKShader.RelFolder)').Replace('\','/'))" "%(SKShader.Identity)"</Command>
+				<Command>"$(SKShadercPath)" $(SKOpt) $(SKShaderSVSL) -e -i "$(IncludeFolderNormalized)" -o "$([System.String]::Copy('$(IntermediateOutputPath)$(SKAssetDestination)/%(SKShader.RelFolder)').Replace('\','/'))" "%(SKShader.Identity)"</Command>
 				<Outputs>$(IntermediateOutputPath)$(SKAssetDestination)/%(SKShader.RelFile).sks</Outputs>
 				<RelativeName>%(SKShader.RelFile).sks</RelativeName>
 			</SKShader>
@@ -94,7 +96,7 @@
 	<Target Name="StereoKit_Shader_Code" BeforeTargets="BeforeCompile" Inputs="@(SKShaderCode->'%(FullPath)')" Outputs="@(SKShaderCode->'$(IntermediateOutputPath)%(RecursiveDir)Material%(Filename).gen.cs')">
 		<Message Text="[StereoKit NuGet] Generating C# for %(SKShaderCode.Identity) -> $(IntermediateOutputPath)%(SKShaderCode.RecursiveDir)Material%(SKShaderCode.Filename).gen.cs" Importance="high" />
 
-		<Exec Command='"$(SKShadercPath)" $(SKOpt) -e -sk -i "$(IncludeFolderNormalized)" "%(SKShaderCode.Identity)" -o "$(IntermediateOutputPath)%(SKShaderCode.RecursiveDir)Material%(SKShaderCode.Filename).gen.cs"'></Exec>
+		<Exec Command='"$(SKShadercPath)" $(SKOpt) $(SKShaderSVSL) -e -sk -i "$(IncludeFolderNormalized)" "%(SKShaderCode.Identity)" -o "$(IntermediateOutputPath)%(SKShaderCode.RecursiveDir)Material%(SKShaderCode.Filename).gen.cs"'></Exec>
 
 		<ItemGroup>
 			<Compile Remove ="@(SKShaderCode->'$(IntermediateOutputPath)%(RecursiveDir)Material%(Filename).gen.cs')"/>

--- a/StereoKit/StereoKit.props
+++ b/StereoKit/StereoKit.props
@@ -6,6 +6,7 @@
 		<SKOpenXRLoader          Condition="'$(SKOpenXRLoader)'          == ''">Standard</SKOpenXRLoader>
 		<SKShowDebugVars         Condition="'$(SKShowDebugVars)'         == ''">false</SKShowDebugVars>
 		<SKAutoFindShaders       Condition="'$(SKAutoFindShaders)'       == ''">True</SKAutoFindShaders>
+		<SKUseSVSL               Condition="'$(SKUseSVSL)'               == ''">false</SKUseSVSL>
 		<SKShaderCodeFolder      Condition="'$(SKShaderCodeFolder)'      == ''"></SKShaderCodeFolder>
 		<SKBuildShaderCode       Condition="'$(SKBuildShaderCode)'       == ''">true</SKBuildShaderCode>
 		<SKOpenXRLoaderFolder    Condition="'$(SKOpenXRLoaderFolder)'    == ''">$(ProjectDir)openxr_loader/</SKOpenXRLoaderFolder>
@@ -33,6 +34,7 @@
 		<Message Condition="'$(SKShowDebugVars)'=='true'" Importance="high" Text="[StereoKit NuGet] SKCopyAssets               : $(SKCopyAssets)"/>
 		<Message Condition="'$(SKShowDebugVars)'=='true'" Importance="high" Text="[StereoKit NuGet] SKAutoFindShaders          : $(SKAutoFindShaders)"/>
 		<Message Condition="'$(SKShowDebugVars)'=='true'" Importance="high" Text="[StereoKit NuGet] SKBuildShaderCode          : $(SKBuildShaderCode)"/>
+		<Message Condition="'$(SKShowDebugVars)'=='true'" Importance="high" Text="[StereoKit NuGet] SKUseSVSL                  : $(SKUseSVSL)"/>
 		<Message Condition="'$(SKShowDebugVars)'=='true'" Importance="high" Text="[StereoKit NuGet] SKShaderCodeFolder         : $(SKShaderCodeFolder)"/>
 		<Message Condition="'$(SKShowDebugVars)'=='true'" Importance="high" Text="[StereoKit NuGet] SKShadercExe               : $(SKShadercExe)"/>
 		<Message Condition="'$(SKShowDebugVars)'=='true'" Importance="high" Text="[StereoKit NuGet] SKShaderStandardInclude    : $(SKShaderStandardInclude)"/>


### PR DESCRIPTION
This adds a new [SVSL](https://github.com/maluoi/SVSL) shader compiler backend to skshaderc! The default is still glslang+spirv-opt, so nothing breaks or changes yet.

SVSL is _significantly_ smaller and _much_ faster to build than glslang/spirv-opt, yet produces identical visuals, equally fast shaders, and enables new SPIRV features that HLSL can't use yet! It also introduces new (optional) syntax to make certain tasks easier, such as bit packed structs. SVSL is still fully backwards compatible with procedural HLSL, so all of StereoKit's existing shaders compile under it with no modifications!

To _use_ SVSL in StereoKit right now, you can:
- Use the `.svsl` file extension.
- Set `<SKUseSVSL>true</SKUseSVSL>` in your .csproj.
- Set `SK_USE_SVSL` in cmake (this completely disable glslang, and should improve build times significantly).

For more info and docs on SVSL and its details, [see the GitHub repo for it](https://github.com/maluoi/SVSL)!