### PR TITLE
Add AHardwareBuffer texture import

### DIFF
--- a/StereoKit/Assets/Tex.cs
+++ b/StereoKit/Assets/Tex.cs
@@ -491,6 +491,41 @@ namespace StereoKit
 		public IntPtr GetNativeSurface()
 			=> NativeAPI.tex_get_surface(_inst);
 
+		/// <summary>Imports an Android AHardwareBuffer as an external
+		/// texture, YCbCr camera or decoder buffers come in via sampler
+		/// conversion. This allows zero-copy access to hardware decoder or
+		/// camera output. This is only functional on Android, and requires
+		/// device support for hardware buffer import.</summary>
+		/// <param name="hardwareBuffer">An AHardwareBuffer* coerced into an
+		/// IntPtr.</param>
+		/// <param name="ownsBuffer">Should ownership of the hardware buffer
+		/// be passed on to StereoKit? If so, StereoKit will release it when
+		/// the texture is destroyed.</param>
+		/// <returns>A Tex asset wrapping the hardware buffer, or null if the
+		/// buffer is null, the device doesn't support importing hardware
+		/// buffers, or the import failed.</returns>
+		public static Tex FromHardwareBuffer(IntPtr hardwareBuffer, bool ownsBuffer = false)
+		{
+			IntPtr inst = NativeAPI.tex_create_from_hardware_buffer(hardwareBuffer, ownsBuffer);
+			if (inst == IntPtr.Zero) return null;
+			if (NativeAPI.tex_asset_state(inst) < AssetState.None)
+			{
+				NativeAPI.assets_releaseref_threadsafe(inst);
+				return null;
+			}
+			return new Tex(inst);
+		}
+
+		/// <summary>This will return the AHardwareBuffer* backing this
+		/// texture, if it was created from one. This call will block
+		/// execution until the texture is loaded, if it is not already.
+		/// </summary>
+		/// <returns>An AHardwareBuffer* coerced into an IntPtr, or
+		/// IntPtr.Zero if the texture is not backed by a hardware buffer, or
+		/// when not on Android.</returns>
+		public IntPtr GetHardwareBuffer()
+			=> NativeAPI.tex_get_hardware_buffer(_inst);
+
 		/// <summary>Retrieve the color data of the texture from the GPU. This
 		/// can be a very slow operation, so use it cautiously.</summary>
 		/// <typeparam name="T">This should be a struct or basic type used to

--- a/StereoKit/Native/NativeAPI.cs
+++ b/StereoKit/Native/NativeAPI.cs
@@ -276,6 +276,8 @@ namespace StereoKit
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         tex_set_fallback(IntPtr texture, IntPtr fallback);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         tex_set_surface(IntPtr texture, IntPtr native_surface, TexType type, long native_fmt, int width, int height, int surface_count, int multisample, [MarshalAs(UnmanagedType.Bool)] bool owned);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr       tex_get_surface(IntPtr texture);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr       tex_create_from_hardware_buffer(IntPtr hardware_buffer, [MarshalAs(UnmanagedType.Bool)] bool owns_buffer);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr       tex_get_hardware_buffer(IntPtr texture);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         tex_addref(IntPtr texture);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         tex_release(IntPtr texture);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern AssetState   tex_asset_state(IntPtr texture);

--- a/StereoKitC/asset_types/texture.cpp
+++ b/StereoKitC/asset_types/texture.cpp
@@ -971,6 +971,57 @@ void* tex_get_surface(tex_t texture) {
 
 ///////////////////////////////////////////
 
+tex_t tex_create_from_hardware_buffer(void *hardware_buffer, bool32_t owns_buffer) {
+#if defined(SK_OS_ANDROID)
+	if (hardware_buffer == nullptr) return nullptr;
+	if (!skr_is_capable(skr_capability_external_ahb)) {
+		log_warn("tex_create_from_hardware_buffer: AHardwareBuffer import is not supported on this device!");
+		return nullptr;
+	}
+
+	tex_t result = tex_create(tex_type_image_nomips, tex_format_none);
+
+	skr_tex_external_ahb_info_t info = {};
+	info.hardware_buffer = hardware_buffer;
+	info.format          = skr_tex_fmt_none;
+	info.sampler         = tex_get_skr_sampler(result);
+	info.owns_buffer     = owns_buffer;
+
+	if (skr_tex_create_external_ahb(info, &result->gpu_tex) == skr_err_success) {
+		skr_vec3i_t size = skr_tex_get_size(&result->gpu_tex);
+		result->width    = size.x;
+		result->height   = size.y;
+		result->format   = (tex_format_)skr_tex_get_format(&result->gpu_tex);
+	}
+
+	result->header.state = skr_tex_is_valid(&result->gpu_tex)
+		? asset_state_loaded
+		: asset_state_error;
+	tex_set_fallback(result, result->header.state <= 0
+		? _tex_get_error_fallback(result)
+		: nullptr);
+	return result;
+#else
+	(void)hardware_buffer;
+	(void)owns_buffer;
+	return nullptr;
+#endif
+}
+
+///////////////////////////////////////////
+
+void* tex_get_hardware_buffer(tex_t texture) {
+#if defined(SK_OS_ANDROID)
+	assets_block_until(&texture->header, asset_state_loaded);
+	return texture->gpu_tex.ahb_handle;
+#else
+	(void)texture;
+	return nullptr;
+#endif
+}
+
+///////////////////////////////////////////
+
 void tex_set_fallback(tex_t texture, tex_t fallback) {
 	if (texture->header.state >= asset_state_loaded && fallback != nullptr) return;
 

--- a/StereoKitC/stereokit.h
+++ b/StereoKitC/stereokit.h
@@ -1624,6 +1624,8 @@ SK_API const char*  tex_get_id              (const tex_t texture);
 SK_API void         tex_set_fallback        (tex_t texture, tex_t fallback);
 SK_API void         tex_set_surface         (tex_t texture, void *native_surface, tex_type_ type, int64_t native_fmt, int32_t width, int32_t height, int32_t surface_count, int32_t multisample sk_default(1), bool32_t owned sk_default(true));
 SK_API void*        tex_get_surface         (tex_t texture);
+SK_API tex_t        tex_create_from_hardware_buffer(void *hardware_buffer, bool32_t owns_buffer sk_default(false));
+SK_API void*        tex_get_hardware_buffer (tex_t texture);
 SK_API void         tex_addref              (tex_t texture);
 SK_API void         tex_release             (tex_t texture);
 SK_API asset_state_ tex_asset_state         (const tex_t texture);


### PR DESCRIPTION
Adds `Tex.FromHardwareBuffer` / `tex_create_from_hardware_buffer`, which imports an `AHardwareBuffer` as an external texture with no copy (YCbCr camera and decoder buffers come in via sampler conversion), so camera passthrough frames and hardware-decoder output go straight to the GPU. It rides on sk_renderer's existing `skr_tex_create_external_ahb` and is additive and Android-only. The C API returns null on a null buffer or missing device capability, and an error-state tex per the usual asset convention when the import fails; the C# wrapper resolves all of these to null. `Tex.GetHardwareBuffer` returns the backing buffer.