### PR TITLE
Custom vertex formats

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -305,7 +305,7 @@ if (NOT SK_LOCAL_SK_RENDERER)
   CPMAddPackage(
     NAME sk_renderer
     GITHUB_REPOSITORY StereoKit/sk_renderer
-    GIT_TAG v2026.7.8
+    GIT_TAG v2026.7.9
   )
 else()
   # For building directly with in-progress sk_renderer changes, point this to your
@@ -474,7 +474,9 @@ set(SK_SRC_SYSTEMS
   StereoKitC/systems/system.h
   StereoKitC/systems/system.cpp
   StereoKitC/systems/text.h
-  StereoKitC/systems/text.cpp  
+  StereoKitC/systems/text.cpp
+  StereoKitC/systems/vert_format.h
+  StereoKitC/systems/vert_format.cpp
   StereoKitC/systems/world.h
   StereoKitC/systems/world.cpp )
 
@@ -900,6 +902,8 @@ if (SK_BUILD_TESTS)
     Examples/StereoKitCTest/demo_aliasing.cpp
     Examples/StereoKitCTest/demo_bvh.h
     Examples/StereoKitCTest/demo_bvh.cpp
+    Examples/StereoKitCTest/demo_custom_verts.h
+    Examples/StereoKitCTest/demo_custom_verts.cpp
     Examples/StereoKitCTest/demo_desktop.h
     Examples/StereoKitCTest/demo_desktop.cpp
     Examples/StereoKitCTest/demo_picker.h
@@ -954,7 +958,8 @@ if (SK_BUILD_TESTS)
     Examples/StereoKitCTest/Shaders/skt_default_lighting.hlsl
     Examples/StereoKitCTest/Shaders/skt_light_only.hlsl
     Examples/StereoKitCTest/Shaders/skt_shadow.hlsl
-    Examples/StereoKitCTest/Shaders/skt_shadow_caster.hlsl)
+    Examples/StereoKitCTest/Shaders/skt_shadow_caster.hlsl
+    Examples/StereoKitCTest/Shaders/skt_vert_custom.hlsl)
 
   # Add source assets and compiled shaders to the app
   target_skapp_assets(StereoKitCTest ${CMAKE_CURRENT_BINARY_DIR}/shaders)

--- a/Examples/Assets/Shaders/vert_custom.hlsl
+++ b/Examples/Assets/Shaders/vert_custom.hlsl
@@ -1,0 +1,27 @@
+#include "stereokit.hlsli"
+
+//--name = app/vert_custom
+
+// For meshes with a custom position + color vertex format, see
+// TestVertexFormat.cs. Mesh data is matched to these inputs by semantic.
+struct vsIn {
+	float4 pos : SV_Position;
+	float4 col : COLOR0;
+};
+struct psIn {
+	float4 pos : SV_POSITION;
+	float4 col : COLOR0;
+};
+
+psIn vs(vsIn input, sk_ids_t ids) {
+	psIn o;
+
+	float4 world = mul(input.pos, sk_inst[ids.inst].world);
+	o.pos = mul(world, sk_viewproj[ids.view]);
+	o.col = input.col;
+	return o;
+}
+
+float4 ps(psIn input) : SV_TARGET {
+	return input.col;
+}

--- a/Examples/Assets/point_cloud.hlsl
+++ b/Examples/Assets/point_cloud.hlsl
@@ -7,32 +7,40 @@ float point_size;
 //--screen_size = 0
 float screen_size;
 
+// These inputs pair with the custom vertex format in DemoPointCloud.cs.
+// Each point is 4 sequential verts, quad corners come from the vert id.
 struct vsIn {
 	float4 pos  : SV_POSITION;
-	float3 norm : NORMAL0;
-	float2 off  : TEXCOORD0;
 	float4 color: COLOR0;
 };
 struct psIn {
 	float4 pos   : SV_POSITION;
-	float2 uv    : TEXCOORD0;
 	float4 color : COLOR0;
 };
 
