### PR TITLE
Add Backend.Vulkan.GetFrameFenceFd to expose the per-frame fence sync FD

### DIFF
--- a/StereoKit/Native/NativeAPI.cs
+++ b/StereoKit/Native/NativeAPI.cs
@@ -925,6 +925,7 @@ namespace StereoKit
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern BackendXRType backend_xr_get_type();
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern BackendPlatform backend_platform_get();
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern BackendGraphics backend_graphics_get();
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern int          backend_vulkan_get_frame_fence_fd();
 
 		///////////////////////////////////////////
 

--- a/StereoKit/Systems/Backend.cs
+++ b/StereoKit/Systems/Backend.cs
@@ -324,6 +324,24 @@ namespace StereoKit
 			/// `eglCreateContext`.</summary>
 			public static IntPtr Context => NativeAPI.backend_opengl_egl_get_context();
 		}
+
+		/// <summary>When using Vulkan for rendering, this contains a number
+		/// of variables that may be useful for doing advanced rendering
+		/// tasks.</summary>
+		public static class Vulkan
+		{
+			/// <summary>Returns a sync file descriptor for the most recently
+			/// submitted frame's GPU work! Waiting on it (e.g. via
+			/// EGL_ANDROID_native_fence_sync) guarantees all rendering
+			/// submitted up to the last frame end has completed. Call from
+			/// StereoKit's main thread. The caller owns the descriptor and
+			/// must close it. Only functional on platforms and devices
+			/// supporting external fence export.</summary>
+			/// <returns>A sync file descriptor, or -1 when unsupported or no
+			/// frame has been submitted yet.</returns>
+			public static int GetFrameFenceFd()
+				=> NativeAPI.backend_vulkan_get_frame_fence_fd();
+		}
 		
 	}
 }

--- a/StereoKitC/backend.cpp
+++ b/StereoKitC/backend.cpp
@@ -169,6 +169,12 @@ backend_graphics_ backend_graphics_get() {
 }
 
 ///////////////////////////////////////////
+
+int32_t backend_vulkan_get_frame_fence_fd() {
+	return skr_renderer_frame_fence_fd();
+}
+
+///////////////////////////////////////////
 // Legacy D3D11 backend functions - always return null/0 since we're Vulkan-only now
 
 void    *backend_d3d11_get_d3d_device()           { return nullptr; }

--- a/StereoKitC/stereokit.h
+++ b/StereoKitC/stereokit.h
@@ -3614,6 +3614,7 @@ SK_API void*             backend_android_get_activity (void);
 SK_API void*             backend_android_get_jni_env  (void);
 
 SK_API backend_graphics_ backend_graphics_get                  (void);
+SK_API int32_t           backend_vulkan_get_frame_fence_fd     (void);
 SK_API void             *backend_d3d11_get_d3d_device          (void);
 SK_API void             *backend_d3d11_get_d3d_context         (void);
 SK_API void             *backend_d3d11_get_deferred_d3d_context(void);


### PR DESCRIPTION
Managed accessor for sk_renderer's per-frame fence as a sync FD (`skr_renderer_frame_fence_fd`), exposed as `Backend.Vulkan.GetFrameFenceFd` in a new `Backend.Vulkan` class, so an external consumer such as a hardware encoder or another GPU API can wait on frame completion without a CPU stall (e.g. via `EGL_ANDROID_native_fence_sync`). Call it from StereoKit's main thread, since the underlying command rings are per-thread and the fence tracks the frame-submitting thread's work (see StereoKit/sk_renderer#11). Returns -1 when unsupported or before the first submitted frame; the caller owns and closes the descriptor.

Depends on StereoKit/sk_renderer#11, which adds `skr_renderer_frame_fence_fd` on the renderer side.