### PR TITLE
Enable multisample settings in windowed modes

### DIFF
--- a/Examples/StereoKitTest/Demos/DemoRenderScaling.cs
+++ b/Examples/StereoKitTest/Demos/DemoRenderScaling.cs
@@ -28,16 +28,17 @@ class DemoRenderScaling : ITest
 	{
 		UI.WindowBegin("Render Scaling Settings", ref windowPose, new Vec2(0.3f,0));
 
-		if (Backend.XRType != BackendXRType.OpenXR)
-		{
-			UI.Label("These settings are only available in XR");
-			UI.PushEnabled(false);
-		}
+		// The scaling settings are still XR only, but MSAA works everywhere.
+		bool xr = Backend.XRType == BackendXRType.OpenXR;
+		if (!xr)
+			UI.Label("Scaling settings are only available in XR");
 
+		UI.PushEnabled(xr);
 		UI.Label("Swapchain scaling");
 		UI.Label($"{scaling:0.00}", V.XY(0.04f,0));
 		UI.SameLine();
 		UI.HSlider("scaling", ref scaling, 0.1f, 2, 0.05f);
+		UI.PopEnabled();
 
 		UI.HSeparator();
 
@@ -46,27 +47,33 @@ class DemoRenderScaling : ITest
 		UI.SameLine();
 		UI.HSlider("msaa", ref multisample, 1, 8, 1);
 
-		if (Input.Key(Key.Right).IsJustActive()) scaling = Math.Min(scaling + 0.1f, 2);
-		if (Input.Key(Key.Left ).IsJustActive()) scaling = Math.Max(scaling - 0.1f, 0.1f);
+		if (xr && Input.Key(Key.Right).IsJustActive()) scaling = Math.Min(scaling + 0.1f, 2);
+		if (xr && Input.Key(Key.Left ).IsJustActive()) scaling = Math.Max(scaling - 0.1f, 0.1f);
 		if (Input.Key(Key.Up   ).IsJustActive()) multisample = Math.Min(multisample + 1, 8);
 		if (Input.Key(Key.Down ).IsJustActive()) multisample = Math.Max(multisample - 1, 1);
 
 		if (UI.Button("Confirm") || Input.Key(Key.Space).IsJustActive())
 		{
+			// Read back what we set, since MSAA gets clamped to whatever the
+			// GPU actually supports.
 			Renderer.Multisample = (int)multisample;
-			Renderer.Scaling     = scaling;
+			multisample          = Renderer.Multisample;
+			if (xr)
+			{
+				Renderer.Scaling = scaling;
+				scaling          = Renderer.Scaling;
+			}
 		}
 
 		UI.HSeparator();
 
+		UI.PushEnabled(xr);
 		UI.Label("Viewport Scaling");
 		UI.Label($"{viewScaling:0.00}", V.XY(0.04f, 0));
 		UI.SameLine();
 		if (UI.HSlider("viewscaling", ref viewScaling, 0.1f, 1, 0))
 			Renderer.ViewportScaling = viewScaling;
-
-		if (Backend.XRType != BackendXRType.OpenXR)
-			UI.PopEnabled();
+		UI.PopEnabled();
 
 		UI.WindowEnd();
 

--- a/StereoKit/Native/NativeTypes.Custom.cs
+++ b/StereoKit/Native/NativeTypes.Custom.cs
@@ -95,7 +95,8 @@ namespace StereoKit
 		/// <summary>If you know in advance that you need this feature, this
 		/// setting allows you to set `Renderer.Multisample` before
 		/// initialization. This avoids creating and discarding a large and
-		/// unnecessary swapchain object. Default value is 1.</summary>
+		/// unnecessary swapchain object. Leave this at 0 to use the default,
+		/// which is 4.</summary>
 		public int renderMultisample;
 
 		/// <summary>Set the behavior of StereoKit's initial origin. Default

--- a/StereoKit/Systems/Renderer.cs
+++ b/StereoKit/Systems/Renderer.cs
@@ -104,12 +104,18 @@ namespace StereoKit
 		}
 
 		/// <summary>Allows you to set the multisample (MSAA) level of the