-psIn vs(vsIn input, sk_ids_t ids) {
+// Corner ids 0,1,2,3 wind clockwise from the top left:
+// (-.5,.5) (.5,.5) (.5,-.5) (-.5,-.5)
+float2 corner_off(uint vert_id) {
+	uint corner = vert_id % 4;
+	return float2(
+		((corner + 1) & 2) ? .5 : -.5,
+		( corner      & 2) ?-.5 :  .5);
+}
+
+psIn vs(vsIn input, uint vert_id : SV_VertexID, sk_ids_t ids) {
 	psIn o;
 
+	float2 off   = corner_off(vert_id);
 	float4 world = mul(input.pos, sk_inst[ids.inst].world);
 	float4 view  = mul(world, sk_view[ids.view]);
 	if (screen_size <= 0.1)
-		view.xy = point_size * input.off + view.xy;
+		view.xy = point_size * off + view.xy;
 	o.pos        = mul(view, sk_proj[ids.view]);
-	o.uv         = input.off + 0.5;
 	o.color      = input.color;
 
 	if (screen_size > 0.1) {
 		float  aspect = sk_proj[ids.view]._m11 / sk_proj[ids.view]._m00;
-		o.pos.xy = ( point_size * input.off / float2(aspect,1) ) *o.pos.w + o.pos.xy;
+		o.pos.xy = ( point_size * off / float2(aspect,1) ) *o.pos.w + o.pos.xy;
 	}
 
 	return o;

--- a/Examples/Assets/point_cloud.hlsl
+++ b/Examples/Assets/point_cloud.hlsl
@@ -39,7 +39,9 @@ psIn vs(vsIn input, uint vert_id : SV_VertexID, sk_ids_t ids) {
 	o.color      = input.color;
 
 	if (screen_size > 0.1) {
-		float  aspect = sk_proj[ids.view]._m11 / sk_proj[ids.view]._m00;
+		// sk_aspect_ratio, not manual element access: Adreno's multiview
+		// linker fails when ViewIndex isn't terminal in an access chain.
+		float  aspect = sk_aspect_ratio(ids.view);
 		o.pos.xy = ( point_size * off / float2(aspect,1) ) *o.pos.w + o.pos.xy;
 	}
 

--- a/Examples/Assets/sensor_depth_point_cloud.hlsl
+++ b/Examples/Assets/sensor_depth_point_cloud.hlsl
@@ -83,7 +83,9 @@ psIn vs(vsIn input, sk_ids_t ids) {
 	o.pos = mul(view, sk_proj[ids.view]);
 
 	if (screen_size > 0.1) {
-		float aspect = sk_proj[ids.view]._m11 / sk_proj[ids.view]._m00;
+		// sk_aspect_ratio, not manual element access: Adreno's multiview
+		// linker fails when ViewIndex isn't terminal in an access chain.
+		float aspect = sk_aspect_ratio(ids.view);
 		o.pos.xy = (point_size * input.off / float2(aspect, 1)) * o.pos.w + o.pos.xy;
 	}
 

--- a/Examples/StereoKitCTest/Shaders/blit.hlsl
+++ b/Examples/StereoKitCTest/Shaders/blit.hlsl
@@ -19,7 +19,7 @@ struct vsIn {
 	float2 uv   : TEXCOORD0;
 	float4 col  : COLOR0;
 };
-struct psIn : sk_ps_input_t {
+struct psIn {
 	float4 pos : SV_POSITION;
 	float2 uv  : TEXCOORD0;
 };

--- a/Examples/StereoKitCTest/Shaders/skt_light_only.hlsl
+++ b/Examples/StereoKitCTest/Shaders/skt_light_only.hlsl
@@ -14,7 +14,7 @@ struct vsIn {
 	float4 pos  : SV_POSITION;
 	float3 norm : NORMAL;
 };
-struct psIn : sk_ps_input_t {
+struct psIn {
 	float4 pos   : SV_POSITION;
 	float3 world : TEXCOORD0;
 	float3 normal: NORMAL;

--- a/Examples/StereoKitCTest/Shaders/skt_vert_custom.hlsl
+++ b/Examples/StereoKitCTest/Shaders/skt_vert_custom.hlsl
@@ -1,0 +1,27 @@
+#include "stereokit.hlsli"
+
+//--name = app/vert_custom
+
+// Paired with the custom pos+color vertex format in demo_custom_verts.
+// Mesh components match these inputs by semantic, order doesn't matter.
+struct vsIn {
+	float4 pos : SV_Position;
+	float4 col : COLOR0;
+};
+struct psIn {
+	float4 pos : SV_POSITION;
+	float4 col : COLOR0;
+};
+
+psIn vs(vsIn input, sk_ids_t ids) {
+	psIn o;
+
+	float4 world = mul(input.pos, sk_inst[ids.inst].world);
+	o.pos = mul(world, sk_viewproj[ids.view]);
+	o.col = input.col;
+	return o;
+}
+
+float4 ps(psIn input) : SV_TARGET {
+	return input.col;
+}

--- a/Examples/StereoKitCTest/demo_custom_verts.cpp
+++ b/Examples/StereoKitCTest/demo_custom_verts.cpp
@@ -1,0 +1,97 @@
+#include "demo_custom_verts.h"
+
+#include <stereokit.h>
+#include <stereokit_ui.h>
+#include <math.h>
+#include <string.h>
+
+#include "skt_vert_custom.hlsl.h"
+
+using namespace sk;
+
+#ifndef _countof
+#define _countof(array) (sizeof(array) / sizeof(array[0]))
+#endif
+
+///////////////////////////////////////////
+
+// A minimal vertex, just a color and a position! Component order matches
+// this struct's memory, not the shader, inputs are matched by semantic.
+struct vert_pos_col_t {
+	color32 col;
+	vec3    pos;
+};
+const vert_component_t vert_pos_col_fmt[] = {
+	{ vert_fmt_u8_normalized, 4, vert_semantic_color,    0 },
+	{ vert_fmt_f32,           3, vert_semantic_position, 0 },
+};
+
+pose_t     custom_verts_pose = {0,0,-0.5f, quat_identity};
+material_t custom_verts_material;
+mesh_t     custom_verts_mesh;
+
+///////////////////////////////////////////
+
+void demo_custom_verts_init() {
+	shader_t shader = shader_create_mem((void*)sks_skt_vert_custom_hlsl, sizeof(sks_skt_vert_custom_hlsl));
+	custom_verts_material = material_create(shader);
+	shader_release(shader);
+
+	// An octahedron with a color per corner
+	const float   s = 0.1f;
+	vert_pos_col_t verts[] = {
+		{ {255,  0,  0,255}, { s, 0, 0} },
+		{ {  0,255,  0,255}, {-s, 0, 0} },
+		{ {  0,  0,255,255}, { 0, s, 0} },
+		{ {255,255,  0,255}, { 0,-s, 0} },
+		{ {  0,255,255,255}, { 0, 0, s} },
+		{ {255,  0,255,255}, { 0, 0,-s} },
+	};
+	vind_t inds[] = {
+		2,4,0,  2,0,5,  2,5,1,  2,1,4,
+		3,0,4,  3,5,0,  3,1,5,  3,4,1,
+	};
+
+	custom_verts_mesh = mesh_create();
+	mesh_set_data_fmt(custom_verts_mesh, vert_pos_col_fmt, _countof(vert_pos_col_fmt), verts, _countof(verts), inds, _countof(inds));
+
+	// Quick sanity checks for the custom format APIs, results land in the
+	// log where the test runner can spot them.
+	bounds_t bounds = mesh_get_bounds(custom_verts_mesh);
+	log_infof("custom_verts bounds:    %s <~BLK>(expected dimensions 0.2)<~clr>",
+		fabsf(bounds.dimensions.x - 2*s) < 0.0001f && fabsf(bounds.dimensions.y - 2*s) < 0.0001f && fabsf(bounds.dimensions.z - 2*s) < 0.0001f
+		? "<~GRN>pass<~clr>" : "<~RED>FAIL<~clr>");
+
+	// The -z face plane satisfies x+y-z = s, so this ray should hit at
+	// z = 0.02-s. Ray is offset from center to land inside a triangle.
+	ray_t hit = {};
+	ray_t ray = { {0.01f, 0.01f, -1}, {0, 0, 1} };
+	log_infof("custom_verts intersect: %s <~BLK>(expected hit at z=%.2f)<~clr>",
+		mesh_ray_intersect(custom_verts_mesh, ray, cull_back, &hit, nullptr) && fabsf(hit.pos.z - (0.02f-s)) < 0.0001f
+		? "<~GRN>pass<~clr>" : "<~RED>FAIL<~clr>", 0.02f-s);
+
+	vert_component_t* fmt       = nullptr;
+	int32_t           fmt_count = 0;
+	void*             raw       = nullptr;
+	int32_t           raw_count = 0;
+	mesh_get_verts_fmt(custom_verts_mesh, &fmt, &fmt_count, &raw, &raw_count, memory_reference);
+	log_infof("custom_verts get_fmt:   %s <~BLK>(expected matching format and data)<~clr>",
+		fmt_count == _countof(vert_pos_col_fmt) && memcmp(fmt, vert_pos_col_fmt, sizeof(vert_pos_col_fmt)) == 0 &&
+		raw_count == _countof(verts)            && memcmp(raw, verts, sizeof(verts)) == 0
+		? "<~GRN>pass<~clr>" : "<~RED>FAIL<~clr>");
+}
+
+///////////////////////////////////////////
+
+void demo_custom_verts_update() {
+	ui_handle_begin("CustomVerts", custom_verts_pose, nullptr, mesh_get_bounds(custom_verts_mesh), false);
+	mesh_draw      (custom_verts_mesh, custom_verts_material, matrix_r(quat_from_angles(0, time_totalf() * 45, 0)));
+	ui_handle_end  ();
+}
+
+///////////////////////////////////////////
+
+void demo_custom_verts_shutdown() {
+	mesh_release    (custom_verts_mesh);
+	material_release(custom_verts_material);
+}

--- a/Examples/StereoKitCTest/demo_custom_verts.h
+++ b/Examples/StereoKitCTest/demo_custom_verts.h
@@ -1,0 +1,5 @@
+#pragma once
+
+void demo_custom_verts_init();
+void demo_custom_verts_update();
+void demo_custom_verts_shutdown();

--- a/Examples/StereoKitCTest/main.cpp
+++ b/Examples/StereoKitCTest/main.cpp
@@ -20,6 +20,7 @@ using namespace sk;
 #include "demo_desktop.h"
 #include "demo_bvh.h"
 #include "demo_aliasing.h"
+#include "demo_custom_verts.h"
 #include "log_window.h"
 
 #include <stdio.h>
@@ -91,6 +92,11 @@ scene_t demos[] = {
 		demo_aliasing_init,
 		demo_aliasing_update,
 		demo_aliasing_shutdown,
+	}, {
+		"Custom Verts",
+		demo_custom_verts_init,
+		demo_custom_verts_update,
+		demo_custom_verts_shutdown,
 	}, {
 		"Environment Map",
 		demo_envmap_init,

--- a/Examples/StereoKitTest/Demos/DemoPointCloud.cs
+++ b/Examples/StereoKitTest/Demos/DemoPointCloud.cs
@@ -6,12 +6,26 @@
 using StereoKit;
 using System;
 using System.Linq;
+using System.Runtime.InteropServices;
 
 public class PointCloud
 {
-	Material mat;
-	Vertex[] verts;
-	Mesh     mesh;
+	// Each point becomes a camera-facing quad, so per-vertex cost is x4!
+	// 16 bytes to Vertex's 36, the shader derives corners from vertex id.
+	[StructLayout(LayoutKind.Sequential, Pack = 1)]
+	struct PointVert
+	{
+		[VertComponent(VertSemantic.Position, VertFmt.F32,          3)]
+		public Vec3    pos;
+		[VertComponent(VertSemantic.Color,    VertFmt.U8Normalized, 4)]
+		public Color32 col;
+
+		public PointVert(Vec3 position, Color32 color) { pos = position; col = color; }
+	}
+
+	Material    mat;
+	PointVert[] verts;
+	Mesh        mesh;
 
 	bool  distanceIndependant;
 	float pointSize;
@@ -36,7 +50,7 @@ public class PointCloud
 	public void SetPoints(Vertex[] points)
 	{
 		if (verts == null)
-			verts = new Vertex[points.Length*4];
+			verts = new PointVert[points.Length*4];
 		if (verts.Length != points.Length * 4)
 		{
 			Log.Err("You can re-use a point cloud, but the number of points should stay the same!");
@@ -45,16 +59,16 @@ public class PointCloud
 
 		for (int i = 0; i < points.Length; i++)
 		{
-			Vertex p = points[i];
-			int idx = i*4;
-			verts[idx  ] = new Vertex(p.pos, p.norm, V.XY(-.5f, .5f), p.col);
-			verts[idx+1] = new Vertex(p.pos, p.norm, V.XY( .5f, .5f), p.col);
-			verts[idx+2] = new Vertex(p.pos, p.norm, V.XY( .5f,-.5f), p.col);
-			verts[idx+3] = new Vertex(p.pos, p.norm, V.XY(-.5f,-.5f), p.col);
+			Vertex    p    = points[i];
+			PointVert vert = new PointVert(p.pos, p.col);
+			int       idx  = i*4;
+			verts[idx  ] = vert;
+			verts[idx+1] = vert;
+			verts[idx+2] = vert;
+			verts[idx+3] = vert;
 		}
-		uint[] inds = null;
 		if (mesh == null) {
-			inds = new uint[points.Length*6];
+			uint[] inds = new uint[points.Length*6];
 			for (uint i = 0; i < points.Length; i++)
 			{
 				uint ind  = i*6;
@@ -67,7 +81,9 @@ public class PointCloud
 				inds[ind+4] = vert+2;
 				inds[ind+5] = vert+0;
 			}
-			mesh = new Mesh(verts, inds);
+			mesh = new Mesh();
+			mesh.SetVerts(verts);
+			mesh.SetInds (inds);
 		}
 		else
 		{
@@ -92,7 +108,7 @@ public class PointCloud
 class DemoPointCloud : ITest
 {
 	string title       = "Point Clouds";
-	string description = "Point clouds are not a built-in feature of StereoKit, but it's not hard to do this yourself! Check out the code for this demo for a class that'll help you do this directly from data, or from a Model.";
+	string description = "Point clouds are not a built-in feature of StereoKit, but it's not hard to do this yourself! Check out the code for this demo for a class that'll help you do this directly from data, or from a Model. It's also a nice example of pairing a custom vertex format with a custom shader, point clouds only need a fraction of the data regular meshes use!";
 
 	Pose       cloudPose    = (Matrix.T(0.2f,-0.1f,0) * Demo.contentPose).Pose;
 	float      cloudScale   = 1;
@@ -103,10 +119,8 @@ class DemoPointCloud : ITest
 
 	public void Initialize()
 	{
-		// Generate colored points in the shape of a UV sphere! This tool
-		// re-uses the Vertex type, but doesn't particularly need the
-		// normals, and will replace the UVs. You could pretty easily add
-		// lighting to the points using the normals if you wanted to :)
+		// Generate colored points in the shape of a UV sphere! Vertex is
+		// just a convenient carrier here, see PointCloud.SetPoints.
 		const int xCount = 24;
 		const int yCount = 16;
 		Vertex[] points = new Vertex[xCount*yCount];

--- a/Examples/StereoKitTest/Tests/TestVertexFormat.cs
+++ b/Examples/StereoKitTest/Tests/TestVertexFormat.cs
@@ -1,0 +1,356 @@
+using StereoKit;
+using System;
+using System.Runtime.InteropServices;
+
+class TestVertexFormat : ITest
+{
+	/// :CodeSample: Mesh.SetVerts VertComponentAttribute VertSemantic VertFmt
+	/// ### Custom vertex formats
+	/// Meshes can use custom vertex layouts! Define a struct that provides
+	/// what your shader's vertex stage needs, and tag each field with a
+	/// VertComponent attribute saying what it is. StereoKit derives the
+	/// vertex format from the struct automatically. Since vertex data is
+	/// matched to shader inputs by semantic, fields don't need to be in the
+	/// same order as the shader declares them!
+	[StructLayout(LayoutKind.Sequential, Pack = 1)]
+	struct VertPosColor
+	{
+		[VertComponent(VertSemantic.Color,    VertFmt.U8Normalized, 4)]
+		public Color32 color;
+		[VertComponent(VertSemantic.Position, VertFmt.F32,          3)]
+		public Vec3    pos;
+
+		public VertPosColor(Vec3 position, Color32 c) { pos = position; color = c; }
+	}
+
+	Mesh     _mesh;
+	Material _material;
+
+	Mesh BuildOctahedron(float s)
+	{
+		Mesh mesh = new Mesh();
+		mesh.SetVerts(new VertPosColor[] {
+			new VertPosColor(V.XYZ( s, 0, 0), new Color32(255,  0,  0,255)),
+			new VertPosColor(V.XYZ(-s, 0, 0), new Color32(  0,255,  0,255)),
+			new VertPosColor(V.XYZ( 0, s, 0), new Color32(  0,  0,255,255)),
+			new VertPosColor(V.XYZ( 0,-s, 0), new Color32(255,255,  0,255)),
+			new VertPosColor(V.XYZ( 0, 0, s), new Color32(  0,255,255,255)),
+			new VertPosColor(V.XYZ( 0, 0,-s), new Color32(255,  0,255,255)) });
+		mesh.SetInds(new uint[] {
+			2,4,0,  2,0,5,  2,5,1,  2,1,4,
+			3,0,4,  3,5,0,  3,1,5,  3,4,1 });
+		return mesh;
+	}
+	/// :End:
+
+	public void Initialize()
+	{
+		_mesh     = BuildOctahedron(0.1f);
+		_material = new Material(Shader.FromFile("Shaders/vert_custom.hlsl"));
+
+		Tests.Test(TestBoundsFromPosition);
+		Tests.Test(TestRoundTrip);
+		Tests.Test(TestLayoutValidation);
+		Tests.Test(TestSetData);
+		Tests.Test(TestSetDataAsync);
+		Tests.Test(TestGetTriangle);
+		Tests.Test(TestBvhIntersect);
+		Tests.Test(TestCalculatedNormals);
+		Tests.Test(TestSkinnedCustomFormat);
+		Tests.Test(TestVertexAsGeneric);
+		Tests.Test(TestCreativeUnaligned);
+		Tests.Test(TestCreativeRoundTrip);
+	}
+
+	// GetTriangle decodes custom formats into Vertex, with defaults for
+	// components the format doesn't have.
+	bool TestGetTriangle()
+	{
+		if (!_mesh.GetTriangle(0, out Vertex a, out Vertex b, out Vertex c))
+			return false;
+
+		// Triangle 0 is inds 2,4,0 of the octahedron
+		if (Vec3.DistanceSq(a.pos, V.XYZ(0, 0.1f, 0)) > 1e-10f) return false;
+		if (Vec3.DistanceSq(b.pos, V.XYZ(0, 0, 0.1f)) > 1e-10f) return false;
+		if (Vec3.DistanceSq(c.pos, V.XYZ(0.1f, 0, 0)) > 1e-10f) return false;
+		// Normals aren't in the format, they read as the (0,1,0) default
+		if (Vec3.DistanceSq(a.norm, V.XYZ(0, 1, 0)) > 1e-10f)   return false;
+		// Colors decode, vert 2 is blue
+		return a.col.r == 0 && a.col.g == 0 && a.col.b == 255 && a.col.a == 255;
+	}
+
+	// The BVH intersection path builds from format-aware collision data.
+	bool TestBvhIntersect()
+	{
+		Ray ray = new Ray(V.XYZ(0.01f, 0.01f, -1), V.XYZ(0, 0, 1));
+		if (!_mesh.Intersect(ray, out Ray at, out uint startInds))
+			return false;
+		// The -z face plane satisfies x+y-z = s, so the hit lands at 0.02-s
+		return Math.Abs(at.position.z - (0.02f - 0.1f)) < 0.0001f;
+	}
+
+	// The built-in Vertex type works with the generic APIs too, and lands
+	// on the same default format as the typed overloads.
+	bool TestVertexAsGeneric()
+	{
+		Vertex[] verts = {
+			new Vertex(V.XYZ(-1, 0, 0), Vec3.Up),
+			new Vertex(V.XYZ( 1, 0, 0), Vec3.Up),
+			new Vertex(V.XYZ( 0, 1, 0), Vec3.Up) };
+		Mesh mesh = new Mesh();
+		mesh.SetVerts<Vertex>(verts);
+		mesh.SetInds(new uint[] { 0, 1, 2 });
+
+		Vertex[] back = mesh.GetVerts<Vertex>();
+		if (back == null || back.Length != 3)                        return false;
+		if (Vec3.DistanceSq(back[2].pos, V.XYZ(0, 1, 0)) > 1e-10f)   return false;
+		// The typed getter agrees, it's the same default format mesh
+		return mesh.GetVerts() != null;
+	}
+
+	// CPU skinning deforms positions through the vertex format, and a
+	// skinned mesh must reject vertex format changes.
+	bool TestSkinnedCustomFormat()
+	{
+		VertPosColor[] verts = _mesh.GetVerts<VertPosColor>();
+		uint[]         inds  = _mesh.GetInds ();
+		Mesh mesh = new Mesh();
+		mesh.SetData(verts, inds);
+
+		// Every vertex fully weighted to a single identity-rest bone
+		ushort[] ids     = new ushort[verts.Length * 4];
+		Vec4[]   weights = new Vec4  [verts.Length];
+		for (int i = 0; i < verts.Length; i++) weights[i] = V.XYZW(1, 0, 0, 0);
+		mesh.SetSkin(ids, weights, new Matrix[] { Matrix.Identity });
+
+		// Moving the bone moves the deformed bounds with it
+		mesh.UpdateSkin(new Matrix[] { Matrix.T(1, 0, 0) });
+		if (Vec3.DistanceSq(mesh.Bounds.center, V.XYZ(1, 0, 0)) > 1e-6f)
+			return false;
+
+		// A format change on a skinned mesh gets rejected, the mesh should
+		// still be readable with its original format.
+		mesh.SetVerts(new Vertex[] { new Vertex(Vec3.Zero, Vec3.Up) });
+		VertPosColor[] after = mesh.GetVerts<VertPosColor>();
+		return after != null && after.Length == verts.Length;
+	}
+
+	// A normal-less obj sends the loader through calculate normals, which
+	// routes through the vertex format codec.
+	bool TestCalculatedNormals()
+	{
+		string obj =
+			"v 0 0 0\n" +
+			"v 1 0 0\n" +
+			"v 1 1 0\n" +
+			"v 0 1 0\n" +
+			"f 1 2 3\n" +
+			"f 1 3 4\n";
+		Model model = Model.FromMemory("flat_quad.obj", System.Text.Encoding.UTF8.GetBytes(obj));
+		Vertex[] verts = model.Visuals[0].Mesh.GetVerts();
+		if (verts == null || verts.Length == 0) return false;
+
+		// Every vertex of a flat +Z facing quad gets a (0,0,1) normal
+		foreach (Vertex v in verts)
+			if (Vec3.DistanceSq(v.norm, V.XYZ(0, 0, 1)) > 1e-6f) return false;
+		return true;
+	}
+
+	bool TestBoundsFromPosition()
+		=> Vec3.DistanceSq(_mesh.Bounds.dimensions, V.XYZ(0.2f, 0.2f, 0.2f)) < 0.0001f;
+
+	bool TestRoundTrip()
+	{
+		VertPosColor[] verts = _mesh.GetVerts<VertPosColor>();
+		if (verts == null || verts.Length != 6)                        return false;
+		if (Vec3.DistanceSq(verts[0].pos, V.XYZ(0.1f, 0, 0)) > 1e-8f)  return false;
+		if (verts[5].color.a != 255 || verts[5].color.g != 0)          return false;
+
+		// A struct whose format doesn't match the mesh must throw rather
+		// than misinterpret the data.
+		try { _mesh.GetVerts<VertPosOnly>(); return false; }
+		catch (InvalidOperationException) { }
+
+		return true;
+	}
+
+	[StructLayout(LayoutKind.Sequential, Pack = 1)]
+	struct VertPosOnly
+	{
+		[VertComponent(VertSemantic.Position, VertFmt.F32, 3)]
+		public Vec3 pos;
+	}
+
+	// These structs are intentionally broken to check layout validation,
+	// their fields are never assigned.
+	#pragma warning disable 0649
+	struct VertPadded
+	{
+		[VertComponent(VertSemantic.Color, VertFmt.U8Normalized, 1)]
+		public byte  color;
+		// Default layout pads 3 bytes here, which the layout reflection
+		// must catch and complain about.
+		[VertComponent(VertSemantic.Position, VertFmt.F32, 1)]
+		public float pos;
+	}
+
+	struct VertUntagged
+	{
+		public Vec3 pos;
+	}
+
+	[StructLayout(LayoutKind.Sequential, Pack = 1)]
+	struct VertWrongSize
+	{
+		[VertComponent(VertSemantic.Position, VertFmt.F32, 2)]
+		public Vec3 pos;
+	}
+	#pragma warning restore 0649
+
+	bool TestLayoutValidation()
+	{
+		Mesh mesh = new Mesh();
+
+		try { mesh.SetVerts(new VertPadded   [1]); return false; } catch (ArgumentException) { }
+		try { mesh.SetVerts(new VertUntagged [1]); return false; } catch (ArgumentException) { }
+		try { mesh.SetVerts(new VertWrongSize[1]); return false; } catch (ArgumentException) { }
+
+		return true;
+	}
+
+	static bool MatchesReference(Mesh mesh, Mesh reference)
+	{
+		if (Vec3.DistanceSq(mesh.Bounds.dimensions, reference.Bounds.dimensions) > 1e-8f)
+			return false;
+
+		VertPosColor[] a = mesh     .GetVerts<VertPosColor>();
+		VertPosColor[] b = reference.GetVerts<VertPosColor>();
+		if (a == null || b == null || a.Length != b.Length) return false;
+		for (int i = 0; i < a.Length; i++)
+		{
+			if (Vec3.DistanceSq(a[i].pos, b[i].pos) > 1e-10f) return false;
+			if (a[i].color.r != b[i].color.r || a[i].color.g != b[i].color.g ||
+				a[i].color.b != b[i].color.b || a[i].color.a != b[i].color.a) return false;
+		}
+		return mesh.GetInds().Length == reference.GetInds().Length;
+	}
+
+	// SetData with a custom format should produce the same mesh SetVerts +
+	// SetInds does.
+	bool TestSetData()
+	{
+		VertPosColor[] verts = _mesh.GetVerts<VertPosColor>();
+		uint[]         inds  = _mesh.GetInds ();
+
+		Mesh mesh = new Mesh();
+		mesh.SetData(verts, inds);
+		return MatchesReference(mesh, _mesh);
+	}
+
+	bool TestSetDataAsync()
+	{
+		VertPosColor[] verts = _mesh.GetVerts<VertPosColor>();
+		uint[]         inds  = _mesh.GetInds ();
+
+		Mesh mesh = new Mesh();
+		mesh.SetData(verts, inds, MeshData.CalcBounds | MeshData.Async);
+		Assets.BlockForPriority(0);
+		return MatchesReference(mesh, _mesh);
+	}
+
+	// A deliberately awkward "compressed" vertex format that stresses the
+	// trickier paths all at once: a leading 1-byte component pushes the
+	// float3 position to byte offset 1, so bounds, collision, and the BVH
+	// all have to read it unaligned; the normal and UV are bit-packed into
+	// plain integer fields (the format describes the bytes, not the field's
+	// C# type); and the components are declared out of the shader's input
+	// order. Five components, none of them where you'd expect.
+	[StructLayout(LayoutKind.Sequential, Pack = 1)]
+	struct VertCreative
+	{
+		[VertComponent(VertSemantic.Psize,    VertFmt.U8Normalized, 1)] public byte    size;   // @0
+		[VertComponent(VertSemantic.Position, VertFmt.F32,          3)] public Vec3    pos;    // @1  (unaligned!)
+		[VertComponent(VertSemantic.Color,    VertFmt.U8Normalized, 4)] public Color32 color;  // @13
+		[VertComponent(VertSemantic.Normal,   VertFmt.I8Normalized, 4)] public int     normal; // @17 4x i8, packed
+		[VertComponent(VertSemantic.Texcoord, VertFmt.F16,          2)] public uint    uv;     // @21 2x f16, packed
+	}
+
+	static byte ToI8Norm (float v)          => (byte)(sbyte)Math.Round(Math.Clamp(v, -1f, 1f) * 127f);
+	static int  PackNormal(Vec3  n)         => ToI8Norm(n.x) | (ToI8Norm(n.y) << 8) | (ToI8Norm(n.z) << 16); // w stays 0
+	static uint PackUv    (float u, float v) => (uint)BitConverter.HalfToUInt16Bits((Half)u) | ((uint)BitConverter.HalfToUInt16Bits((Half)v) << 16);
+
+	Mesh BuildCreativeOctahedron(float s)
+	{
+		Vec3[]    p = { V.XYZ(s,0,0), V.XYZ(-s,0,0), V.XYZ(0,s,0), V.XYZ(0,-s,0), V.XYZ(0,0,s), V.XYZ(0,0,-s) };
+		Color32[] c = { new Color32(255,0,0,255), new Color32(0,255,0,255), new Color32(0,0,255,255),
+		                new Color32(255,255,0,255), new Color32(0,255,255,255), new Color32(255,0,255,255) };
+
+		VertCreative[] verts = new VertCreative[6];
+		for (int i = 0; i < 6; i++)
+			verts[i] = new VertCreative {
+				size   = 128,
+				pos    = p[i],
+				color  = c[i],
+				normal = PackNormal(p[i].Normalized),
+				uv     = PackUv(i / 5.0f, 0) };
+
+		Mesh mesh = new Mesh();
+		mesh.SetVerts(verts);
+		mesh.SetInds(new uint[] {
+			2,4,0,  2,0,5,  2,5,1,  2,1,4,
+			3,0,4,  3,5,0,  3,1,5,  3,4,1 });
+		return mesh;
+	}
+
+	// The creative format's position sits at an unaligned byte offset, so
+	// this drives the unaligned reads in bounds, collision, and the BVH,
+	// plus a GetTriangle decode of every packed component.
+	bool TestCreativeUnaligned()
+	{
+		Mesh mesh = BuildCreativeOctahedron(0.1f);
+
+		// Bounds are computed from the (unaligned) position component.
+		if (Vec3.DistanceSq(mesh.Bounds.dimensions, V.XYZ(0.2f, 0.2f, 0.2f)) > 0.0001f) return false;
+
+		// Ray intersection runs through format-aware, unaligned collision data.
+		Ray ray = new Ray(V.XYZ(0.01f, 0.01f, -1), V.XYZ(0, 0, 1));
+		if (!mesh.Intersect(ray, out Ray at, out _)) return false;
+		if (Math.Abs(at.position.z - (0.02f - 0.1f)) > 0.0001f) return false;
+
+		// GetTriangle decodes every component, incl. the packed i8 normal.
+		// Triangle 0 is inds 2,4,0; vert 0 is the +x corner (red, normal +x).
+		if (!mesh.GetTriangle(0, out Vertex a, out _, out Vertex c)) return false;
+		if (Vec3.DistanceSq(c.pos,  V.XYZ(0.1f, 0, 0)) > 1e-10f) return false;
+		if (Vec3.DistanceSq(c.norm, V.XYZ(1, 0, 0))    > 0.02f)  return false; // not the (0,1,0) default
+		if (c.col.r != 255 || c.col.g != 0)                     return false;
+		// Vert 2 is the +y corner, blue.
+		if (a.col.b != 255 || a.col.r != 0)                     return false;
+
+		return true;
+	}
+
+	// A five-component packed format round-trips byte-for-byte through
+	// GetVerts, integer fields included.
+	bool TestCreativeRoundTrip()
+	{
+		Mesh           mesh  = BuildCreativeOctahedron(0.1f);
+		VertCreative[] verts = mesh.GetVerts<VertCreative>();
+		if (verts == null || verts.Length != 6) return false;
+
+		VertCreative got = verts[0]; // the +x corner
+		return got.size == 128
+			&& Vec3.DistanceSq(got.pos, V.XYZ(0.1f, 0, 0)) < 1e-12f
+			&& got.color.r == 255 && got.color.g == 0 && got.color.b == 0 && got.color.a == 255
+			&& got.normal == PackNormal(V.XYZ(1, 0, 0))
+			&& got.uv     == PackUv(0, 0);
+	}
+
+	public void Shutdown() { }
+
+	public void Step()
+	{
+		_mesh.Draw(_material, Matrix.R(0, 45, 0));
+
+		Tests.Screenshot("Tests/VertexFormat.jpg", 400, 400, 90, V.XYZ(0.12f, 0.12f, 0.25f), V.XYZ(0, 0, 0));
+	}
+}

--- a/Examples/StereoKitTest/Tests/TestVertexFormat.cs
+++ b/Examples/StereoKitTest/Tests/TestVertexFormat.cs
@@ -130,6 +130,7 @@ class TestVertexFormat : ITest
 
 		// A format change on a skinned mesh gets rejected, the mesh should
 		// still be readable with its original format.
+		Log.Warn("Expected error:");
 		mesh.SetVerts(new Vertex[] { new Vertex(Vec3.Zero, Vec3.Up) });
 		VertPosColor[] after = mesh.GetVerts<VertPosColor>();
 		return after != null && after.Length == verts.Length;

--- a/StereoKit/Assets/Mesh.cs
+++ b/StereoKit/Assets/Mesh.cs
@@ -174,6 +174,51 @@ namespace StereoKit
 		public void SetData(Vertex[] vertices, uint[] indices, MeshData flags, int priority = 0)
 			=> NativeAPI.mesh_set_data(_inst, vertices, vertices?.Length ?? 0, indices, indices.Length, flags, priority);
 
+		/// <summary>Assigns vertices with a custom vertex format along with
+		/// face indices for this Mesh in a single call! The format is derived
+		/// from T's [VertComponent] tagged fields, see SetVerts for details.
+		///
+		/// Calling SetData is slightly more efficient than calling SetVerts
+		/// and SetInds separately.</summary>
+		/// <param name="vertices">An array of vertices to add to the mesh.
+		/// </param>
+		/// <param name="indices">A list of face indices, must be a multiple of
+		/// 3. Each index represents a vertex from the provided vertex array.
+		/// </param>
+		/// <param name="calculateBounds">If true, this will also update the
+		/// Mesh's bounds based on the vertices provided. This requires the
+		/// format to contain a float3 position component.</param>
+		public void SetData<T>(T[] vertices, uint[] indices, bool calculateBounds = true) where T : unmanaged
+			=> SetData(vertices, indices, calculateBounds ? MeshData.CalcBounds : MeshData.None, 0);
+
+		/// <summary>Assigns vertices with a custom vertex format along with
+		/// face indices for this Mesh in a single call, with control over
+		/// upload behavior via flags! Upload is synchronous by default — pass
+		/// MeshData.Async for background upload. The format is derived from
+		/// T's [VertComponent] tagged fields, see SetVerts for details.
+		/// </summary>
+		/// <param name="vertices">An array of vertices to add to the mesh.
+		/// </param>
+		/// <param name="indices">A list of face indices, must be a multiple of
+		/// 3. Each index represents a vertex from the provided vertex array.
+		/// </param>
+		/// <param name="flags">Flags controlling upload behavior. See
+		/// MeshData for options.</param>
+		/// <param name="priority">Loading priority for async upload. Lower
+		/// values load sooner.</param>
+		public void SetData<T>(T[] vertices, uint[] indices, MeshData flags, int priority = 0) where T : unmanaged
+		{
+			VertComponent[] format = VertLayout<T>.Components;
+			if (vertices == null)
+			{
+				NativeAPI.mesh_set_data_fmt(_inst, format, format.Length, IntPtr.Zero, 0, indices, indices.Length, flags, priority);
+				return;
+			}
+			GCHandle pin = GCHandle.Alloc(vertices, GCHandleType.Pinned);
+			try     { NativeAPI.mesh_set_data_fmt(_inst, format, format.Length, pin.AddrOfPinnedObject(), vertices.Length, indices, indices.Length, flags, priority); }
+			finally { pin.Free(); }
+		}
+
 		/// <summary>Assigns the vertices for this Mesh! This will create a
 		/// vertex buffer object on the graphics card. If you're
 		/// calling this a second time, the buffer will be marked as dynamic
@@ -200,7 +245,7 @@ namespace StereoKit
 		/// <summary>This marshalls the Mesh's vertex data into an array. If
 		/// KeepData is false, then the Mesh is _not_ storing verts on the CPU,
 		/// and this information will _not_ be available.
-		/// 
+		///
 		/// Due to the way marshalling works, this is _not_ a cheap function!
 		/// </summary>
 		/// <returns>An array of vertices representing the Mesh, or null if
@@ -216,6 +261,67 @@ namespace StereoKit
 			// AHHHHHH
 			for (uint i = 0; i < size; i++)
 				result[i] = Marshal.PtrToStructure<Vertex>(new IntPtr(ptr.ToInt64() + (szStruct * i)));
+			return result;
+		}
+
+		/// <summary>Assigns vertices with a custom vertex format to this Mesh!
+		/// The format is derived from T's fields, each of which must be tagged
+		/// with a [VertComponent] attribute describing what it is. The shader
+		/// this Mesh is drawn with must be one that works with the components
+		/// this format provides, StereoKit's built-in shaders all expect
+		/// position, normal, texcoord and color.
+		///
+		/// A T that doesn't exactly describe its own memory layout will throw
+		/// an ArgumentException here, see [VertComponent] docs for the rules.
+		/// </summary>
+		/// <param name="vertices">An array of vertices to add to the mesh.
+		/// </param>
+		/// <param name="calculateBounds">If true, this will also update the
+		/// Mesh's bounds based on the vertices provided. This requires the
+		/// format to contain a float3 position component.</param>
+		public void SetVerts<T>(T[] vertices, bool calculateBounds = true) where T : unmanaged
+		{
+			VertComponent[] format = VertLayout<T>.Components;
+			GCHandle        pin    = GCHandle.Alloc(vertices, GCHandleType.Pinned);
+			try     { NativeAPI.mesh_set_verts_fmt(_inst, format, format.Length, pin.AddrOfPinnedObject(), vertices.Length, calculateBounds); }
+			finally { pin.Free(); }
+		}
+
+		/// <summary>This marshalls the vertex data of a custom format Mesh
+		/// into an array of T. T's [VertComponent] derived format must exactly
+		/// match the format the Mesh was created with, and KeepData must be
+		/// true for vertex data to be available.
+		///
+		/// Due to the way marshalling works, this is _not_ a cheap function!
+		/// </summary>
+		/// <returns>An array of vertices representing the Mesh, or null if
+		/// KeepData is false.</returns>
+		public T[] GetVerts<T>() where T : unmanaged
+		{
+			NativeAPI.mesh_get_verts_fmt(_inst, out IntPtr fmtPtr, out int fmtCount, out IntPtr dataPtr, out int count, Memory.Reference);
+			if (dataPtr == IntPtr.Zero)
+				return null;
+
+			VertComponent[] expected = VertLayout<T>.Components;
+			if (fmtCount != expected.Length)
+				throw new InvalidOperationException($"This Mesh's vertex format has {fmtCount} components, but {typeof(T).Name} describes {expected.Length}!");
+			int szComp = Marshal.SizeOf(typeof(VertComponent));
+			for (int i = 0; i < fmtCount; i++)
+			{
+				VertComponent comp = Marshal.PtrToStructure<VertComponent>(new IntPtr(fmtPtr.ToInt64() + (szComp * i)));
+				if (comp.Format   != expected[i].Format   || comp.Count        != expected[i].Count ||
+					comp.Semantic != expected[i].Semantic || comp.SemanticSlot != expected[i].SemanticSlot)
+					throw new InvalidOperationException($"This Mesh's vertex format doesn't match component {i} of {typeof(T).Name}!");
+			}
+
+			// Bulk copy the raw bytes across via a pinned destination array.
+			T[]      result = new T[count];
+			int      bytes  = count * Marshal.SizeOf<T>();
+			byte[]   buffer = new byte[bytes];
+			Marshal.Copy(dataPtr, buffer, 0, bytes);
+			GCHandle pin    = GCHandle.Alloc(result, GCHandleType.Pinned);
+			try     { Marshal.Copy(buffer, 0, pin.AddrOfPinnedObject(), bytes); }
+			finally { pin.Free(); }
 			return result;
 		}
 

--- a/StereoKit/Assets/VertexFormat.cs
+++ b/StereoKit/Assets/VertexFormat.cs
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: MIT
+// The authors below grant copyright rights under the MIT license:
+// Copyright (c) 2026 Nick Klingensmith
+// Copyright (c) 2026 Qualcomm Technologies, Inc.
+
+using System;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace StereoKit
+{
+	/// <summary>Describes how a field of a vertex struct maps to a component
+	/// of a vertex format! Tag every field of your custom vertex struct with
+	/// this attribute, and `Mesh.SetVerts&lt;T&gt;` will derive the complete
+	/// vertex format from the struct via reflection.
+	///
+	/// The field's format is explicit rather than inferred from the field's
+	/// type, so the field just needs to be the right size for the format.
+	/// This means packed data like a pair of half floats can live in a plain
+	/// `uint` field, with bit math or types like `System.Half` used to fill
+	/// it in.
+	///
+	/// Vertex structs must be tightly packed, with no padding between fields
+	/// or at the end of the struct. If your field sizes don't naturally align,
+	/// use `[StructLayout(LayoutKind.Sequential, Pack = 1)]`.</summary>
+	[AttributeUsage(AttributeTargets.Field, AllowMultiple = false)]
+	public sealed class VertComponentAttribute : Attribute
+	{
+		/// <summary>What this component means, this is matched with the
+		/// shader's vertex input semantics.</summary>
+		public VertSemantic Semantic { get; }
+		/// <summary>The data format of a single element of this component.
+		/// </summary>
+		public VertFmt Format { get; }
+		/// <summary>How many format elements this component has, 1-4. A Vec3
+		/// position would be 3.</summary>
+		public int Count { get; }
+		/// <summary>Distinguishes multiple components with the same semantic,
+		/// like TEXCOORD0 vs TEXCOORD1. Usually 0.</summary>
+		public int SemanticSlot { get; }
+
+		/// <summary>Describe the vertex component this field contains.
+		/// </summary>
+		/// <param name="semantic">What this component means, this is matched
+		/// with the shader's vertex input semantics.</param>
+		/// <param name="format">The data format of a single element of this
+		/// component.</param>
+		/// <param name="count">How many format elements this component has,
+		/// 1-4. A Vec3 position would be 3.</param>
+		/// <param name="semanticSlot">Distinguishes multiple components with
+		/// the same semantic, like TEXCOORD0 vs TEXCOORD1.</param>
+		public VertComponentAttribute(VertSemantic semantic, VertFmt format, int count, int semanticSlot = 0)
+		{
+			Semantic     = semantic;
+			Format       = format;
+			Count        = count;
+			SemanticSlot = semanticSlot;
+		}
+	}
+
+	/// <summary>Derives and caches the vertex format of a vertex struct from
+	/// its [VertComponent] attributes. Validation is aggressive, a layout
+	/// that doesn't exactly describe the struct's memory throws with an
+	/// explanation at first use.</summary>
+	internal static class VertLayout<T> where T : unmanaged
+	{
+		static VertComponent[] _components;
+
+		internal static VertComponent[] Components { get { if (_components == null) _components = Build(); return _components; } }
+
+		static int FmtSize(VertFmt fmt) => fmt switch {
+			VertFmt.F32 or VertFmt.I32 or VertFmt.U32 => 4,
+			VertFmt.F16 or VertFmt.I16 or VertFmt.U16 or VertFmt.I16Normalized or VertFmt.U16Normalized => 2,
+			VertFmt.I8 or VertFmt.U8 or VertFmt.I8Normalized or VertFmt.U8Normalized => 1,
+			_ => 0,
+		};
+
+		static VertComponent[] Build()
+		{
+			Type        type   = typeof(T);
+			FieldInfo[] fields = type.GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+			if (fields.Length == 0)
+				throw new ArgumentException($"Vertex struct {type.Name} has no fields!");
+
+			// Reflection makes no promises about field order, sort the
+			// fields by their actual memory offsets.
+			int[] offsets = new int[fields.Length];
+			for (int i = 0; i < fields.Length; i++)
+				offsets[i] = (int)Marshal.OffsetOf<T>(fields[i].Name);
+			Array.Sort(offsets, fields);
+
+			// Each field must start exactly where the previous components end,
+			// one chain that catches padding and size mismatches alike.
+			const string layoutHint = "Check that each field's size matches its [VertComponent], and that the struct is tightly packed, like with [StructLayout(LayoutKind.Sequential, Pack = 1)].";
+
+			VertComponent[] result = new VertComponent[fields.Length];
+			int             size   = 0;
+			for (int i = 0; i < fields.Length; i++)
+			{
+				VertComponentAttribute attr = fields[i].GetCustomAttribute<VertComponentAttribute>() ??
+					throw new ArgumentException($"Vertex struct field {type.Name}.{fields[i].Name} needs a [VertComponent] attribute!");
+				if (attr.Semantic == VertSemantic.None || FmtSize(attr.Format) == 0 || attr.Count < 1 || attr.Count > 4)
+					throw new ArgumentException($"Vertex struct field {type.Name}.{fields[i].Name} has an invalid [VertComponent] semantic, format, or count!");
+				if (offsets[i] != size)
+					throw new ArgumentException($"Vertex struct {type.Name}: field {fields[i].Name} starts at byte {offsets[i]}, but the components before it describe {size} bytes! {layoutHint}");
+
+				result[i] = new VertComponent(attr.Semantic, attr.Format, attr.Count, attr.SemanticSlot);
+				size     += FmtSize(attr.Format) * attr.Count;
+			}
+
+			int structSize = Marshal.SizeOf<T>();
+			if (size != structSize)
+				throw new ArgumentException($"Vertex struct {type.Name} is {structSize} bytes, but its components describe {size} bytes! {layoutHint}");
+
+			return result;
+		}
+	}
+}

--- a/StereoKit/Native/NativeAPI.cs
+++ b/StereoKit/Native/NativeAPI.cs
@@ -225,8 +225,12 @@ namespace StereoKit
 		[return: MarshalAs(UnmanagedType.Bool)]
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern bool         mesh_get_keep_data(IntPtr mesh);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         mesh_set_data(IntPtr mesh, [In] Vertex[] in_arr_vertices, int vertex_count, [In] uint[] in_arr_indices, int index_count, MeshData flags, int priority);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         mesh_set_data_fmt(IntPtr mesh, [In] VertComponent[] in_arr_format, int component_count, IntPtr vertex_data, int vertex_count, [In] uint[] in_arr_indices, int index_count, MeshData flags, int priority);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         mesh_set_verts(IntPtr mesh, [In] Vertex[] in_arr_vertices, int vertex_count, [MarshalAs(UnmanagedType.Bool)] bool calculate_bounds);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         mesh_get_verts(IntPtr mesh, out IntPtr out_arr_vertices, out int out_vertex_count, Memory reference_mode);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         mesh_set_verts_fmt(IntPtr mesh, [In] VertComponent[] in_arr_format, int component_count, IntPtr vertex_data, int vertex_count, [MarshalAs(UnmanagedType.Bool)] bool calculate_bounds);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         mesh_get_verts_fmt(IntPtr mesh, out IntPtr out_arr_format, out int out_component_count, out IntPtr out_vertex_data, out int out_vertex_count, Memory reference_mode);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern int          mesh_fmt_stride([In] VertComponent[] in_arr_format, int component_count);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern int          mesh_get_vert_count(IntPtr mesh);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         mesh_set_inds(IntPtr mesh, [In] uint[] in_arr_indices, int index_count);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         mesh_get_inds(IntPtr mesh, out IntPtr out_arr_indices, out int out_index_count, Memory reference_mode);

--- a/StereoKit/Native/NativeEnums.cs
+++ b/StereoKit/Native/NativeEnums.cs
@@ -781,6 +781,65 @@ namespace StereoKit
 		Granted      = 1,
 	}
 
+	/// <summary>The data format of a single element of a vertex component. Normalized
+	/// formats map their integer range onto 0-1 (unsigned) or -1-1 (signed)
+	/// when read by the GPU, other integer formats arrive as integers.</summary>
+	public enum VertFmt {
+		/// <summary>Invalid format, this is not a valid value for a component.</summary>
+		None         = 0,
+		/// <summary>32 bit float.</summary>
+		F32,
+		/// <summary>16 bit half float.</summary>
+		F16,
+		/// <summary>32 bit signed integer.</summary>
+		I32,
+		/// <summary>16 bit signed integer.</summary>
+		I16,
+		/// <summary>8 bit signed integer.</summary>
+		I8,
+		/// <summary>16 bit signed integer, normalized to -1-1 on the GPU.</summary>
+		I16Normalized,
+		/// <summary>8 bit signed integer, normalized to -1-1 on the GPU.</summary>
+		I8Normalized,
+		/// <summary>32 bit unsigned integer.</summary>
+		U32,
+		/// <summary>16 bit unsigned integer.</summary>
+		U16,
+		/// <summary>8 bit unsigned integer.</summary>
+		U8,
+		/// <summary>16 bit unsigned integer, normalized to 0-1 on the GPU.</summary>
+		U16Normalized,
+		/// <summary>8 bit unsigned integer, normalized to 0-1 on the GPU. A color32 is
+		/// 4 of these.</summary>
+		U8Normalized,
+	}
+
+	/// <summary>What a vertex component means! This is matched against the semantics
+	/// the shader's vertex inputs declare, so component order in a format
+	/// doesn't need to match the shader's input order.</summary>
+	public enum VertSemantic {
+		/// <summary>Invalid semantic, this is not a valid value for a component.</summary>
+		None         = 0,
+		/// <summary>Vertex position, in model space coordinates.</summary>
+		Position,
+		/// <summary>Direction the vertex is facing.</summary>
+		Normal,
+		/// <summary>Texture coordinates.</summary>
+		Texcoord,
+		/// <summary>Vertex color.</summary>
+		Color,
+		/// <summary>Tangent direction for normal mapping.</summary>
+		Tangent,
+		/// <summary>Binormal/bitangent direction for normal mapping.</summary>
+		Binormal,
+		/// <summary>Bone weights for skinning.</summary>
+		Blendweight,
+		/// <summary>Bone indices for skinning.</summary>
+		Blendindices,
+		/// <summary>Point size for point rendering.</summary>
+		Psize,
+	}
+
 	/// <summary>Culling is discarding an object from the render pipeline!
 	/// This enum describes how mesh faces get discarded on the graphics
 	/// card. With culling set to none, you can double the number of pixels

--- a/StereoKit/Native/NativeTypes.Custom.cs
+++ b/StereoKit/Native/NativeTypes.Custom.cs
@@ -196,8 +196,32 @@ namespace StereoKit
 		public DisplayBlend displayType { get => DisplayBlend.None;  set { } }
 	}
 
+	// Hand-written mirror of the C header's vert_t (@noimpl in APIGen) so
+	// the fields can carry VertComponent attributes. The doc comments here
+	// are duplicated from stereokit.h, keep them in sync!
+	/// <summary>This represents a single vertex in a Mesh, all StereoKit Meshes
+	/// currently use this exact layout!
+	/// It's good to fill out all values of a Vertex explicitly, as default
+	/// values for the normal (0,0,0) and color (0,0,0,0) will cause your
+	/// mesh to appear completely black, or even transparent in most shaders!</summary>
+	[StructLayout(LayoutKind.Sequential)]
 	public partial struct Vertex
 	{
+		/// <summary>Position of the vertex, in model space coordinates.</summary>
+		[VertComponent(VertSemantic.Position, VertFmt.F32, 3)]
+		public Vec3 pos;
+		/// <summary>The normal of this vertex, or the direction the vertex is
+		/// facing. Preferably normalized.</summary>
+		[VertComponent(VertSemantic.Normal, VertFmt.F32, 3)]
+		public Vec3 norm;
+		/// <summary>The texture coordinates at this vertex.</summary>
+		[VertComponent(VertSemantic.Texcoord, VertFmt.F32, 2)]
+		public Vec2 uv;
+		/// <summary>The color of the vertex. If you aren't using it, set it to
+		/// white.</summary>
+		[VertComponent(VertSemantic.Color, VertFmt.U8Normalized, 4)]
+		public Color32 col;
+
 		/// <summary>Create a new Vertex, use the overloads to take advantage
 		/// of default values. Vertex color defaults to White. UV defaults to
 		/// (0,0).</summary>
@@ -619,6 +643,53 @@ namespace StereoKit
 		/// <returns>An equivalent Pivot.</returns>
 		[Obsolete("Use Pivot instead")]
 		public static implicit operator Pivot(TextAlign a) => (Pivot)a;
+	}
+
+	/// <summary>A single component of a custom vertex layout, such as a
+	/// position or a UV coordinate. A vertex format is described by an array
+	/// of these, in the same order the components appear in the vertex data.
+	/// Data is always tightly packed, aligned to nothing, so the format
+	/// fully describes the vertex layout.
+	///
+	/// This maps to a compact 4 byte native representation, the properties
+	/// here disguise that byte packing.</summary>
+	[StructLayout(LayoutKind.Sequential)]
+	public struct VertComponent
+	{
+		private byte _format;
+		private byte _count;
+		private byte _semantic;
+		private byte _semanticSlot;
+
+		/// <summary>The data format of a single element of this component.
+		/// </summary>
+		public VertFmt      Format       { get => (VertFmt)_format;        set => _format       = (byte)value; }
+		/// <summary>How many format elements this component has, 1-4. A
+		/// float3 position would be 3.</summary>
+		public int          Count        { get => _count;                  set => _count        = (byte)value; }
+		/// <summary>What this component means, this is matched with the
+		/// shader's vertex input semantics.</summary>
+		public VertSemantic Semantic     { get => (VertSemantic)_semantic; set => _semantic     = (byte)value; }
+		/// <summary>Distinguishes multiple components with the same semantic,
+		/// like TEXCOORD0 vs TEXCOORD1. Usually 0.</summary>
+		public int          SemanticSlot { get => _semanticSlot;           set => _semanticSlot = (byte)value; }
+
+		/// <summary>Describes a single vertex component.</summary>
+		/// <param name="semantic">What this component means, this is matched
+		/// with the shader's vertex input semantics.</param>
+		/// <param name="format">The data format of a single element of this
+		/// component.</param>
+		/// <param name="count">How many format elements this component has,
+		/// 1-4. A float3 position would be 3.</param>
+		/// <param name="semanticSlot">Distinguishes multiple components with
+		/// the same semantic, like TEXCOORD0 vs TEXCOORD1.</param>
+		public VertComponent(VertSemantic semantic, VertFmt format, int count, int semanticSlot = 0)
+		{
+			_format       = (byte)format;
+			_count        = (byte)count;
+			_semantic     = (byte)semantic;
+			_semanticSlot = (byte)semanticSlot;
+		}
 	}
 
 }

--- a/StereoKit/Native/NativeTypes.cs
+++ b/StereoKit/Native/NativeTypes.cs
@@ -57,26 +57,6 @@ namespace StereoKit
 		public float bottom;
 	}
 
-	/// <summary>This represents a single vertex in a Mesh, all StereoKit Meshes
-	/// currently use this exact layout!
-	/// It's good to fill out all values of a Vertex explicitly, as default
-	/// values for the normal (0,0,0) and color (0,0,0,0) will cause your
-	/// mesh to appear completely black, or even transparent in most shaders!</summary>
-	[StructLayout(LayoutKind.Sequential)]
-	public partial struct Vertex
-	{
-		/// <summary>Position of the vertex, in model space coordinates.</summary>
-		public Vec3 pos;
-		/// <summary>The normal of this vertex, or the direction the vertex is
-		/// facing. Preferably normalized.</summary>
-		public Vec3 norm;
-		/// <summary>The texture coordinates at this vertex.</summary>
-		public Vec2 uv;
-		/// <summary>The color of the vertex. If you aren't using it, set it to
-		/// white.</summary>
-		public Color32 col;
-	}
-
 	/// <summary>Used to represent lines for the line drawing functions! This is
 	/// just a snapshot of information about each individual point on a line.</summary>
 	[StructLayout(LayoutKind.Sequential)]

--- a/StereoKitC/asset_types/mesh.cpp
+++ b/StereoKitC/asset_types/mesh.cpp
@@ -5,6 +5,7 @@
 #include "mesh.h"
 #include "assets.h"
 #include "../systems/render.h"
+#include "../systems/vert_format.h"
 
 #include <stdio.h>
 #include <string.h>
@@ -18,6 +19,24 @@ using namespace DirectX;
 namespace sk {
 
 void mesh_update_label(mesh_t mesh);
+// Calculates bounds via the format's position component, which must be a
+// float3 for this to succeed.
+static bool mesh_calculate_bounds(int32_t format_id, const void* verts, int32_t vert_count, bounds_t* out_bounds);
+
+///////////////////////////////////////////
+
+// Unaligned safe vec3 load/store, packed vertex formats can put float
+// components at any byte offset. The memcpy compiles to plain loads.
+static inline XMVECTOR xm_load_v3 (const void* at) {
+	XMFLOAT3 v;
+	memcpy(&v, at, sizeof(v));
+	return XMLoadFloat3(&v);
+}
+static inline void     xm_store_v3(void* at, XMVECTOR value) {
+	XMFLOAT3 v;
+	XMStoreFloat3(&v, value);
+	memcpy(at, &v, sizeof(v));
+}
 
 ///////////////////////////////////////////
 
@@ -42,21 +61,38 @@ bool32_t mesh_get_keep_data(mesh_t mesh) {
 
 ///////////////////////////////////////////
 
-void _mesh_set_verts(mesh_t mesh, const vert_t *vertices, uint32_t vertex_count, bool32_t calculate_bounds, bool update_original) {
+// Shared vertex upload path for both vert_t and custom format meshes. The
+// mesh manages its own reference to format_id here, callers keep theirs.
+static void _mesh_set_verts(mesh_t mesh, const void *vertices, uint32_t vertex_count, int32_t format_id, bool32_t calculate_bounds, bool update_original) {
 	if (mesh->header.state >= asset_state_loaded && mesh->vert_count == 0) {
 		log_diagf("mesh_set_verts: Setting verts after mesh is already loaded. For best results, set verts before inds. (%s)", mesh->header.id_text);
 	}
 
-	// Assign default vertex type when vertex data is first provided
-	mesh->gpu_mesh.vert_type = render_get_default_vert();
+	uint32_t stride = vert_format_get_stride(format_id);
+
+	// Swap the mesh's format reference if it changed. Skinned meshes can't
+	// change format, their deformed copy and weights pair with the current
+	// format's stride and vertex order.
+	if (format_id != mesh->vert_format) {
+		if (mesh_has_skin(mesh)) {
+			log_err("mesh_set_verts: can't change the vertex format of a mesh with skinning data");
+			return;
+		}
+		vert_format_addref (format_id);
+		vert_format_release(mesh->vert_format);
+		mesh->vert_format = format_id;
+	}
+	mesh->vert_stride        = stride;
+	mesh->gpu_mesh.vert_type = vert_format_get_skr(format_id);
 
 	// Keep track of vertex data for use on CPU side
 	if (!mesh->discard_data && update_original) {
-		if (mesh->vert_capacity < vertex_count) {
-			mesh->verts         = sk_realloc_t(vert_t, mesh->verts, vertex_count);
-			mesh->vert_capacity = vertex_count;
+		uint32_t bytes = vertex_count * stride;
+		if (mesh->vert_capacity_bytes < bytes) {
+			mesh->verts               = (vert_t*)sk_realloc(mesh->verts, bytes);
+			mesh->vert_capacity_bytes = bytes;
 		}
-		memcpy(mesh->verts, vertices, sizeof(vert_t) * vertex_count);
+		memcpy(mesh->verts, vertices, bytes);
 	}
 
 	// skr_mesh_set_verts handles static-to-dynamic conversion and resizing internally
@@ -71,9 +107,11 @@ void _mesh_set_verts(mesh_t mesh, const vert_t *vertices, uint32_t vertex_count,
 	mesh->vert_count = vertex_count;
 
 	if (calculate_bounds && vertex_count > 0) {
-		mesh->bounds = mesh_calculate_bounds(vertices, vertex_count);
+		if (!mesh_calculate_bounds(format_id, vertices, vertex_count, &mesh->bounds))
+			log_warnf("mesh_set_verts: can't calculate bounds without a float3 position component (%s)", mesh->header.id_text);
 	}
 }
+
 ///////////////////////////////////////////
 
 void mesh_set_verts(mesh_t mesh, const vert_t *vertices, int32_t vertex_count, bool32_t calculate_bounds) {
@@ -87,23 +125,85 @@ void mesh_set_verts(mesh_t mesh, const vert_t *vertices, int32_t vertex_count, b
 
 	assets_execute_blocking([](void *data) {
 		vert_upload_job_t *job_data = (vert_upload_job_t *)data;
-		_mesh_set_verts(job_data->mesh, job_data->vertices, job_data->vertex_count, job_data->calculate_bounds, true);
-		
+		_mesh_set_verts(job_data->mesh, job_data->vertices, job_data->vertex_count, VERT_FORMAT_DEFAULT, job_data->calculate_bounds, true);
+
 		return (bool32_t)true;
 	}, &job_data);
 }
 
 ///////////////////////////////////////////
 
+void mesh_set_verts_fmt(mesh_t mesh, const vert_component_t *format, int32_t component_count, const void *vertex_data, int32_t vertex_count, bool32_t calculate_bounds) {
+	int32_t format_id = vert_format_ref(format, component_count);
+	if (format_id < 0) return;
+	if (format_id != mesh->vert_format && mesh_has_skin(mesh)) {
+		log_err("mesh_set_verts_fmt: can't change the vertex format of a mesh with skinning data");
+		vert_format_release(format_id);
+		return;
+	}
+
+	struct vert_fmt_upload_job_t {
+		mesh_t      mesh;
+		const void *vertices;
+		int32_t     vertex_count;
+		int32_t     format_id;
+		bool32_t    calculate_bounds;
+	};
+	vert_fmt_upload_job_t job_data = {mesh, vertex_data, vertex_count, format_id, calculate_bounds};
+
+	assets_execute_blocking([](void *data) {
+		vert_fmt_upload_job_t *job_data = (vert_fmt_upload_job_t *)data;
+		_mesh_set_verts(job_data->mesh, job_data->vertices, job_data->vertex_count, job_data->format_id, job_data->calculate_bounds, true);
+
+		return (bool32_t)true;
+	}, &job_data);
+
+	vert_format_release(format_id);
+}
+
+///////////////////////////////////////////
+
 void mesh_get_verts(mesh_t mesh, vert_t *&out_vertices, int32_t &out_vertex_count, memory_ reference_mode) {
-	out_vertex_count = mesh->verts == nullptr ? 0 : mesh->vert_count;
+	out_vertex_count = 0;
 	out_vertices     = nullptr;
-	
+
+	if (mesh->vert_format != VERT_FORMAT_DEFAULT) {
+		log_warn("mesh_get_verts: this mesh uses a custom vertex format, use mesh_get_verts_fmt instead");
+		return;
+	}
+	out_vertex_count = mesh->verts == nullptr ? 0 : mesh->vert_count;
+
 	if (reference_mode == memory_copy && mesh->verts != nullptr && mesh->vert_count > 0) {
 		out_vertices = sk_malloc_t(vert_t, mesh->vert_count);
 		memcpy(out_vertices, mesh->verts, sizeof(vert_t) * mesh->vert_count);
 	} else if (reference_mode == memory_reference) {
 		out_vertices = mesh->verts;
+	}
+}
+
+///////////////////////////////////////////
+
+void mesh_get_verts_fmt(mesh_t mesh, vert_component_t **out_format, int32_t *out_component_count, void **out_vertex_data, int32_t *out_vertex_count, memory_ reference_mode) {
+	*out_format          = nullptr;
+	*out_component_count = 0;
+	*out_vertex_data     = nullptr;
+	*out_vertex_count    = mesh->verts == nullptr ? 0 : mesh->vert_count;
+
+	int32_t                 component_count = 0;
+	const vert_component_t* components      = vert_format_get_components(mesh->vert_format, &component_count);
+	*out_component_count = component_count;
+
+	if (reference_mode == memory_copy) {
+		*out_format = sk_malloc_t(vert_component_t, component_count);
+		memcpy(*out_format, components, sizeof(vert_component_t) * component_count);
+		if (mesh->verts != nullptr && mesh->vert_count > 0) {
+			uint32_t bytes = mesh->vert_count * mesh->vert_stride;
+			*out_vertex_data = sk_malloc(bytes);
+			memcpy(*out_vertex_data, mesh->verts, bytes);
+		}
+	} else if (reference_mode == memory_reference) {
+		*out_format      = (vert_component_t*)components;
+		*out_vertex_data = mesh->verts;
 	}
 }
 
@@ -169,10 +269,11 @@ void mesh_set_inds(mesh_t mesh, const vind_t *indices,  int32_t index_count) {
 ///////////////////////////////////////////
 
 struct mesh_load_t {
-	vert_t*  verts;
+	void*    verts;
 	vind_t*  inds;
 	int32_t  vert_count;
 	int32_t  ind_count;
+	int32_t  vert_format; // load holds its own registry ref
 	bool32_t calc_bounds;
 };
 
@@ -181,7 +282,8 @@ static bool32_t mesh_load_process(asset_task_t*, asset_header_t* asset, void *da
 	mesh_load_t* load = (mesh_load_t*)data;
 
 	if (load->calc_bounds && load->vert_count > 0) {
-		mesh->bounds = mesh_calculate_bounds(load->verts, load->vert_count);
+		if (!mesh_calculate_bounds(load->vert_format, load->verts, load->vert_count, &mesh->bounds))
+			log_warnf("mesh_set_data: can't calculate bounds without a float3 position component (%s)", mesh->header.id_text);
 	}
 
 	mesh->header.state = asset_state_loaded_meta;
@@ -204,14 +306,14 @@ static bool32_t mesh_load_upload(asset_task_t*, asset_header_t* asset, void *dat
 	// Upload from load's data, then hand ownership to the mesh or
 	// discard. The load task exclusively owns verts/inds until this
 	// point, so there's no race with the main thread for those.
-	if (load->vert_count > 0) _mesh_set_verts(mesh, load->verts, load->vert_count, false, false);
-	if (load->ind_count  > 0) _mesh_set_inds (mesh, load->inds,  load->ind_count);
+	if (load->vert_count > 0) _mesh_set_verts(mesh, load->verts, load->vert_count, load->vert_format, false, false);
+	if (load->ind_count  > 0) _mesh_set_inds     (mesh, load->inds,  load->ind_count);
 
 	if (!mesh->discard_data) {
-		mesh->verts         = load->verts;
-		mesh->vert_capacity = load->vert_count;
-		mesh->inds          = load->inds;
-		mesh->ind_capacity  = load->ind_count;
+		mesh->verts               = (vert_t*)load->verts;
+		mesh->vert_capacity_bytes = load->vert_count * vert_format_get_stride(load->vert_format);
+		mesh->inds                = load->inds;
+		mesh->ind_capacity        = load->ind_count;
 
 		load->verts = nullptr;
 		load->inds  = nullptr;
@@ -222,6 +324,7 @@ static bool32_t mesh_load_upload(asset_task_t*, asset_header_t* asset, void *dat
 
 static void mesh_load_free(asset_header_t*, void *data) {
 	mesh_load_t* load = (mesh_load_t*)data;
+	vert_format_release(load->vert_format);
 	sk_free(load->verts);
 	sk_free(load->inds);
 	sk_free(load);
@@ -233,30 +336,39 @@ static void mesh_load_on_failure(asset_header_t* asset, void *) {
 
 ///////////////////////////////////////////
 
-void mesh_set_data(mesh_t mesh, const vert_t* vertices, int32_t vertex_count, const vind_t* indices, int32_t index_count, mesh_data_ flags, int32_t priority) {
+// Shared implementation for default and custom format data uploads, the
+// caller keeps its own reference to format_id.
+static void _mesh_set_data(mesh_t mesh, int32_t format_id, const void* vertices, int32_t vertex_count, const vind_t* indices, int32_t index_count, mesh_data_ flags, int32_t priority) {
 	bool32_t calc_bounds = (flags & mesh_data_calc_bounds) != 0;
 
 	if (!(flags & mesh_data_async)) {
 		struct mesh_upload_job_t {
 			mesh_t        mesh;
-			const vert_t* vertices;
+			const void*   vertices;
 			int32_t       vertex_count;
 			const vind_t* indices;
 			int32_t       index_count;
+			int32_t       format_id;
 			bool32_t      calc_bounds;
 		};
-		mesh_upload_job_t job_data = {mesh, vertices, vertex_count, indices, index_count, calc_bounds};
+		mesh_upload_job_t job_data = {mesh, vertices, vertex_count, indices, index_count, format_id, calc_bounds};
 
 		assets_execute_blocking([](void *data) {
 			mesh_upload_job_t *job_data = (mesh_upload_job_t *)data;
-			if (job_data->vertex_count > 0) _mesh_set_verts(job_data->mesh, job_data->vertices, job_data->vertex_count, job_data->calc_bounds, true);
-			if (job_data->index_count  > 0) _mesh_set_inds (job_data->mesh, job_data->indices,  job_data->index_count);
+			if (job_data->vertex_count > 0) _mesh_set_verts(job_data->mesh, job_data->vertices, job_data->vertex_count, job_data->format_id, job_data->calc_bounds, true);
+			if (job_data->index_count  > 0) _mesh_set_inds     (job_data->mesh, job_data->indices,  job_data->index_count);
 			return (bool32_t)true;
 		}, &job_data);
 	} else {
 		mesh->header.state = asset_state_loading;
 		mesh->vert_count   = vertex_count;
 		mesh->ind_count    = index_count;
+
+		uint32_t stride = vert_format_get_stride(format_id);
+
+		// The load's format reference protects against the mesh's format
+		// being swapped from another thread mid-task.
+		vert_format_addref(format_id);
 
 		// The load task exclusively owns the vert/ind data until
 		// upload completes. mesh->verts/inds stay null during
@@ -266,9 +378,10 @@ void mesh_set_data(mesh_t mesh, const vert_t* vertices, int32_t vertex_count, co
 		load_data->calc_bounds = calc_bounds;
 		load_data->vert_count  = vertex_count;
 		load_data->ind_count   = index_count;
+		load_data->vert_format = format_id;
 		if (vertex_count > 0) {
-			load_data->verts = sk_malloc_t(vert_t, vertex_count);
-			memcpy(load_data->verts, vertices, sizeof(vert_t) * vertex_count);
+			load_data->verts = sk_malloc(vertex_count * stride);
+			memcpy(load_data->verts, vertices, vertex_count * stride);
 		}
 		if (index_count > 0) {
 			load_data->inds = sk_malloc_t(vind_t, index_count);
@@ -288,10 +401,32 @@ void mesh_set_data(mesh_t mesh, const vert_t* vertices, int32_t vertex_count, co
 		task.free_data    = mesh_load_free;
 		task.on_failure   = mesh_load_on_failure;
 		task.priority     = priority;
-		task.sort         = asset_sort(priority, asset_complexity_bytes(vertex_count * sizeof(vert_t) + index_count * sizeof(vind_t)));
+		task.sort         = asset_sort(priority, asset_complexity_bytes(vertex_count * stride + index_count * sizeof(vind_t)));
 
 		assets_add_task(task);
 	}
+}
+
+///////////////////////////////////////////
+
+void mesh_set_data(mesh_t mesh, const vert_t* vertices, int32_t vertex_count, const vind_t* indices, int32_t index_count, mesh_data_ flags, int32_t priority) {
+	_mesh_set_data(mesh, VERT_FORMAT_DEFAULT, vertices, vertex_count, indices, index_count, flags, priority);
+}
+
+///////////////////////////////////////////
+
+void mesh_set_data_fmt(mesh_t mesh, const vert_component_t* format, int32_t component_count, const void* vertex_data, int32_t vertex_count, const vind_t* indices, int32_t index_count, mesh_data_ flags, int32_t priority) {
+	int32_t format_id = vert_format_ref(format, component_count);
+	if (format_id < 0) return;
+	if (format_id != mesh->vert_format && mesh_has_skin(mesh)) {
+		log_err("mesh_set_data_fmt: can't change the vertex format of a mesh with skinning data");
+		vert_format_release(format_id);
+		return;
+	}
+
+	_mesh_set_data(mesh, format_id, vertex_data, vertex_count, indices, index_count, flags, priority);
+
+	vert_format_release(format_id);
 }
 
 ///////////////////////////////////////////
@@ -316,30 +451,74 @@ int32_t mesh_get_ind_count(mesh_t mesh) {
 
 ///////////////////////////////////////////
 
-void mesh_calculate_normals(vert_t *verts, int32_t vert_count, const vind_t *inds, int32_t ind_count) {
-	for (int32_t i = 0; i < vert_count; i++) verts[i].norm = vec3_zero;
-	for (int32_t i = 0; i < ind_count; i+=3) {
-		vert_t *v1 = &verts[inds[i  ]];
-		vert_t *v2 = &verts[inds[i+1]];
-		vert_t *v3 = &verts[inds[i+2]];
-		// Length of cross product is twice the area of the triangle it's 
-		// from, so if we don't 'normalize' it, then we get trangle area
-		// weighting on our normals for free!
-		vec3 normal = vec3_cross(v3->pos - v2->pos, v1->pos - v2->pos);
-		v1->norm += normal;
-		v2->norm += normal;
-		v3->norm += normal;
+bool mesh_calculate_normals(int32_t format_id, void *verts, int32_t vert_count, const vind_t *inds, int32_t ind_count) {
+	// This needs a position to read, and a normal to write back to.
+	vert_fmt_ pos_fmt  = vert_fmt_none, norm_fmt  = vert_fmt_none;
+	int32_t   pos_ct   = 0,             norm_ct   = 0;
+	int32_t   pos_off  = vert_format_semantic_offset(format_id, vert_semantic_position, 0, &pos_fmt,  &pos_ct);
+	int32_t   norm_off = vert_format_semantic_offset(format_id, vert_semantic_normal,   0, &norm_fmt, &norm_ct);
+	if (pos_off < 0 || norm_off < 0)
+		return false;
+
+	uint32_t stride = vert_format_get_stride(format_id);
+	uint8_t* data   = (uint8_t*)verts;
+
+	// Float positions read strided straight from the vertex data, other
+	// position formats decode into a dense scratch array first.
+	const uint8_t* pos_base   = data + pos_off;
+	uint32_t       pos_stride = stride;
+	XMFLOAT4*      scratch    = nullptr;
+	if (!(pos_fmt == vert_fmt_f32 && pos_ct >= 3)) {
+		scratch = sk_malloc_t(XMFLOAT4, vert_count);
+		for (int32_t i = 0; i < vert_count; i++) {
+			vec4 p = {};
+			vert_format_decode(format_id, data + i*stride, vert_semantic_position, 0, &p);
+			memcpy(&scratch[i], &p, sizeof(p));
+		}
+		pos_base   = (uint8_t*)scratch;
+		pos_stride = sizeof(XMFLOAT4);
 	}
-	for (int32_t i = 0; i < vert_count; i++) verts[i].norm = vec3_normalize(verts[i].norm);
+
+	// Normals accumulate in a dense 16 byte array, partial width stores
+	// into the vertices themselves would cripple the SIMD here.
+	XMFLOAT4* acc = sk_malloc_zero_t(XMFLOAT4, vert_count);
+	for (int32_t i = 0; i < ind_count; i+=3) {
+		vind_t   i1 = inds[i  ];
+		vind_t   i2 = inds[i+1];
+		vind_t   i3 = inds[i+2];
+		XMVECTOR p2 = xm_load_v3(pos_base + i2*pos_stride);
+		// Unnormalized cross product length is twice the triangle's area,
+		// which gives us area weighted normals for free!
+		XMVECTOR n  = XMVector3Cross(
+			XMVectorSubtract(xm_load_v3(pos_base + i3*pos_stride), p2),
+			XMVectorSubtract(xm_load_v3(pos_base + i1*pos_stride), p2));
+		XMStoreFloat4(&acc[i1], XMVectorAdd(XMLoadFloat4(&acc[i1]), n));
+		XMStoreFloat4(&acc[i2], XMVectorAdd(XMLoadFloat4(&acc[i2]), n));
+		XMStoreFloat4(&acc[i3], XMVectorAdd(XMLoadFloat4(&acc[i3]), n));
+	}
+
+	bool norm_direct = norm_fmt == vert_fmt_f32 && norm_ct == 3;
+	for (int32_t i = 0; i < vert_count; i++) {
+		XMFLOAT4 n;
+		XMStoreFloat4(&n, XMVector3Normalize(XMLoadFloat4(&acc[i])));
+		if (norm_direct) memcpy(data + i*stride + norm_off, &n, sizeof(vec3));
+		else             vert_format_encode(format_id, data + i*stride, vert_semantic_normal, 0, vec4{n.x, n.y, n.z, 0});
+	}
+
+	sk_free(scratch);
+	sk_free(acc);
+	return true;
 }
 
 ///////////////////////////////////////////
 
-bounds_t mesh_calculate_bounds(const vert_t* verts, int32_t vert_count) {
+static bounds_t mesh_calculate_bounds_strided(const void* verts, int32_t vert_count, int32_t stride, int32_t position_offset) {
 	// Calculate the bounds for this mesh by searching it for min and max
 	// values! This uses DirectXMath's SIMD capabilities, and uses multiple
 	// separate accumulators to reduce operation dependencies.
-	XMVECTOR min_a = XMLoadFloat3((XMFLOAT3*)&verts[0].pos);
+	const uint8_t* pos = (const uint8_t*)verts + position_offset;
+
+	XMVECTOR min_a = xm_load_v3(pos);
 	XMVECTOR min_b = min_a;
 	XMVECTOR min_c = min_a;
 	XMVECTOR min_d = min_a;
@@ -348,27 +527,27 @@ bounds_t mesh_calculate_bounds(const vert_t* verts, int32_t vert_count) {
 	XMVECTOR max_c = min_a;
 	XMVECTOR max_d = min_a;
 
-	const vert_t* curr = verts;
+	const uint8_t* curr = pos;
 	for (int32_t i = 0; i < vert_count/4; i++) {
-		XMVECTOR pt_a = XMLoadFloat3((XMFLOAT3*)&curr[0].pos);
+		XMVECTOR pt_a = xm_load_v3(curr           );
 		min_a = XMVectorMin(min_a, pt_a);
 		max_a = XMVectorMax(max_a, pt_a);
-		XMVECTOR pt_b = XMLoadFloat3((XMFLOAT3*)&curr[1].pos);
+		XMVECTOR pt_b = xm_load_v3(curr + stride  );
 		min_b = XMVectorMin(min_b, pt_b);
 		max_b = XMVectorMax(max_b, pt_b);
-		XMVECTOR pt_c = XMLoadFloat3((XMFLOAT3*)&curr[2].pos);
+		XMVECTOR pt_c = xm_load_v3(curr + stride*2);
 		min_c = XMVectorMin(min_c, pt_c);
 		max_c = XMVectorMax(max_c, pt_c);
-		XMVECTOR pt_d = XMLoadFloat3((XMFLOAT3*)&curr[3].pos);
+		XMVECTOR pt_d = xm_load_v3(curr + stride*3);
 		min_d = XMVectorMin(min_d, pt_d);
 		max_d = XMVectorMax(max_d, pt_d);
-		curr += 4;
+		curr += stride*4;
 	}
 	for (int32_t i = (vert_count / 4) * 4; i < vert_count; i++) {
-		XMVECTOR pt_a = XMLoadFloat3((XMFLOAT3*)&curr[0].pos);
+		XMVECTOR pt_a = xm_load_v3(curr);
 		min_a = XMVectorMin(min_a, pt_a);
 		max_a = XMVectorMax(max_a, pt_a);
-		curr += 1;
+		curr += stride;
 	}
 
 	XMVECTOR min = XMVectorMin(min_a, min_b);
@@ -385,6 +564,19 @@ bounds_t mesh_calculate_bounds(const vert_t* verts, int32_t vert_count) {
 	XMStoreFloat3((XMFLOAT3*)&bounds.dimensions, dimensions);
 
 	return bounds;
+}
+
+///////////////////////////////////////////
+
+static bool mesh_calculate_bounds(int32_t format_id, const void* verts, int32_t vert_count, bounds_t* out_bounds) {
+	vert_fmt_ pos_fmt   = vert_fmt_none;
+	int32_t   pos_count = 0;
+	int32_t   pos_off   = vert_format_semantic_offset(format_id, vert_semantic_position, 0, &pos_fmt, &pos_count);
+	if (pos_off < 0 || pos_fmt != vert_fmt_f32 || pos_count < 3)
+		return false;
+
+	*out_bounds = mesh_calculate_bounds_strided(verts, vert_count, vert_format_get_stride(format_id), pos_off);
+	return true;
 }
 
 ///////////////////////////////////////////
@@ -448,10 +640,12 @@ void _mesh_set_weights(mesh_t mesh, const uint16_t* bone_ids_4, int32_t bone_id_
 		mesh->skin_data.bone_data[i].weight[1] = weight[1];
 		mesh->skin_data.bone_data[i].weight[2] = weight[2];
 		mesh->skin_data.bone_data[i].weight[3] = weight[3];
-		mesh->skin_data.bone_data[i].bone_id[0] = bone_ids_4[i * 4 + 0];
-		mesh->skin_data.bone_data[i].bone_id[1] = bone_ids_4[i * 4 + 1];
-		mesh->skin_data.bone_data[i].bone_id[2] = bone_ids_4[i * 4 + 2];
-		mesh->skin_data.bone_data[i].bone_id[3] = bone_ids_4[i * 4 + 3];
+		// Zero weight slots still get their palette entry read by the
+		// branchless blend in mesh_update_skin, keep their ids valid.
+		mesh->skin_data.bone_data[i].bone_id[0] = weight[0] > 0 ? bone_ids_4[i * 4 + 0] : 0;
+		mesh->skin_data.bone_data[i].bone_id[1] = weight[1] > 0 ? bone_ids_4[i * 4 + 1] : 0;
+		mesh->skin_data.bone_data[i].bone_id[2] = weight[2] > 0 ? bone_ids_4[i * 4 + 2] : 0;
+		mesh->skin_data.bone_data[i].bone_id[3] = weight[3] > 0 ? bone_ids_4[i * 4 + 3] : 0;
 	}
 }
 
@@ -466,12 +660,22 @@ bool _mesh_set_skin(mesh_t mesh, const bone_weight_t *bone_weights, uint32_t bon
 		log_err("mesh_set_skin: mesh has no vertex data, ensure mesh data is loaded before setting skin");
 		return false;
 	}
+	if (vert_format_semantic_offset(mesh->vert_format, vert_semantic_position, 0, nullptr, nullptr) < 0) {
+		log_err("mesh_set_skin: the mesh's vertex format has no position component");
+		return false;
+	}
 
 	mesh->skin_data.bone_data      = sk_malloc_t(bone_weight_t, bone_weight_count);
-	mesh->skin_data.deformed_verts = sk_malloc_t(vert_t,        mesh->vert_count);
-	memcpy(mesh->skin_data.deformed_verts, mesh->verts, sizeof(vert_t) * mesh->vert_count);
-	if (bone_weights != nullptr)
+	mesh->skin_data.deformed_verts = sk_malloc(mesh->vert_count * mesh->vert_stride);
+	memcpy(mesh->skin_data.deformed_verts, mesh->verts, mesh->vert_count * mesh->vert_stride);
+	if (bone_weights != nullptr) {
 		memcpy(mesh->skin_data.bone_data, bone_weights, sizeof(bone_weight_t) * bone_weight_count);
+		// Zero weight slots still get their palette entry read by the
+		// branchless blend in mesh_update_skin, keep their ids valid.
+		for (uint32_t i = 0; i < bone_weight_count; i++)
+			for (int32_t k = 0; k < 4; k++)
+				if (mesh->skin_data.bone_data[i].weight[k] == 0) mesh->skin_data.bone_data[i].bone_id[k] = 0;
+	}
 
 	mesh->skin_data.bone_inverse_transforms = sk_malloc_t(matrix, bone_count);
 	mesh->skin_data.bone_transforms         = sk_malloc_t(matrix, bone_count);
@@ -514,43 +718,74 @@ void mesh_update_skin(mesh_t mesh, const matrix *bone_transforms, int32_t bone_c
 		mesh->skin_data.bone_transforms[i] = mesh->skin_data.bone_inverse_transforms[i] * bone_transforms[i];
 	}
 
+	// Positions and normals read and write through the mesh's vertex
+	// format, float components directly, anything else via the codec.
+	vert_fmt_ pos_fmt  = vert_fmt_none, norm_fmt  = vert_fmt_none;
+	int32_t   pos_ct   = 0,             norm_ct   = 0;
+	int32_t   pos_off  = vert_format_semantic_offset(mesh->vert_format, vert_semantic_position, 0, &pos_fmt,  &pos_ct);
+	int32_t   norm_off = vert_format_semantic_offset(mesh->vert_format, vert_semantic_normal,   0, &norm_fmt, &norm_ct);
+	bool      pos_f32  = pos_fmt  == vert_fmt_f32 && pos_ct  >= 3;
+	bool      norm_f32 = norm_fmt == vert_fmt_f32 && norm_ct == 3;
+	uint32_t  stride   = mesh->vert_stride;
+	const uint8_t* rest = (const uint8_t*)mesh->verts;
+	uint8_t*       def  = (      uint8_t*)mesh->skin_data.deformed_verts;
+
 	XMFLOAT3 xmmin = {  FLT_MAX,   FLT_MAX,   FLT_MAX };
 	XMFLOAT3 xmmax = { -FLT_MAX,  -FLT_MAX,  -FLT_MAX };
 	XMVECTOR min   = XMLoadFloat3(&xmmin);
 	XMVECTOR max   = XMLoadFloat3(&xmmax);
 	for (uint32_t i = 0; i < mesh->vert_count; i++) {
-		XMVECTOR pos  = XMLoadFloat3((XMFLOAT3 *)&mesh->verts[i].pos);
-		XMVECTOR norm = XMLoadFloat3((XMFLOAT3 *)&mesh->verts[i].norm);
-		XMVECTOR new_pos, new_norm;
-
+		XMVECTOR pos, norm;
+		if (pos_f32) {
+			pos = xm_load_v3(rest + i*stride + pos_off);
+		} else {
+			vec4 p = {};
+			vert_format_decode(mesh->vert_format, rest + i*stride, vert_semantic_position, 0, &p);
+			pos = XMLoadFloat4((const XMFLOAT4*)&p);
+		}
+		if (norm_f32) {
+			norm = xm_load_v3(rest + i*stride + norm_off);
+		} else if (norm_off >= 0) {
+			vec4 n = {};
+			vert_format_decode(mesh->vert_format, rest + i*stride, vert_semantic_normal, 0, &n);
+			norm = XMLoadFloat4((const XMFLOAT4*)&n);
+		} else {
+			norm = XMVectorZero();
+		}
+		// Blend the bone matrices unconditionally, then transform once.
+		// Zero weights contribute nothing, and mispredictable early-exit
+		// branches here cost more than the math they skip (~2x).
 		const bone_weight_t *bone = &mesh->skin_data.bone_data[i];
-
-		{
-			float w = bone->weight[0] / 255.0f;
-			XMMATRIX xm0 = XMLoadFloat4x4((XMFLOAT4X4*)&mesh->skin_data.bone_transforms[bone->bone_id[0]]);
-			new_pos      =             XMVectorScale(XMVector3Transform      (pos,  xm0), w);
-			new_norm     =             XMVectorScale(XMVector3TransformNormal(norm, xm0), w);
+		const matrix* pal = mesh->skin_data.bone_transforms;
+		XMMATRIX m0 = XMLoadFloat4x4((XMFLOAT4X4*)&pal[bone->bone_id[0]]);
+		XMMATRIX m1 = XMLoadFloat4x4((XMFLOAT4X4*)&pal[bone->bone_id[1]]);
+		XMMATRIX m2 = XMLoadFloat4x4((XMFLOAT4X4*)&pal[bone->bone_id[2]]);
+		XMMATRIX m3 = XMLoadFloat4x4((XMFLOAT4X4*)&pal[bone->bone_id[3]]);
+		float    w0 = bone->weight[0] * (1.0f/255.0f);
+		float    w1 = bone->weight[1] * (1.0f/255.0f);
+		float    w2 = bone->weight[2] * (1.0f/255.0f);
+		float    w3 = bone->weight[3] * (1.0f/255.0f);
+		XMMATRIX m;
+		m.r[0] = XMVectorAdd(XMVectorAdd(XMVectorScale(m0.r[0], w0), XMVectorScale(m1.r[0], w1)), XMVectorAdd(XMVectorScale(m2.r[0], w2), XMVectorScale(m3.r[0], w3)));
+		m.r[1] = XMVectorAdd(XMVectorAdd(XMVectorScale(m0.r[1], w0), XMVectorScale(m1.r[1], w1)), XMVectorAdd(XMVectorScale(m2.r[1], w2), XMVectorScale(m3.r[1], w3)));
+		m.r[2] = XMVectorAdd(XMVectorAdd(XMVectorScale(m0.r[2], w0), XMVectorScale(m1.r[2], w1)), XMVectorAdd(XMVectorScale(m2.r[2], w2), XMVectorScale(m3.r[2], w3)));
+		m.r[3] = XMVectorAdd(XMVectorAdd(XMVectorScale(m0.r[3], w0), XMVectorScale(m1.r[3], w1)), XMVectorAdd(XMVectorScale(m2.r[3], w2), XMVectorScale(m3.r[3], w3)));
+		XMVECTOR new_pos  = XMVector3Transform      (pos,  m);
+		XMVECTOR new_norm = XMVector3TransformNormal(norm, m);
+		if (pos_f32) {
+			xm_store_v3(def + i*stride + pos_off, new_pos);
+		} else {
+			XMFLOAT4 p;
+			XMStoreFloat4(&p, new_pos);
+			vert_format_encode(mesh->vert_format, def + i*stride, vert_semantic_position, 0, vec4{p.x, p.y, p.z, 0});
 		}
-		if (bone->weight[1] != 0) {
-			float w = bone->weight[1] / 255.0f;
-			XMMATRIX xm1 = XMLoadFloat4x4((XMFLOAT4X4*)&mesh->skin_data.bone_transforms[bone->bone_id[1]]);
-			new_pos      = XMVectorAdd(XMVectorScale(XMVector3Transform      (pos,  xm1), w), new_pos);
-			new_norm     = XMVectorAdd(XMVectorScale(XMVector3TransformNormal(norm, xm1), w), new_norm);
+		if (norm_f32) {
+			xm_store_v3(def + i*stride + norm_off, new_norm);
+		} else if (norm_off >= 0) {
+			XMFLOAT4 n;
+			XMStoreFloat4(&n, new_norm);
+			vert_format_encode(mesh->vert_format, def + i*stride, vert_semantic_normal, 0, vec4{n.x, n.y, n.z, 0});
 		}
-		if (bone->weight[2] != 0) {
-			float w = bone->weight[2] / 255.0f;
-			XMMATRIX xm2 = XMLoadFloat4x4((XMFLOAT4X4*)&mesh->skin_data.bone_transforms[bone->bone_id[2]]);
-			new_pos      = XMVectorAdd(XMVectorScale(XMVector3Transform      (pos,  xm2), w), new_pos);
-			new_norm     = XMVectorAdd(XMVectorScale(XMVector3TransformNormal(norm, xm2), w), new_norm);
-		}
-		if (bone->weight[3] != 0) {
-			float w = bone->weight[3] / 255.0f;
-			XMMATRIX xm3 = XMLoadFloat4x4((XMFLOAT4X4*)&mesh->skin_data.bone_transforms[bone->bone_id[3]]);
-			new_pos      = XMVectorAdd(XMVectorScale(XMVector3Transform      (pos,  xm3), w), new_pos);
-			new_norm     = XMVectorAdd(XMVectorScale(XMVector3TransformNormal(norm, xm3), w), new_norm);
-		}
-		XMStoreFloat3((XMFLOAT3 *)&mesh->skin_data.deformed_verts[i].pos,  new_pos );
-		XMStoreFloat3((XMFLOAT3 *)&mesh->skin_data.deformed_verts[i].norm, new_norm);
 		min = XMVectorMin(min, new_pos);
 		max = XMVectorMax(max, new_pos);
 	}
@@ -558,7 +793,7 @@ void mesh_update_skin(mesh_t mesh, const matrix *bone_transforms, int32_t bone_c
 	XMVECTOR dimensions = XMVectorSubtract(max, min);
 	mesh->bounds.center     = math_fast_to_vec3(center);
 	mesh->bounds.dimensions = math_fast_to_vec3(dimensions);
-	_mesh_set_verts(mesh, mesh->skin_data.deformed_verts, mesh->vert_count, false, false);
+	_mesh_set_verts(mesh, mesh->skin_data.deformed_verts, mesh->vert_count, mesh->vert_format, false, false);
 }
 
 ///////////////////////////////////////////
@@ -624,6 +859,7 @@ void mesh_on_load_remove(mesh_t mesh, void (*on_load)(mesh_t mesh, void *context
 
 mesh_t mesh_create() {
 	mesh_t result = (_mesh_t*)assets_allocate(asset_type_mesh);
+	vert_format_addref(result->vert_format);
 	// Initialize gpu_mesh with empty vertex type — actual vertex format
 	// is assigned when vertex data is provided via mesh_set_verts.
 	// This allows index-only meshes for vertex-pulling (SV_VertexID).
@@ -640,6 +876,7 @@ mesh_t mesh_copy(mesh_t mesh) {
 	}
 
 	mesh_t result = (mesh_t)assets_allocate(asset_type_mesh);
+	vert_format_addref(result->vert_format);
 	result->gpu_mesh.vert_type  = render_get_default_vert();
 	result->gpu_mesh.ind_format = skr_index_fmt_u32;
 	result->bounds       = mesh->bounds;
@@ -649,7 +886,13 @@ mesh_t mesh_copy(mesh_t mesh) {
 	if (mesh->discard_data) {
 		log_err("mesh_copy not yet implemented for meshes with discard data set!");
 	} else {
-		mesh_set_verts(result, mesh->verts, mesh->vert_count, false);
+		if (mesh->vert_format == VERT_FORMAT_DEFAULT) {
+			mesh_set_verts(result, mesh->verts, mesh->vert_count, false);
+		} else {
+			int32_t                 component_count = 0;
+			const vert_component_t* components      = vert_format_get_components(mesh->vert_format, &component_count);
+			mesh_set_verts_fmt(result, components, component_count, mesh->verts, mesh->vert_count, false);
+		}
 		mesh_set_inds (result, mesh->inds,  mesh->ind_count);
 		if (mesh_has_skin(mesh))
 			mesh_set_skin_inv(result, mesh->skin_data.bone_data, mesh->vert_count, mesh->skin_data.bone_inverse_transforms, mesh->skin_data.bone_count);
@@ -666,11 +909,24 @@ const mesh_collision_t *mesh_get_collision_data(mesh_t mesh) {
 	if (mesh->discard_data)
 		return nullptr;
 
+	// Positions get extracted through the vertex format, so any format
+	// with a float3 position supports collision.
+	vert_fmt_ pos_fmt   = vert_fmt_none;
+	int32_t   pos_count = 0;
+	int32_t   pos_off   = vert_format_semantic_offset(mesh->vert_format, vert_semantic_position, 0, &pos_fmt, &pos_count);
+	if (pos_off < 0 || pos_fmt != vert_fmt_f32 || pos_count < 3) {
+		log_warn("mesh_get_collision_data: mesh collision requires a float3 position component");
+		return nullptr;
+	}
+	const uint8_t* pos    = (const uint8_t*)mesh->verts + pos_off;
+	uint32_t       stride = mesh->vert_stride;
+
 	mesh_collision_t &coll = mesh->collision_data;
 	coll.pts    = sk_malloc_t(vec3   , mesh->ind_count);
 	coll.planes = sk_malloc_t(plane_t, mesh->ind_count/3);
 
-	for (uint32_t i = 0; i < mesh->ind_count; i++) coll.pts[i] = mesh->verts[mesh->inds[i]].pos;
+	// memcpy tolerates the unaligned positions packed formats can produce
+	for (uint32_t i = 0; i < mesh->ind_count; i++) memcpy(&coll.pts[i], pos + mesh->inds[i]*stride, sizeof(vec3));
 
 	for (uint32_t i = 0; i < mesh->ind_count; i += 3) {
 		vec3    dir1   = coll.pts[i+1] - coll.pts[i];
@@ -691,6 +947,8 @@ const mesh_bvh_t *mesh_get_bvh_data(mesh_t mesh) {
 	if (mesh->discard_data)
 		return nullptr;
 
+	// The BVH builds from mesh_get_collision_data, so this handles custom
+	// vertex formats too, and comes back null when there's no position.
 	mesh->bvh_data = mesh_bvh_create(mesh, 16);
 
 	return mesh->bvh_data;
@@ -707,7 +965,10 @@ void mesh_release(mesh_t mesh) {
 ///////////////////////////////////////////
 
 void mesh_destroy(mesh_t mesh) {
+	// The gpu mesh's vert_type points into the format registry, destroy it
+	// before releasing what may be the format's last reference.
 	skr_mesh_destroy(&mesh->gpu_mesh);
+	vert_format_release(mesh->vert_format);
 	sk_free(mesh->verts);
 	sk_free(mesh->inds);
 	sk_free(mesh->collision_data.pts   );	// XXX doesn't this fail when no colldata has been created?
@@ -832,14 +1093,41 @@ bool32_t mesh_get_triangle(mesh_t mesh, uint32_t triangle_index, vert_t* a, vert
 		log_err("mesh_get_triangle: can't work with a mesh that doesn't keep data, ensure mesh_get_keep_data() is true");
 		return false;
 	}
-	if (mesh->ind_count > triangle_index) {
+	// Phrased to dodge overflow from a triangle_index near UINT32_MAX
+	if (mesh->ind_count < 3 || triangle_index > mesh->ind_count - 3)
+		return false;
+
+	if (mesh->vert_format == VERT_FORMAT_DEFAULT) {
 		*a = mesh->verts[mesh->inds[triangle_index]];
 		*b = mesh->verts[mesh->inds[triangle_index + 1]];
 		*c = mesh->verts[mesh->inds[triangle_index + 2]];
 		return true;
-	}else {
-		return false;
 	}
+
+	// Custom formats decode into vert_t, components the format doesn't
+	// have read as vert_create style defaults.
+	vert_t* out[3] = {a, b, c};
+	for (int32_t i = 0; i < 3; i++) {
+		const void* vert = (uint8_t*)mesh->verts + mesh->inds[triangle_index + i] * mesh->vert_stride;
+		vec4 pos  = {0,0,0,1};
+		vec4 norm = {0,1,0,0};
+		vec4 uv   = {0,0,0,0};
+		vec4 col  = {1,1,1,1};
+		vert_format_decode(mesh->vert_format, vert, vert_semantic_position, 0, &pos );
+		vert_format_decode(mesh->vert_format, vert, vert_semantic_normal,   0, &norm);
+		vert_format_decode(mesh->vert_format, vert, vert_semantic_texcoord, 0, &uv  );
+		vert_format_decode(mesh->vert_format, vert, vert_semantic_color,    0, &col );
+		*out[i] = vert_t{
+			{pos.x, pos.y, pos.z},
+			{norm.x, norm.y, norm.z},
+			{uv.x, uv.y},
+			color32{
+				(uint8_t)roundf(fmaxf(0, fminf(1, col.x)) * 255),
+				(uint8_t)roundf(fmaxf(0, fminf(1, col.y)) * 255),
+				(uint8_t)roundf(fmaxf(0, fminf(1, col.z)) * 255),
+				(uint8_t)roundf(fmaxf(0, fminf(1, col.w)) * 255) } };
+	}
+	return true;
 }
 
 ///////////////////////////////////////////

--- a/StereoKitC/asset_types/mesh.h
+++ b/StereoKitC/asset_types/mesh.h
@@ -15,7 +15,8 @@ struct mesh_weights_t {
 	bone_weight_t *bone_data;
 	matrix   *bone_inverse_transforms;
 	matrix   *bone_transforms;
-	vert_t   *deformed_verts;
+	// A full vertex buffer in the mesh's own vertex format and stride.
+	void     *deformed_verts;
 	int32_t   bone_count;
 };
 
@@ -25,10 +26,14 @@ struct _mesh_t {
 	uint32_t         ind_draw;
 	bounds_t         bounds;
 	bool32_t         discard_data;
+	// Vertex format registry id, VERT_FORMAT_DEFAULT means verts is vert_t
+	// data, anything else and verts is raw vert_stride sized vertices.
+	int32_t          vert_format;
+	uint32_t         vert_stride;
 	vert_t*          verts;
 	vind_t*          inds;
 	uint32_t         vert_count;
-	uint32_t         vert_capacity;
+	uint32_t         vert_capacity_bytes;
 	uint32_t         ind_count;
 	uint32_t         ind_capacity;
 	mesh_collision_t collision_data;

--- a/StereoKitC/asset_types/mesh_.h
+++ b/StereoKitC/asset_types/mesh_.h
@@ -15,8 +15,8 @@ struct bone_weight_t {
 };
 
 const mesh_collision_t* mesh_get_collision_data(mesh_t mesh);
-void                    mesh_calculate_normals (      vert_t *verts, int32_t vert_count, const vind_t *inds, int32_t ind_count);
-bounds_t                mesh_calculate_bounds  (const vert_t *verts, int32_t vert_count);
+// Requires a position and a normal in the format, returns false otherwise.
+bool                    mesh_calculate_normals (int32_t format_id, void *verts, int32_t vert_count, const vind_t *inds, int32_t ind_count);
 void                    mesh_set_skin_inv      (mesh_t mesh, const bone_weight_t* bone_weights, uint32_t bone_weight_count, const matrix* bone_resting_transforms_inverted, int32_t bone_count);
 
 } // namespace sk

--- a/StereoKitC/asset_types/model.cpp
+++ b/StereoKitC/asset_types/model.cpp
@@ -9,6 +9,7 @@
 #include "../sk_memory.h"
 #include "model.h"
 #include "mesh.h"
+#include "../systems/vert_format.h"
 #include "../libraries/stref.h"
 #include "../platforms/platform.h"
 
@@ -368,11 +369,24 @@ void model_recalculate_bounds_exact(model_t model) {
 
 		XMMATRIX      transform_model = XMLoadFloat4x4((XMFLOAT4X4*)&vis->transform_model.row);
 		const mesh_t  mesh            = vis->mesh;
-		const vert_t* verts           = mesh->verts;
 
-		if (verts != nullptr) {
+		// Positions read through the vertex format, so custom formats get
+		// exact bounds too. No readable position falls back to the mesh's
+		// precalculated bounds.
+		const uint8_t* pos_at = nullptr;
+		if (mesh->verts != nullptr) {
+			vert_fmt_ pos_fmt   = vert_fmt_none;
+			int32_t   pos_count = 0;
+			int32_t   pos_off   = vert_format_semantic_offset(mesh->vert_format, vert_semantic_position, 0, &pos_fmt, &pos_count);
+			if (pos_off >= 0 && pos_fmt == vert_fmt_f32 && pos_count >= 3)
+				pos_at = (const uint8_t*)mesh->verts + pos_off;
+		}
+
+		if (pos_at != nullptr) {
 			for (uint32_t i = 0; i < mesh->vert_count; i += 1) {
-				XMVECTOR pt = matrix_mul_pointx(transform_model, verts[i].pos);
+				vec3 p;
+				memcpy(&p, pos_at + i*mesh->vert_stride, sizeof(p));
+				XMVECTOR pt = matrix_mul_pointx(transform_model, p);
 
 				min = XMVectorMin(min, pt);
 				max = XMVectorMax(max, pt);

--- a/StereoKitC/asset_types/model_gltf.cpp
+++ b/StereoKitC/asset_types/model_gltf.cpp
@@ -11,6 +11,7 @@
 #include "model.h"
 #include "material.h"
 #include "mesh_.h"
+#include "../systems/vert_format.h"
 #include "texture_.h"
 #include "../sk_math.h"
 #include "../sk_memory.h"
@@ -481,7 +482,7 @@ mesh_t gltf_parsemesh(cgltf_mesh *mesh, int node_id, int primitive_id, const cha
 	}
 
 	if (!has_normals) {
-		mesh_calculate_normals(verts, vert_count, inds, (int32_t)ind_count);
+		mesh_calculate_normals(VERT_FORMAT_DEFAULT, verts, vert_count, inds, (int32_t)ind_count);
 	}
 
 	/*uint32_t* remap = sk_malloc_t(uint32_t, vert_count);

--- a/StereoKitC/asset_types/model_obj.cpp
+++ b/StereoKitC/asset_types/model_obj.cpp
@@ -1,5 +1,6 @@
 #include "model.h"
 #include "mesh_.h"
+#include "../systems/vert_format.h"
 #include "../libraries/stref.h"
 #include "../libraries/array.h"
 #include "../sk_memory.h"
@@ -101,7 +102,7 @@ static mesh_t obj_load_mesh(const void *file_data, const char *filename, int32_t
 	}
 
 	if (norms.count <= 0)
-		mesh_calculate_normals(&verts[0], verts.count, &faces[0], faces.count);
+		mesh_calculate_normals(VERT_FORMAT_DEFAULT, &verts[0], verts.count, &faces[0], faces.count);
 
 	mesh = mesh_create();
 	mesh_set_id  (mesh, id);

--- a/StereoKitC/platforms/platform.cpp
+++ b/StereoKitC/platforms/platform.cpp
@@ -12,6 +12,7 @@
 #include "../device.h"
 #include "../_stereokit.h"
 #include "../sk_memory.h"
+#include "../systems/vert_format.h"
 #include "../sk_math.h"
 #include "../log.h"
 #include "../libraries/stref.h"
@@ -165,6 +166,13 @@ bool platform_init() {
 	vk_extensions.free();
 	if (!skr_result) {
 		log_fail_reason(95, log_error, "Failed to initialize sk_renderer!");
+		return false;
+	}
+
+	// The vertex format registry wraps skr vertex types, and travels with
+	// skr's lifecycle — its shutdown pairs with skr_shutdown.
+	if (!vert_format_sys_init()) {
+		log_fail_reason(95, log_error, "Failed to initialize vertex formats!");
 		return false;
 	}
 

--- a/StereoKitC/stereokit.cpp
+++ b/StereoKitC/stereokit.cpp
@@ -11,6 +11,7 @@
 
 #include "systems/system.h"
 #include "systems/_stereokit_systems.h"
+#include "systems/vert_format.h"
 #include "libraries/sokol_time.h"
 #include "libraries/ferr_thread.h"
 #include "libraries/ferr_hash.h"
@@ -181,6 +182,9 @@ void sk_shutdown_unsafe(void) {
 	log_show_any_fail_reason();
 
 	systems_shutdown      ();
+	// The vertex format registry initializes with skr in platform_init, and
+	// must shut down with skr too — wherever skr_shutdown goes, this goes.
+	vert_format_sys_shutdown();
 	skr_shutdown          (); // I'd prefer to do this in Platform, but refactoring may be needed to make that happen
 	sk_mem_log_allocations();
 	log_clear_subscribers ();

--- a/StereoKitC/stereokit.h
+++ b/StereoKitC/stereokit.h
@@ -1329,6 +1329,86 @@ typedef struct vert_t {
 
 static inline vert_t vert_create(vec3 position, vec3 normal sk_default({ 0,1,0 }), vec2 texture_coordinates sk_default({ 0,0 }), color32 vertex_color sk_default({ 255,255,255,255 })) { vert_t v = { position, normal, texture_coordinates, vertex_color }; return v;  }
 
+/*The data format of a single element of a vertex component. Normalized
+  formats map their integer range onto 0-1 (unsigned) or -1-1 (signed)
+  when read by the GPU, other integer formats arrive as integers.*/
+typedef enum vert_fmt_ {
+	/*Invalid format, this is not a valid value for a component.*/
+	vert_fmt_none = 0,
+	/*32 bit float.*/
+	vert_fmt_f32,
+	/*16 bit half float.*/
+	vert_fmt_f16,
+	/*32 bit signed integer.*/
+	vert_fmt_i32,
+	/*16 bit signed integer.*/
+	vert_fmt_i16,
+	/*8 bit signed integer.*/
+	vert_fmt_i8,
+	/*16 bit signed integer, normalized to -1-1 on the GPU.*/
+	vert_fmt_i16_normalized,
+	/*8 bit signed integer, normalized to -1-1 on the GPU.*/
+	vert_fmt_i8_normalized,
+	/*32 bit unsigned integer.*/
+	vert_fmt_u32,
+	/*16 bit unsigned integer.*/
+	vert_fmt_u16,
+	/*8 bit unsigned integer.*/
+	vert_fmt_u8,
+	/*16 bit unsigned integer, normalized to 0-1 on the GPU.*/
+	vert_fmt_u16_normalized,
+	/*8 bit unsigned integer, normalized to 0-1 on the GPU. A color32 is
+	  4 of these.*/
+	vert_fmt_u8_normalized,
+} vert_fmt_;
+
+/*What a vertex component means! This is matched against the semantics
+  the shader's vertex inputs declare, so component order in a format
+  doesn't need to match the shader's input order.*/
+typedef enum vert_semantic_ {
+	/*Invalid semantic, this is not a valid value for a component.*/
+	vert_semantic_none = 0,
+	/*Vertex position, in model space coordinates.*/
+	vert_semantic_position,
+	/*Direction the vertex is facing.*/
+	vert_semantic_normal,
+	/*Texture coordinates.*/
+	vert_semantic_texcoord,
+	/*Vertex color.*/
+	vert_semantic_color,
+	/*Tangent direction for normal mapping.*/
+	vert_semantic_tangent,
+	/*Binormal/bitangent direction for normal mapping.*/
+	vert_semantic_binormal,
+	/*Bone weights for skinning.*/
+	vert_semantic_blendweight,
+	/*Bone indices for skinning.*/
+	vert_semantic_blendindices,
+	/*Point size for point rendering.*/
+	vert_semantic_psize,
+} vert_semantic_;
+
+/*A single component of a custom vertex layout, such as a position or a
+  UV coordinate. A vertex format is described by an array of these, in
+  the same order the fields appear in the vertex struct. Data is always
+  tightly packed, aligned to nothing, so the format fully describes the
+  vertex layout.*/
+typedef struct vert_component_t {
+	/*The data format of a single element, of type vert_fmt_.*/
+	uint8_t format;
+	/*How many format elements this component has, 1-4. A float3
+	  position would be 3.*/
+	uint8_t count;
+	/*What this component means, of type vert_semantic_. This is matched
+	  with the shader's vertex input semantics.*/
+	uint8_t semantic;
+	/*Distinguishes multiple components with the same semantic, like
+	  TEXCOORD0 vs TEXCOORD1. Usually 0.*/
+	uint8_t semantic_slot;
+} vert_component_t;
+
+static inline vert_component_t vert_component(vert_semantic_ semantic, vert_fmt_ format, int32_t count, int32_t semantic_slot sk_default(0)) { vert_component_t c = { (uint8_t)format, (uint8_t)count, (uint8_t)semantic, (uint8_t)semantic_slot }; return c; }
+
 typedef uint32_t vind_t;
 
 /*Culling is discarding an object from the render pipeline!
@@ -1377,8 +1457,12 @@ SK_API void         mesh_draw            (mesh_t mesh, material_t material, matr
 SK_API void         mesh_set_keep_data   (mesh_t mesh, bool32_t keep_data);
 SK_API bool32_t     mesh_get_keep_data   (mesh_t mesh);
 SK_API void         mesh_set_data        (mesh_t mesh, const vert_t *in_arr_vertices, int32_t vertex_count, const vind_t *in_arr_indices, int32_t index_count, mesh_data_ flags sk_default(mesh_data_calc_bounds), int32_t priority sk_default(0));
+SK_API void         mesh_set_data_fmt    (mesh_t mesh, const vert_component_t *in_arr_format, int32_t component_count, const void *vertex_data, int32_t vertex_count, const vind_t *in_arr_indices, int32_t index_count, mesh_data_ flags sk_default(mesh_data_calc_bounds), int32_t priority sk_default(0));
 SK_API void         mesh_set_verts       (mesh_t mesh, const vert_t *in_arr_vertices, int32_t vertex_count, bool32_t calculate_bounds sk_default(true));
 SK_API void         mesh_get_verts       (mesh_t mesh, sk_ref_arr(vert_t) out_arr_vertices, sk_ref(int32_t) out_vertex_count, memory_ reference_mode);
+SK_API void         mesh_set_verts_fmt   (mesh_t mesh, const vert_component_t *in_arr_format, int32_t component_count, const void *vertex_data, int32_t vertex_count, bool32_t calculate_bounds sk_default(true));
+SK_API void         mesh_get_verts_fmt   (mesh_t mesh, vert_component_t **out_arr_format, int32_t *out_component_count, void **out_vertex_data, int32_t *out_vertex_count, memory_ reference_mode);
+SK_API int32_t      mesh_fmt_stride      (const vert_component_t *in_arr_format, int32_t component_count);
 SK_API int32_t      mesh_get_vert_count  (mesh_t mesh);
 SK_API void         mesh_set_inds        (mesh_t mesh, const vind_t *in_arr_indices, int32_t index_count);
 SK_API void         mesh_get_inds        (mesh_t mesh, sk_ref_arr(vind_t) out_arr_indices,  sk_ref(int32_t) out_index_count, memory_ reference_mode);

--- a/StereoKitC/systems/bvh.cpp
+++ b/StereoKitC/systems/bvh.cpp
@@ -381,6 +381,7 @@ mesh_bvh_create(const mesh_t mesh, int acc_leaf_size, bool show_stats)
     if (bvh->collision_data == nullptr)
     {
         log_err("mesh_bvh_t::build(): no mesh collision data available");
+        sk_free(bvh);
         return nullptr;
     }
 
@@ -399,15 +400,14 @@ mesh_bvh_create(const mesh_t mesh, int acc_leaf_size, bool show_stats)
     }
 
 #ifdef VERBOSE_BUILD
-    const vert_t* vertices = mesh->verts;
-    const vind_t* indices  = mesh->inds;
+    const vind_t* indices = mesh->inds;
 
     printf("%d triangles:\n", num_triangles);
     for (int t = 0; t < num_triangles; t++)
     {
         printf("[tri %d] %d %d %d\n", t, indices[3*t+0], indices[3*t+1], indices[3*t+2]);
         for (int i = 0; i < 3; i++)
-            printf("... %.6f %.6f %.6f\n", vertices[indices[3*t+i]].pos.x, vertices[indices[3*t+i]].pos.y, vertices[indices[3*t+i]].pos.z);
+            printf("... %.6f %.6f %.6f\n", triangle_vertices[3*t+i].x, triangle_vertices[3*t+i].y, triangle_vertices[3*t+i].z);
         printf("... centroid %.6f, %.6f, %.6f\n", triangle_centroids[t].x, triangle_centroids[t].y, triangle_centroids[t].z);
     }
 #endif

--- a/StereoKitC/systems/render.cpp
+++ b/StereoKitC/systems/render.cpp
@@ -11,6 +11,7 @@
 #include "render_.h"
 #include "world.h"
 #include "lighting.h"
+#include "vert_format.h"
 #include "../_stereokit.h"
 #include "../device.h"
 #include "../libraries/stref.h"
@@ -161,7 +162,6 @@ struct render_action_t {
 
 struct render_state_t {
 	bool32_t                initialized;
-	skr_vert_type_t         default_vert_type;
 	skr_render_list_t       gpu_render_list;
 
 	material_buffer_t       shader_globals;
@@ -217,15 +217,6 @@ bool render_init() {
 	profiler_zone();
 
 	local = {};
-
-	// Initialize the default vertex type for vert_t
-	skr_vert_component_t vert_components[] = {
-		{ skr_vertex_fmt_f32,            3, skr_semantic_position, 0, 0 },
-		{ skr_vertex_fmt_f32,            3, skr_semantic_normal,   0, 0 },
-		{ skr_vertex_fmt_f32,            2, skr_semantic_texcoord, 0, 0 },
-		{ skr_vertex_fmt_ui8_normalized, 4, skr_semantic_color,    0, 0 },
-	};
-	skr_vert_type_create(vert_components, _countof(vert_components), &local.default_vert_type);
 
 	local.initialized           = true;
 	local.sim_origin            = matrix_identity;
@@ -300,7 +291,6 @@ void render_shutdown() {
 
 	skr_buffer_destroy     (&local.shader_blit);
 	skr_render_list_destroy(&local.gpu_render_list);
-	skr_vert_type_destroy  (&local.default_vert_type);
 
 	local = {};
 
@@ -310,7 +300,7 @@ void render_shutdown() {
 ///////////////////////////////////////////
 
 const skr_vert_type_t* render_get_default_vert() {
-	return &local.default_vert_type;
+	return vert_format_get_skr(VERT_FORMAT_DEFAULT);
 }
 
 ///////////////////////////////////////////

--- a/StereoKitC/systems/vert_format.cpp
+++ b/StereoKitC/systems/vert_format.cpp
@@ -1,0 +1,413 @@
+// SPDX-License-Identifier: MIT
+// The authors below grant copyright rights under the MIT license:
+// Copyright (c) 2026 Nick Klingensmith
+// Copyright (c) 2026 Qualcomm Technologies, Inc.
+
+#include "vert_format.h"
+#include "../sk_memory.h"
+#include "../platforms/platform.h"
+#include "../libraries/ferr_hash.h"
+#include "../libraries/ferr_thread.h"
+#include "../libraries/atomic_util.h"
+
+#include <string.h>
+#include <math.h>
+
+namespace sk {
+
+// Entries are individually allocated into a fixed size table, so entry
+// addresses and slots stay stable, and readers never take the lock.
+#define VERT_FORMAT_MAX 256
+
+struct vert_format_entry_t {
+	uint64_t          hash;
+	vert_component_t* components;
+	int32_t           component_count;
+	uint32_t          stride;
+	skr_vert_type_t   skr_type;
+	int32_t           refs; // atomic
+};
+
+struct vert_format_state_t {
+	vert_format_entry_t** entries; // zero-ref slots are reused, ids stay valid forever
+	int32_t               count;
+	ft_mutex_t            lock;    // guards entry creation/destruction, refcounts are atomic
+};
+static vert_format_state_t local = {};
+
+///////////////////////////////////////////
+
+int32_t vert_fmt_size(vert_fmt_ format) {
+	switch (format) {
+	case vert_fmt_f32:
+	case vert_fmt_i32:
+	case vert_fmt_u32:            return 4;
+	case vert_fmt_f16:
+	case vert_fmt_i16:
+	case vert_fmt_u16:
+	case vert_fmt_i16_normalized:
+	case vert_fmt_u16_normalized: return 2;
+	case vert_fmt_i8:
+	case vert_fmt_u8:
+	case vert_fmt_i8_normalized:
+	case vert_fmt_u8_normalized:  return 1;
+	default:                      return 0;
+	}
+}
+
+///////////////////////////////////////////
+
+static skr_vertex_fmt_ vert_fmt_to_skr(vert_fmt_ format) {
+	switch (format) {
+	case vert_fmt_f32:            return skr_vertex_fmt_f32;
+	case vert_fmt_f16:            return skr_vertex_fmt_f16;
+	case vert_fmt_i32:            return skr_vertex_fmt_i32;
+	case vert_fmt_i16:            return skr_vertex_fmt_i16;
+	case vert_fmt_i8:             return skr_vertex_fmt_i8;
+	case vert_fmt_i16_normalized: return skr_vertex_fmt_i16_normalized;
+	case vert_fmt_i8_normalized:  return skr_vertex_fmt_i8_normalized;
+	case vert_fmt_u32:            return skr_vertex_fmt_ui32;
+	case vert_fmt_u16:            return skr_vertex_fmt_ui16;
+	case vert_fmt_u8:             return skr_vertex_fmt_ui8;
+	case vert_fmt_u16_normalized: return skr_vertex_fmt_ui16_normalized;
+	case vert_fmt_u8_normalized:  return skr_vertex_fmt_ui8_normalized;
+	default:                      return skr_vertex_fmt_none;
+	}
+}
+
+///////////////////////////////////////////
+
+static skr_semantic_ vert_semantic_to_skr(vert_semantic_ semantic) {
+	switch (semantic) {
+	case vert_semantic_position:     return skr_semantic_position;
+	case vert_semantic_normal:       return skr_semantic_normal;
+	case vert_semantic_texcoord:     return skr_semantic_texcoord;
+	case vert_semantic_color:        return skr_semantic_color;
+	case vert_semantic_tangent:      return skr_semantic_tangent;
+	case vert_semantic_binormal:     return skr_semantic_binormal;
+	case vert_semantic_blendweight:  return skr_semantic_blendweight;
+	case vert_semantic_blendindices: return skr_semantic_blendindices;
+	case vert_semantic_psize:        return skr_semantic_psize;
+	default:                         return skr_semantic_none;
+	}
+}
+
+///////////////////////////////////////////
+
+static bool vert_format_validate(const vert_component_t* components, int32_t count) {
+	if (components == nullptr || count <= 0) {
+		log_err("Vertex formats need at least one component!");
+		return false;
+	}
+	for (int32_t i = 0; i < count; i++) {
+		const vert_component_t* c = &components[i];
+		if (vert_fmt_size((vert_fmt_)c->format) == 0)                                { log_errf("Vertex component %d has an invalid format!",   i); return false; }
+		if (c->count < 1 || c->count > 4)                                            { log_errf("Vertex component %d count must be 1-4!",       i); return false; }
+		if (vert_semantic_to_skr((vert_semantic_)c->semantic) == skr_semantic_none)  { log_errf("Vertex component %d has an invalid semantic!", i); return false; }
+		for (int32_t p = 0; p < i; p++) {
+			if (components[p].semantic == c->semantic && components[p].semantic_slot == c->semantic_slot) {
+				log_errf("Vertex components %d and %d share a semantic, semantics may only appear once per format!", p, i);
+				return false;
+			}
+		}
+	}
+	return true;
+}
+
+///////////////////////////////////////////
+
+static vert_format_entry_t* vert_format_entry_create(const vert_component_t* components, int32_t count, uint64_t hash) {
+	skr_vert_component_t skr_components[16];
+	if (count > (int32_t)_countof(skr_components)) {
+		log_errf("Vertex formats support at most %d components!", (int32_t)_countof(skr_components));
+		return nullptr;
+	}
+	uint32_t stride = 0;
+	for (int32_t i = 0; i < count; i++) {
+		skr_components[i] = {};
+		skr_components[i].format        = vert_fmt_to_skr     ((vert_fmt_     )components[i].format);
+		skr_components[i].count         = components[i].count;
+		skr_components[i].semantic      = vert_semantic_to_skr((vert_semantic_)components[i].semantic);
+		skr_components[i].semantic_slot = components[i].semantic_slot;
+		stride += vert_fmt_size((vert_fmt_)components[i].format) * components[i].count;
+	}
+
+	vert_format_entry_t* entry = sk_malloc_zero_t(vert_format_entry_t, 1);
+	if (skr_vert_type_create(skr_components, count, &entry->skr_type) != skr_err_success) {
+		log_err("Failed to create GPU vertex type!");
+		sk_free(entry);
+		return nullptr;
+	}
+	entry->hash            = hash;
+	entry->components      = sk_malloc_t(vert_component_t, count);
+	entry->component_count = count;
+	entry->stride          = stride;
+	entry->refs            = 0;
+	memcpy(entry->components, components, sizeof(vert_component_t) * count);
+	return entry;
+}
+
+///////////////////////////////////////////
+
+// Core of vert_format_ref, the caller holds the registry lock.
+static int32_t vert_format_ref_unlocked(const vert_component_t* components, int32_t count) {
+	uint64_t hash = hash_fnv64_data(components, sizeof(vert_component_t) * count);
+
+	int32_t free_slot = -1;
+	for (int32_t i = 0; i < local.count; i++) {
+		vert_format_entry_t* entry = local.entries[i];
+		if (entry == nullptr) { if (free_slot < 0) free_slot = i; continue; }
+		if (entry->hash == hash && entry->component_count == count &&
+			memcmp(entry->components, components, sizeof(vert_component_t) * count) == 0) {
+			atomic_increment(&entry->refs);
+			return i;
+		}
+	}
+	if (free_slot < 0 && local.count >= VERT_FORMAT_MAX) {
+		log_errf("Too many unique vertex formats, the limit is %d!", VERT_FORMAT_MAX);
+		return -1;
+	}
+
+	vert_format_entry_t* entry = vert_format_entry_create(components, count, hash);
+	if (entry == nullptr)
+		return -1;
+	entry->refs = 1;
+
+	int32_t id = free_slot;
+	if (id < 0) { id = local.count; local.count += 1; }
+	local.entries[id] = entry;
+	return id;
+}
+
+///////////////////////////////////////////
+
+bool vert_format_sys_init() {
+	local         = {};
+	local.entries = sk_malloc_zero_t(vert_format_entry_t*, VERT_FORMAT_MAX);
+	local.lock    = ft_mutex_create();
+
+	// Id 0 is the built-in vert_t format, and the reference taken here is
+	// the registry's own, keeping it alive for the registry's whole life.
+	vert_component_t default_components[] = {
+		vert_component(vert_semantic_position, vert_fmt_f32,           3),
+		vert_component(vert_semantic_normal,   vert_fmt_f32,           3),
+		vert_component(vert_semantic_texcoord, vert_fmt_f32,           2),
+		vert_component(vert_semantic_color,    vert_fmt_u8_normalized, 4),
+	};
+	ft_mutex_lock  (local.lock);
+	int32_t id = vert_format_ref_unlocked(default_components, _countof(default_components));
+	ft_mutex_unlock(local.lock);
+	return id == VERT_FORMAT_DEFAULT;
+}
+
+///////////////////////////////////////////
+
+void vert_format_sys_shutdown() {
+	if (local.entries == nullptr) return;
+	for (int32_t i = 0; i < local.count; i++) {
+		vert_format_entry_t* entry = local.entries[i];
+		if (entry == nullptr) continue;
+		// The registry holds one reference to the default format itself.
+		int32_t expected = i == VERT_FORMAT_DEFAULT ? 1 : 0;
+		if (entry->refs > expected)
+			log_warnf("Vertex format %d leaked with %d references!", i, entry->refs - expected);
+		skr_vert_type_destroy(&entry->skr_type);
+		sk_free(entry->components);
+		sk_free(entry);
+	}
+	sk_free(local.entries);
+	ft_mutex_destroy(&local.lock);
+	local = {};
+}
+
+///////////////////////////////////////////
+
+int32_t vert_format_ref(const vert_component_t* components, int32_t count) {
+	if (!vert_format_validate(components, count))
+		return -1;
+
+	ft_mutex_lock(local.lock);
+	int32_t id = vert_format_ref_unlocked(components, count);
+	ft_mutex_unlock(local.lock);
+	return id;
+}
+
+///////////////////////////////////////////
+
+void vert_format_addref(int32_t id) {
+	// Lock-free is safe here, callers only addref formats that are alive.
+	atomic_increment(&local.entries[id]->refs);
+}
+
+///////////////////////////////////////////
+
+void vert_format_release(int32_t id) {
+	if (id < 0) return;
+	vert_format_entry_t* entry = local.entries[id];
+	if (atomic_decrement(&entry->refs) > 0) return;
+
+	// On zero, re-check under the lock, a concurrent vert_format_ref may
+	// have resurrected this entry through deduplication.
+	ft_mutex_lock(local.lock);
+	if (local.entries[id] == entry && entry->refs <= 0) {
+		skr_vert_type_destroy(&entry->skr_type);
+		sk_free(entry->components);
+		sk_free(entry);
+		local.entries[id] = nullptr;
+	}
+	ft_mutex_unlock(local.lock);
+}
+
+///////////////////////////////////////////
+
+const skr_vert_type_t* vert_format_get_skr(int32_t id) {
+	return &local.entries[id]->skr_type;
+}
+
+///////////////////////////////////////////
+
+const vert_component_t* vert_format_get_components(int32_t id, int32_t* out_count) {
+	vert_format_entry_t* entry = local.entries[id];
+	*out_count = entry->component_count;
+	return entry->components;
+}
+
+///////////////////////////////////////////
+
+uint32_t vert_format_get_stride(int32_t id) {
+	return local.entries[id]->stride;
+}
+
+///////////////////////////////////////////
+
+// Subnormal halfs are vanishingly small and flush to zero here.
+static float vert_fmt_half_to_float(uint16_t h) {
+	uint32_t sign = (uint32_t)(h & 0x8000) << 16;
+	uint32_t exp  = (h >> 10) & 0x1F;
+	uint32_t man  =  h        & 0x3FF;
+	uint32_t bits =
+		exp == 0  ? sign :
+		exp == 31 ? sign | 0x7F800000        | (man << 13)
+		          : sign | ((exp + 112) << 23) | (man << 13);
+	float result;
+	memcpy(&result, &bits, sizeof(result));
+	return result;
+}
+
+// Round to nearest, overflow becomes infinity, underflow becomes zero,
+// and NaN stays NaN.
+static uint16_t vert_fmt_float_to_half(float f) {
+	uint32_t bits;
+	memcpy(&bits, &f, sizeof(bits));
+	uint32_t sign = (bits >> 16) & 0x8000;
+	int32_t  exp  = (int32_t)((bits >> 23) & 0xFF) - 127 + 15;
+	uint32_t man  = bits & 0x7FFFFF;
+	if (exp >= 31) return (uint16_t)(sign | 0x7C00 | (man != 0 ? 0x200 : 0));
+	if (exp <= 0 ) return (uint16_t)sign;
+	uint16_t result = (uint16_t)(sign | (exp << 10) | (man >> 13));
+	// Round bit carries up through the exponent correctly on overflow.
+	if (man & 0x1000) result += 1;
+	return result;
+}
+
+///////////////////////////////////////////
+
+// Unaligned safe reads/writes, memcpy compiles down to plain loads/stores.
+static float vert_fmt_decode_element(vert_fmt_ format, const uint8_t* at) {
+	switch (format) {
+	case vert_fmt_f32:            { float    v; memcpy(&v, at, 4); return v; }
+	case vert_fmt_f16:            { uint16_t v; memcpy(&v, at, 2); return vert_fmt_half_to_float(v); }
+	case vert_fmt_i32:            { int32_t  v; memcpy(&v, at, 4); return (float)v; }
+	case vert_fmt_i16:            { int16_t  v; memcpy(&v, at, 2); return (float)v; }
+	case vert_fmt_i8:             { return (float)*(int8_t*)at; }
+	case vert_fmt_i16_normalized: { int16_t  v; memcpy(&v, at, 2); return fmaxf(v / 32767.0f, -1); }
+	case vert_fmt_i8_normalized:  { return fmaxf(*(int8_t*)at / 127.0f, -1); }
+	case vert_fmt_u32:            { uint32_t v; memcpy(&v, at, 4); return (float)v; }
+	case vert_fmt_u16:            { uint16_t v; memcpy(&v, at, 2); return (float)v; }
+	case vert_fmt_u8:             { return (float)*at; }
+	case vert_fmt_u16_normalized: { uint16_t v; memcpy(&v, at, 2); return v / 65535.0f; }
+	case vert_fmt_u8_normalized:  { return *at / 255.0f; }
+	default:                      { return 0; }
+	}
+}
+
+// Out of range values clamp to the format's limits, casting them directly
+// is undefined behavior. 32 bit limits clamp in doubles, their integer
+// bounds aren't exactly representable as floats.
+static void vert_fmt_encode_element(vert_fmt_ format, uint8_t* at, float value) {
+	switch (format) {
+	case vert_fmt_f32:            { memcpy(at, &value, 4); } break;
+	case vert_fmt_f16:            { uint16_t v = vert_fmt_float_to_half(value); memcpy(at, &v, 2); } break;
+	case vert_fmt_i32:            { int32_t  v = (int32_t )fmax (fmin ((double)value, 2147483647.0), -2147483648.0); memcpy(at, &v, 4); } break;
+	case vert_fmt_i16:            { int16_t  v = (int16_t )fmaxf(fminf(value,  32767.0f), -32768.0f); memcpy(at, &v, 2); } break;
+	case vert_fmt_i8:             { *(int8_t*)at = (int8_t )fmaxf(fminf(value,    127.0f),   -128.0f); } break;
+	case vert_fmt_i16_normalized: { int16_t  v = (int16_t )roundf(fmaxf(-1, fminf(1, value)) * 32767); memcpy(at, &v, 2); } break;
+	case vert_fmt_i8_normalized:  { *(int8_t*)at = (int8_t )roundf(fmaxf(-1, fminf(1, value)) * 127); } break;
+	case vert_fmt_u32:            { uint32_t v = (uint32_t)fmax (fmin ((double)value, 4294967295.0), 0.0); memcpy(at, &v, 4); } break;
+	case vert_fmt_u16:            { uint16_t v = (uint16_t)fmaxf(fminf(value,  65535.0f), 0.0f); memcpy(at, &v, 2); } break;
+	case vert_fmt_u8:             { *at = (uint8_t)fmaxf(fminf(value, 255.0f), 0.0f); } break;
+	case vert_fmt_u16_normalized: { uint16_t v = (uint16_t)roundf(fmaxf(0, fminf(1, value)) * 65535); memcpy(at, &v, 2); } break;
+	case vert_fmt_u8_normalized:  { *at = (uint8_t)roundf(fmaxf(0, fminf(1, value)) * 255); } break;
+	default: break;
+	}
+}
+
+///////////////////////////////////////////
+
+bool vert_format_decode(int32_t id, const void* vertex, vert_semantic_ semantic, int32_t semantic_slot, vec4* ref_value) {
+	vert_fmt_ fmt    = vert_fmt_none;
+	int32_t   count  = 0;
+	int32_t   offset = vert_format_semantic_offset(id, semantic, semantic_slot, &fmt, &count);
+	if (offset < 0) return false;
+
+	const uint8_t* at   = (const uint8_t*)vertex + offset;
+	int32_t        size = vert_fmt_size(fmt);
+	float*         out  = &ref_value->x;
+	for (int32_t i = 0; i < count; i++)
+		out[i] = vert_fmt_decode_element(fmt, at + i*size);
+	return true;
+}
+
+///////////////////////////////////////////
+
+bool vert_format_encode(int32_t id, void* vertex, vert_semantic_ semantic, int32_t semantic_slot, vec4 value) {
+	vert_fmt_ fmt    = vert_fmt_none;
+	int32_t   count  = 0;
+	int32_t   offset = vert_format_semantic_offset(id, semantic, semantic_slot, &fmt, &count);
+	if (offset < 0) return false;
+
+	uint8_t*     at   = (uint8_t*)vertex + offset;
+	int32_t      size = vert_fmt_size(fmt);
+	const float* in   = &value.x;
+	for (int32_t i = 0; i < count; i++)
+		vert_fmt_encode_element(fmt, at + i*size, in[i]);
+	return true;
+}
+
+///////////////////////////////////////////
+
+int32_t vert_format_semantic_offset(int32_t id, vert_semantic_ semantic, int32_t semantic_slot, vert_fmt_* out_opt_fmt, int32_t* out_opt_count) {
+	vert_format_entry_t* entry  = local.entries[id];
+	int32_t              offset = 0;
+	for (int32_t i = 0; i < entry->component_count; i++) {
+		const vert_component_t* c = &entry->components[i];
+		if (c->semantic == semantic && c->semantic_slot == semantic_slot) {
+			if (out_opt_fmt  ) *out_opt_fmt   = (vert_fmt_)c->format;
+			if (out_opt_count) *out_opt_count = c->count;
+			return offset;
+		}
+		offset += vert_fmt_size((vert_fmt_)c->format) * c->count;
+	}
+	return -1;
+}
+
+///////////////////////////////////////////
+
+int32_t mesh_fmt_stride(const vert_component_t* format, int32_t component_count) {
+	int32_t stride = 0;
+	for (int32_t i = 0; i < component_count; i++)
+		stride += vert_fmt_size((vert_fmt_)format[i].format) * format[i].count;
+	return stride;
+}
+
+} // namespace sk

--- a/StereoKitC/systems/vert_format.h
+++ b/StereoKitC/systems/vert_format.h
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+// The authors below grant copyright rights under the MIT license:
+// Copyright (c) 2026 Nick Klingensmith
+// Copyright (c) 2026 Qualcomm Technologies, Inc.
+
+#pragma once
+
+#include "../stereokit.h"
+#include <sk_renderer.h>
+
+namespace sk {
+
+// Registry of deduplicated, refcounted vertex formats. An id's
+// skr_vert_type_t address is stable, gpu meshes point directly at it.
+#define VERT_FORMAT_DEFAULT 0 // the built-in vert_t format, always present
+
+bool vert_format_sys_init    ();
+void vert_format_sys_shutdown();
+
+// Finds or creates a format matching these components, and adds a
+// reference to it. Returns -1 for an invalid component list.
+int32_t vert_format_ref    (const vert_component_t* components, int32_t count);
+// Refcounts are atomic, but only addref ids that are currently alive.
+void    vert_format_addref (int32_t id);
+void    vert_format_release(int32_t id);
+
+const skr_vert_type_t*  vert_format_get_skr       (int32_t id);
+const vert_component_t* vert_format_get_components(int32_t id, int32_t* out_count);
+uint32_t                vert_format_get_stride    (int32_t id);
+// Byte offset of a semantic's component within a vertex, or -1 if the
+// format has no such component.
+int32_t                 vert_format_semantic_offset(int32_t id, vert_semantic_ semantic, int32_t semantic_slot, vert_fmt_* out_opt_fmt, int32_t* out_opt_count);
+
+// Decode or encode a single vertex's semantic as floats. Decode writes only
+// the elements the component has, encode reads only those. Both return
+// false when the format has no such component.
+bool vert_format_decode(int32_t id, const void* vertex, vert_semantic_ semantic, int32_t semantic_slot, vec4* ref_value);
+bool vert_format_encode(int32_t id,       void* vertex, vert_semantic_ semantic, int32_t semantic_slot, vec4 value);
+
+int32_t vert_fmt_size(vert_fmt_ format);
+
+} // namespace sk

--- a/StereoKitC/xr_backends/extensions/msft_scene_understanding.cpp
+++ b/StereoKitC/xr_backends/extensions/msft_scene_understanding.cpp
@@ -12,6 +12,7 @@
 #include "../../_stereokit.h"
 #include "../../systems/render.h"
 #include "../../asset_types/mesh_.h"
+#include "../../systems/vert_format.h"
 #include <float.h>
 
 #define XR_EXT_FUNCTIONS( X )              \
@@ -330,7 +331,7 @@ void oxr_su_update_meshes(array_t<scene_mesh_t> *mesh_list) {
 		for (uint32_t v = 0; v < v_count; v++) {
 			local.verts_tmp[v] = { *(vec3 *)&v_buffer.vertices[v], {0,1,0}, {}, {255,255,255,255} };
 		}
-		mesh_calculate_normals(local.verts_tmp.data, v_count, i_buffer.indices, i_count);
+		mesh_calculate_normals(VERT_FORMAT_DEFAULT, local.verts_tmp.data, v_count, i_buffer.indices, i_count);
 		mesh_set_keep_data(mesh.mesh, local.scene_last_req.raycast);
 		mesh_set_data     (mesh.mesh, local.verts_tmp.data, v_count, i_buffer.indices, i_count);
 	}

--- a/tools/StereoKitAPIGen/CSharp/BindCSharp.cs
+++ b/tools/StereoKitAPIGen/CSharp/BindCSharp.cs
@@ -334,6 +334,10 @@ public static class BindCSharp {
 	// ─────────────────────────────────────────────────────────────
 
 	static void BuildFunction(StringBuilder sb, SKFunction fn, Dictionary<string, string> delegates, string indent) {
+		// Skip functions marked with @noimpl in overrides (hand-written in
+		// NativeAPI.Custom.cs)
+		if (_overrides.ShouldSkipImpl(fn.Name)) return;
+
 		var returnType = MapType(fn.ReturnType, "", delegates, isReturn: true);
 		bool returnsBool = fn.ReturnType.Name == "bool32_t";
 
@@ -452,6 +456,16 @@ public static class BindCSharp {
 			if (type.ArraySize1 > 0) {
 				// Fixed size array
 				return ($"[MarshalAs(UnmanagedType.LPArray, SizeConst = {type.ArraySize1})] {typeName}[]", textType);
+			}
+			// A double pointer can't be a caller-allocated element array, the
+			// function is handing back a pointer to its own array → IntPtr
+			if (type.PointerLevel >= 2) {
+				string keyword = passType switch {
+					SKPassType.Out => "out ",
+					SKPassType.Ref => "ref ",
+					_              => "",
+				};
+				return ($"{keyword}IntPtr", textType);
 			}
 			// Variable length array - use [In] or [Out] attribute
 			string attr = passType switch {

--- a/tools/StereoKitAPIGen/NameOverrides.cs
+++ b/tools/StereoKitAPIGen/NameOverrides.cs
@@ -6,7 +6,7 @@ namespace StereoKitAPIGen;
 ///
 /// Supported directives:
 /// - name NewName   : Rename a type/enum value
-/// - @noimpl name   : Skip auto-generating this type/delegate (hand-written elsewhere)
+/// - @noimpl name   : Skip auto-generating this type/delegate/function (hand-written elsewhere)
 /// </summary>
 public class NameOverrides {
 	readonly Dictionary<string, string> _overrides = new();

--- a/tools/StereoKitAPIGen/SKOverridesCSharp.txt
+++ b/tools/StereoKitAPIGen/SKOverridesCSharp.txt
@@ -80,6 +80,7 @@ transparency_msaa MSAA
 sk_settings_t SKSettings
 vind_t uint
 vert_t Vertex
+vert_component_t VertComponent
 model_node_id int
 sh_light_t SHLight
 openxr_handle_t ulong
@@ -123,6 +124,10 @@ ui_scroll_ UIScroll
 
 # Structs with existing hand-written versions elsewhere
 @noimpl hand_joint_t sound_inst_t gradient_key_t sh_light_t
+@noimpl vert_component_t
+
+# Functions with hand-written bindings in NativeAPI.Custom.cs
+# (none currently)
 @noimpl spherical_harmonics_t hand_t controller_t file_filter_t
 
 # Enums with hand-written struct implementations


### PR DESCRIPTION
This adds `Mesh.SetData<T>`, `Mesh.SetVerts<T>`, and `Mesh.GetVerts<T>` for working with custom vertex data formats! This can be used for increasing performance via tighter packing, or dropping components, or for special effects by adding extra data, like additional UV channels!

Shaders now support vertex input remapping, meaning your vsIn struct no longer has to follow a specific order or exactly match the mesh vertex format! The `Mesh` format _must_ still contain all component the shader asks for.

This also adds Attributes for defining custom vertex format structs:
```csharp
// Defining a custom vertex type looks like this! Use VertComponent Attributes to
// connect the data to vertex attributes in the shader.
[StructLayout(LayoutKind.Sequential)]
struct VertPosColor
{
	[VertComponent(VertSemantic.Position, VertFmt.F32,          3)]
	public Vec3    pos;
	[VertComponent(VertSemantic.Color,    VertFmt.U8Normalized, 4)]
	public Color32 color;
}
```