### PR TITLE
Fix unsynchronized Vulkan queue submissions from OpenXR calls

### DIFF
--- a/StereoKitC/xr_backends/openxr.cpp
+++ b/StereoKitC/xr_backends/openxr.cpp
@@ -36,6 +36,7 @@
 #include <openxr/openxr_reflection.h>
 
 #include <sk_app.h>
+#include <sk_renderer.h>
 
 #include <string.h>
 #include <stdlib.h>
@@ -422,8 +423,13 @@ bool openxr_blank_frame() {
 	// up-to-date even on blank frames during init is helpful.
 	xr_time = frame_state.predictedDisplayTime;
 
+	uint32_t queue_family = skr_get_vk_graphics_queue_family();
+
 	XrFrameBeginInfo begin_info = { XR_TYPE_FRAME_BEGIN_INFO };
-	xr_check(xrBeginFrame(xr_session, &begin_info),
+	skr_vk_queue_lock(queue_family);
+	XrResult begin_result = xrBeginFrame(xr_session, &begin_info);
+	skr_vk_queue_unlock(queue_family);
+	xr_check(begin_result,
 		"blank xrBeginFrame");
 
 	XrFrameEndInfo end_info = { XR_TYPE_FRAME_END_INFO };
@@ -431,7 +437,11 @@ bool openxr_blank_frame() {
 	if      (xr_blend_valid(display_blend_opaque  )) end_info.environmentBlendMode = XR_ENVIRONMENT_BLEND_MODE_OPAQUE;
 	else if (xr_blend_valid(display_blend_additive)) end_info.environmentBlendMode = XR_ENVIRONMENT_BLEND_MODE_ADDITIVE;
 	else if (xr_blend_valid(display_blend_blend   )) end_info.environmentBlendMode = XR_ENVIRONMENT_BLEND_MODE_ALPHA_BLEND;
-	xr_check(xrEndFrame(xr_session, &end_info),
+
+	skr_vk_queue_lock(queue_family);
+	XrResult end_result = xrEndFrame(xr_session, &end_info);
+	skr_vk_queue_unlock(queue_family);
+	xr_check(end_result,
 		"blank xrEndFrame");
 
 	return true;

--- a/StereoKitC/xr_backends/openxr_view.cpp
+++ b/StereoKitC/xr_backends/openxr_view.cpp
@@ -826,7 +826,11 @@ bool openxr_render_frame() {
 	{
 		profiler_zone_name("xrBeginFrame");
 
-		xr_check(xrBeginFrame(xr_session, &begin_info),
+		uint32_t queue_family = skr_get_vk_graphics_queue_family();
+		skr_vk_queue_lock(queue_family);
+		XrResult begin_result = xrBeginFrame(xr_session, &begin_info);
+		skr_vk_queue_unlock(queue_family);
+		xr_check(begin_result,
 			"xrBeginFrame");
 	}
 
@@ -946,7 +950,11 @@ bool openxr_render_frame() {
 	{
 		profiler_zone_name("xrEndFrame");
 
-		xr_check(xrEndFrame(xr_session, &end_info),
+		uint32_t queue_family = skr_get_vk_graphics_queue_family();
+		skr_vk_queue_lock(queue_family);
+		XrResult end_result = xrEndFrame(xr_session, &end_info);
+		skr_vk_queue_unlock(queue_family);
+		xr_check(end_result,
 			"xrEndFrame");
 	}
 	return true;
@@ -1048,13 +1056,21 @@ bool openxr_display_swapchain_acquire(device_display_t* display, color128 color,
 	uint64_t                    dead_start   = stm_now();
 	uint32_t                    color_id;
 	XrSwapchainImageAcquireInfo acquire_info = { XR_TYPE_SWAPCHAIN_IMAGE_ACQUIRE_INFO };
-	if (XR_FAILED(xrAcquireSwapchainImage(display->swapchain_color.handle, &acquire_info, &color_id))) return false;
-	display->swapchain_color.acquired = true;
-	if (display->swapchain_depth.handle) {
-		uint32_t depth_id;
-		if (XR_FAILED(xrAcquireSwapchainImage(display->swapchain_depth.handle, &acquire_info, &depth_id))) return false;
-		display->swapchain_depth.acquired = true;
+
+	uint32_t queue_family = skr_get_vk_graphics_queue_family();
+	skr_vk_queue_lock(queue_family);
+	XrResult acquire_result = xrAcquireSwapchainImage(display->swapchain_color.handle, &acquire_info, &color_id);
+	if (XR_SUCCEEDED(acquire_result)) {
+		display->swapchain_color.acquired = true;
+		if (display->swapchain_depth.handle) {
+			uint32_t depth_id;
+			acquire_result = xrAcquireSwapchainImage(display->swapchain_depth.handle, &acquire_info, &depth_id);
+			if (XR_SUCCEEDED(acquire_result))
+				display->swapchain_depth.acquired = true;
+		}
 	}
+	skr_vk_queue_unlock(queue_family);
+	if (XR_FAILED(acquire_result)) return false;
 
 	// Wait until the image is available to render to. The compositor could
 	// still be reading from it.
@@ -1086,8 +1102,11 @@ bool openxr_display_swapchain_acquire(device_display_t* display, color128 color,
 void openxr_display_swapchain_release(device_display_t *display) {
 	// And tell OpenXR we're done with rendering to this one!
 	XrSwapchainImageReleaseInfo release_info = { XR_TYPE_SWAPCHAIN_IMAGE_RELEASE_INFO };
+	uint32_t queue_family = skr_get_vk_graphics_queue_family();
+	skr_vk_queue_lock(queue_family);
 	if (display->swapchain_color.acquired) xrReleaseSwapchainImage(display->swapchain_color.handle, &release_info);
 	if (display->swapchain_depth.acquired) xrReleaseSwapchainImage(display->swapchain_depth.handle, &release_info);
+	skr_vk_queue_unlock(queue_family);
 	display->swapchain_color.acquired = false;
 	display->swapchain_depth.acquired = false;
 


### PR DESCRIPTION
Vulkan requires external synchronization of `vkQueueSubmit` per queue, and the OpenXR spec says the runtime may access the queue from `XrGraphicsBindingVulkanKHR` inside exactly `xrBeginFrame`, `xrEndFrame`, `xrAcquireSwapchainImage`, and `xrReleaseSwapchainImage` (XR_KHR_vulkan_enable concurrency note: https://registry.khronos.org/OpenXR/specs/1.1/html/xrspec.html#XR_KHR_vulkan_enable), so those calls must be externally synchronized against the application's own submissions. sk_renderer's asset threads submit on that queue while these calls run, and nothing serializes them, so this is UB: validation errors, corruption, or GPU hangs.

To reproduce, run the Vulkan backend on Quest/Android XR with the validation layer on, and while rendering, repeatedly start/stop a secondary workload that submits on the graphics queue (asset-thread texture/model uploads, or in our case a sensor-readback worker). Validation fires:

    vkQueueSubmit(): THREADING ERROR : object of type VkQueue is simultaneously
    used in current thread <A> and thread <B>

9 hits in about 2 minutes of stress on Quest; zero after the fix under heavier stress, with the validation channel confirmed still live. With validation off, the same race surfaced as delayed SIGSEGVs in `_skr_cmd_ring_begin` from corrupted driver sync objects, which is what a user without the layer will actually see.

The fix wraps exactly the four queue-touching calls from the spec's list (`xrBeginFrame` and `xrEndFrame` for both render and blank frames, swapchain acquire, swapchain release) in sk_renderer's existing per-queue lock (`skr_vk_queue_lock`). `xrWaitSwapchainImage` is not on the spec's list, so the lock is deliberately not held across it; it can block for a full frame and would stall asset uploads.