-		/// render surface. Valid values are 1, 2, 4, 8, 16, though some OpenXR
-		/// runtimes may clamp this to lower values. Note that while this can
-		/// greatly smooth out edges, it also greatly increases RAM usage and
-		/// fill rate, so use it sparingly. Only works in XR mode. If known in
-		/// advance, set this via SKSettings in initialization. This is a
-		/// _very_ costly change to make.</summary>
+		/// render surface. Valid values are 1, 2, 4, and 8, though this is
+		/// clamped to what the GPU actually supports. Note that while this
+		/// can greatly smooth out edges, it also increases RAM usage and
+		/// fill rate. How much it costs depends a lot on the GPU! Tiled
+		/// renderers, like the mobile chips in most standalone XR headsets,
+		/// resolve MSAA in tile memory, which makes it nearly free. Desktop
+		/// GPUs instead pay memory bandwidth for the multisampled surface
+		/// and for resolving it, so MSAA is far more expensive there,
+		/// especially at high resolutions. A value of 1 skips the
+		/// multisampled surface entirely. If known in advance, set this via
+		/// SKSettings in initialization. This is a _very_ costly change to
+		/// make. Defaults to 4.</summary>
 		public static int Multisample {
 			get => NativeAPI.render_get_multisample();
 			set => NativeAPI.render_set_multisample(value);

--- a/StereoKitC/asset_types/texture.cpp
+++ b/StereoKitC/asset_types/texture.cpp
@@ -1159,9 +1159,16 @@ void _tex_set_color_arr(tex_t texture, int32_t width, int32_t height, void **arr
 		return;
 	}
 
+	// Texture creation caps the sample count to the GPU's max, so compare
+	// against the capped value, or we'd rebuild the texture on every call.
+	int32_t max_msaa = skr_get_max_msaa_samples();
+	if (multisample > max_msaa) multisample = max_msaa;
+	if (multisample < 1)        multisample = 1;
+
 	bool dynamic        = texture->type & tex_type_dynamic;
 	bool different_size = texture->width != width || texture->height != height || (int32_t)texture->gpu_tex.layer_count != array_count;
-	if (!different_size && (array_data == nullptr || *array_data == nullptr))
+	bool different_msaa = skr_tex_is_valid(&texture->gpu_tex) && skr_tex_get_multisample(&texture->gpu_tex) != multisample;
+	if (!different_size && !different_msaa && (array_data == nullptr || *array_data == nullptr))
 		return;
 
 	// Build texture data descriptor from array_data
@@ -1204,8 +1211,8 @@ void _tex_set_color_arr(tex_t texture, int32_t width, int32_t height, void **arr
 		tex_data.row_pitch   = 0; // tightly packed
 	}
 
-	if (!skr_tex_is_valid(&texture->gpu_tex) || different_size || (!different_size && !dynamic)) {
-		if (!different_size && !dynamic)
+	if (!skr_tex_is_valid(&texture->gpu_tex) || different_size || different_msaa || (!different_size && !dynamic)) {
+		if (!different_size && !different_msaa && !dynamic)
 			texture->type &= tex_type_dynamic;
 
 		// Convert tex_type_ to skr_tex_flags_

--- a/StereoKitC/platforms/platform.cpp
+++ b/StereoKitC/platforms/platform.cpp
@@ -13,6 +13,7 @@
 #include "../_stereokit.h"
 #include "../sk_memory.h"
 #include "../systems/vert_format.h"
+#include "../systems/render.h"
 #include "../sk_math.h"
 #include "../log.h"
 #include "../libraries/stref.h"
@@ -168,6 +169,10 @@ bool platform_init() {
 		log_fail_reason(95, log_error, "Failed to initialize sk_renderer!");
 		return false;
 	}
+
+	// The app's multisample request is unvalidated until now, since snapping
+	// it to a real sample count needs the GPU's limits.
+	render_set_multisample(render_get_multisample());
 
 	// The vertex format registry wraps skr vertex types, and travels with
 	// skr's lifecycle — its shutdown pairs with skr_shutdown.

--- a/StereoKitC/systems/render_pipeline.cpp
+++ b/StereoKitC/systems/render_pipeline.cpp
@@ -17,8 +17,11 @@ struct pipeline_surface_t {
 	float                       viewport_scale;
 	int32_t                     array_count;
 	int32_t                     multisample;
+	int32_t                     width;
+	int32_t                     height;
 	color128                    clear_color;
-	tex_t                       tex;
+	tex_t                       tex;       // Null draws into resolve_target
+	tex_t                       depth_tex; // Used when tex is null
 	matrix*                     view_matrices;
 	matrix*                     proj_matrices;
 	bool32_t                    enabled;
@@ -50,11 +53,15 @@ void render_pipeline_draw() {
 		pipeline_surface_t* s = &local.surfaces[i];
 		if (s->enabled == false) continue;
 
-		int32_t width  = (int32_t)fmaxf(1, (float)s->tex->width  * s->viewport_scale);
-		int32_t height = (int32_t)fmaxf(1, (float)s->tex->height * s->viewport_scale);
+		// Drawing direct also means there's nothing left to resolve.
+		skr_tex_t* color_tex = s->tex ? &s->tex->gpu_tex : s->resolve_target;
+		if (color_tex == nullptr) continue;
+
+		int32_t width  = (int32_t)fmaxf(1, (float)s->width  * s->viewport_scale);
+		int32_t height = (int32_t)fmaxf(1, (float)s->height * s->viewport_scale);
 
 		// Get depth buffer if available
-		tex_t      depth_surface = s->tex->depth_buffer;
+		tex_t      depth_surface = s->tex ? s->tex->depth_buffer : s->depth_tex;
 		skr_tex_t* depth_tex     = depth_surface ? &depth_surface->gpu_tex : nullptr;
 
 		// Set up clear values and submit the pass - the pass system handles
@@ -65,9 +72,9 @@ void render_pipeline_draw() {
 		render_draw_queue(list, s->view_matrices, s->proj_matrices, 0, s->array_count, s->layer, 0, width, height);
 
 		skr_pass_t pass = {};
-		pass.color            = &s->tex->gpu_tex;
+		pass.color            = color_tex;
 		pass.depth            = depth_tex;
-		pass.resolve          = s->resolve_target;
+		pass.resolve          = s->tex ? s->resolve_target : nullptr;
 		pass.clear            = clear_flags;
 		pass.clear_color      = clear_color;
 		pass.clear_depth      = 1.0f;
@@ -130,6 +137,7 @@ void render_pipeline_surface_destroy(pipeline_surface_id surface_id) {
 	sk_free(surface->view_matrices);
 	sk_free(surface->proj_matrices);
 	tex_release(surface->tex);
+	tex_release(surface->depth_tex);
 	*surface = {};
 }
 
@@ -138,36 +146,66 @@ void render_pipeline_surface_destroy(pipeline_surface_id surface_id) {
 bool32_t render_pipeline_surface_resize(pipeline_surface_id surface_id, int32_t width, int32_t height, int32_t multisample) {
 	pipeline_surface_t *surface = &local.surfaces[surface_id];
 
-	// If this is the first time getting called, the texture will be null, and
-	// we'll need to create a fresh new one.
-	if (surface->tex == nullptr) {
-		log_diagf("Creating target surface: <~grn>%d<~clr>x<~grn>%d<~clr>x<~grn>%d<~clr>@<~grn>%d<~clr>msaa", width, height, surface->array_count, multisample);
-
-		surface->tex         = tex_create(tex_type_image_nomips | tex_type_rendertarget, surface->color);
-		surface->multisample = multisample;
-		surface->enabled     = true;
-		tex_set_color_arr(surface->tex, width, height, nullptr, surface->array_count, multisample, nullptr);
-
-		char name[64];
-		snprintf(name, sizeof(name), "sk/render/pipeline_surface_%d", surface_id);
-		tex_set_id(surface->tex, name);
-
-		tex_add_zbuffer(surface->tex, surface->depth);
-		tex_t zbuffer = tex_get_zbuffer(surface->tex);
-		snprintf(name, sizeof(name), "sk/render/pipeline_surface_%d_depth", surface_id);
-		tex_set_id (zbuffer, name);
-		tex_release(zbuffer);
-		return true;
+	// The zbuffer has to match the color tex's sample count, so a multisample
+	// change rebuilds both from scratch rather than trying to retarget them.
+	if (surface->tex != nullptr && surface->multisample != multisample) {
+		tex_release(surface->tex);
+		surface->tex = nullptr;
 	}
 
-	// If the surface is the same size, like the OS is sending multiple resize
+	// At 1x there's no intermediate to allocate, just a depth buffer to pair
+	// with the swapchain image.
+	bool    needs_tex = multisample > 1;
+	bool    has_tex   = needs_tex ? surface->tex != nullptr : surface->depth_tex != nullptr;
+	char    name[64];
+
+	// If the surface is the same, like the OS is sending multiple resize
 	// commands at the same dimensions, we don't need to do anything more.
-	if (width == tex_get_width(surface->tex) && height == tex_get_height(surface->tex) && surface->multisample == multisample)
+	if (has_tex && width == surface->width && height == surface->height && surface->multisample == multisample)
 		return false;
 
-	log_diagf("Resizing target surface: <~grn>%d<~clr>x<~grn>%d<~clr>x<~grn>%d<~clr>@<~grn>%d<~clr>msaa", width, height, surface->array_count, multisample);
+	log_diagf("%s target surface: <~grn>%d<~clr>x<~grn>%d<~clr>x<~grn>%d<~clr>@<~grn>%d<~clr>msaa", has_tex ? "Resizing" : "Creating", width, height, surface->array_count, multisample);
+
+	// Only the very first sizing enables the surface, backends own the flag
+	// after that.
+	if (surface->width == 0) surface->enabled = true;
+	surface->width       = width;
+	surface->height      = height;
 	surface->multisample = multisample;
-	tex_set_color_arr(surface->tex, width, height, nullptr, surface->array_count, multisample, nullptr);
+
+	if (needs_tex) {
+		// Release the 1x depth first, it shares an id with the zbuffer below.
+		tex_release(surface->depth_tex);
+		surface->depth_tex = nullptr;
+
+		bool fresh = surface->tex == nullptr;
+		if (fresh) {
+			surface->tex = tex_create(tex_type_image_nomips | tex_type_rendertarget, surface->color);
+			snprintf(name, sizeof(name), "sk/render/pipeline_surface_%d", surface_id);
+			tex_set_id(surface->tex, name);
+		}
+		tex_set_color_arr(surface->tex, width, height, nullptr, surface->array_count, multisample, nullptr);
+
+		// An existing zbuffer already tracks the color tex, and already has
+		// the id below. Naming it a second time would collide with itself.
+		if (fresh) {
+			tex_add_zbuffer(surface->tex, surface->depth);
+			tex_t zbuffer = tex_get_zbuffer(surface->tex);
+			snprintf(name, sizeof(name), "sk/render/pipeline_surface_%d_depth", surface_id);
+			tex_set_id (zbuffer, name);
+			tex_release(zbuffer);
+		}
+	} else {
+		tex_release(surface->tex);
+		surface->tex = nullptr;
+
+		if (surface->depth_tex == nullptr) {
+			surface->depth_tex = tex_create(tex_type_zbuffer, surface->depth);
+			snprintf(name, sizeof(name), "sk/render/pipeline_surface_%d_depth", surface_id);
+			tex_set_id(surface->depth_tex, name);
+		}
+		tex_set_color_arr(surface->depth_tex, width, height, nullptr, surface->array_count, 1, nullptr);
+	}
 
 	render_update_projection();
 	return true;
@@ -244,8 +282,8 @@ void render_pipeline_surface_get_surface_info(pipeline_surface_id surface_id, in
 	*out_array_idx   = view_idx;
 	out_xywh_rect[0] = 0;
 	out_xywh_rect[1] = 0;
-	out_xywh_rect[2] = surface->tex ? (int32_t)fmaxf(1, (float)surface->tex->width  * surface->viewport_scale) : 0;
-	out_xywh_rect[3] = surface->tex ? (int32_t)fmaxf(1, (float)surface->tex->height * surface->viewport_scale) : 0;
+	out_xywh_rect[2] = surface->width  > 0 ? (int32_t)fmaxf(1, (float)surface->width  * surface->viewport_scale) : 0;
+	out_xywh_rect[3] = surface->height > 0 ? (int32_t)fmaxf(1, (float)surface->height * surface->viewport_scale) : 0;
 }
 
 ///////////////////////////////////////////
@@ -255,6 +293,16 @@ void render_pipeline_surface_set_tex(pipeline_surface_id surface_id, tex_t tex) 
 	if (tex)          tex_addref (tex);
 	if (surface->tex) tex_release(surface->tex);
 	surface->tex = tex;
+
+	// An externally provided tex brings its own size, sample count, and depth
+	// along with it. Callers that use this don't also call resize.
+	if (tex) {
+		surface->width       = tex->width;
+		surface->height      = tex->height;
+		surface->multisample = skr_tex_get_multisample(&tex->gpu_tex);
+		tex_release(surface->depth_tex);
+		surface->depth_tex = nullptr;
+	}
 }
 
 ///////////////////////////////////////////

--- a/StereoKitC/xr_backends/simulator.cpp
+++ b/StereoKitC/xr_backends/simulator.cpp
@@ -128,7 +128,7 @@ bool simulator_init() {
 void sim_surface_resize(pipeline_surface_id surface, int32_t width, int32_t height) {
 	device_data.display_width  = width;
 	device_data.display_height = height;
-	render_pipeline_surface_resize(surface, width, height, 8);
+	render_pipeline_surface_resize(surface, width, height, render_get_multisample());
 }
 
 ///////////////////////////////////////////
@@ -299,13 +299,15 @@ void simulator_step_end() {
 		render_pipeline_skip_present();
 
 	// Resize AFTER frame_end (not mid-frame) to avoid command buffer ref_count imbalance
-	if (acquire == skr_acquire_needs_resize && skr_surface_is_valid(&sim_skr_surface)) {
-		skr_surface_resize(&sim_skr_surface);
-		if (sim_skr_surface.size.x > 0 && sim_skr_surface.size.y > 0)
-			sim_surface_resize(sim_surface, sim_skr_surface.size.x, sim_skr_surface.size.y);
-	} else if (acquire == skr_acquire_surface_lost) {
+	if (acquire == skr_acquire_surface_lost) {
 		vkDeviceWaitIdle(skr_get_vk_device());
 		skr_surface_destroy(&sim_skr_surface);
+	} else if (skr_surface_is_valid(&sim_skr_surface)) {
+		if (acquire == skr_acquire_needs_resize)
+			skr_surface_resize(&sim_skr_surface);
+		// Also picks up multisample changes, and no-ops when nothing changed.
+		if (sim_skr_surface.size.x > 0 && sim_skr_surface.size.y > 0)
+			sim_surface_resize(sim_surface, sim_skr_surface.size.x, sim_skr_surface.size.y);
 	}
 }
 

--- a/StereoKitC/xr_backends/window.cpp
+++ b/StereoKitC/xr_backends/window.cpp
@@ -127,7 +127,7 @@ void window_physical_key_interact() {
 void window_surface_resize(pipeline_surface_id surface, int32_t width, int32_t height) {
 	device_data.display_width  = width;
 	device_data.display_height = height;
-	render_pipeline_surface_resize(surface, width, height, 8);
+	render_pipeline_surface_resize(surface, width, height, render_get_multisample());
 }
 
 ///////////////////////////////////////////
@@ -236,13 +236,15 @@ void window_step_end() {
 		render_pipeline_skip_present();
 
 	// Resize AFTER frame_end (not mid-frame) to avoid command buffer ref_count imbalance
-	if (acquire == skr_acquire_needs_resize && skr_surface_is_valid(&local->skr_surface)) {
-		skr_surface_resize(&local->skr_surface);
-		if (local->skr_surface.size.x > 0 && local->skr_surface.size.y > 0)
-			window_surface_resize(local->surface, local->skr_surface.size.x, local->skr_surface.size.y);
-	} else if (acquire == skr_acquire_surface_lost) {
+	if (acquire == skr_acquire_surface_lost) {
 		vkDeviceWaitIdle(skr_get_vk_device());
 		skr_surface_destroy(&local->skr_surface);
+	} else if (skr_surface_is_valid(&local->skr_surface)) {
+		if (acquire == skr_acquire_needs_resize)
+			skr_surface_resize(&local->skr_surface);
+		// Also picks up multisample changes, and no-ops when nothing changed.
+		if (local->skr_surface.size.x > 0 && local->skr_surface.size.y > 0)
+			window_surface_resize(local->surface, local->skr_surface.size.x, local->skr_surface.size.y);
 	}
 }
 


### PR DESCRIPTION
- Default MSAA in window based modes is now 4.
- Changing MSAA at runtime/startup now works in window based modes.
- Fixes windowed modes on devices that may have not been capable of 8x MSAA.