### PR TITLE
Backend.Vulkan for requesting extensions

### DIFF
--- a/Examples/StereoKitTest/Docs/DocBackend.cs
+++ b/Examples/StereoKitTest/Docs/DocBackend.cs
@@ -3,6 +3,8 @@
 // Copyright (c) 2019-2025 Nick Klingensmith
 // Copyright (c) 2025 Qualcomm Technologies, Inc.
 
+using System;
+using System.Runtime.InteropServices;
 using StereoKit;
 using StereoKit.Framework;
 
@@ -73,6 +75,91 @@ class Win32PerformanceCounterExt : IStepper
 
 	// A more complicated extension might use these, but this EXT does not
 	// require any actions on-Step.
+	public void Shutdown() { }
+	public void Step() { }
+}
+/// :End:
+
+/// :CodeSample: Backend.Vulkan Backend.Graphics BackendVulkanRequest IStepper
+/// ### Requesting Vulkan Extensions
+///
+/// StereoKit renders with Vulkan, and `Backend.Vulkan` lets you opt into extra
+/// Vulkan instance/device extensions and device features that StereoKit
+/// wouldn't normally request. Register a `BackendVulkanRequest` _before_
+/// `SK.Initialize`, then after initialization check whether it enabled and
+/// resolve any functions it provides.
+///
+/// A good practical use is `VK_EXT_debug_utils`, which lets you attach
+/// human-readable names to Vulkan objects so they show up nicely in tools like
+/// RenderDoc or the validation layers. Here we request the (instance)
+/// extension, then use it to name the `VkDevice` StereoKit is rendering with.
+/// This is implemented via an `IStepper`, so it must be added before
+/// `SK.Initialize`.
+class VulkanDebugNamesExt : IStepper
+{
+	const string debugUtilsExt = "VK_EXT_debug_utils";
+
+	// A C# equivalent of vkSetDebugUtilsObjectNameEXT and the struct it takes.
+	[StructLayout(LayoutKind.Sequential)]
+	struct VkDebugUtilsObjectNameInfoEXT
+	{
+		public int    sType;
+		public IntPtr pNext;
+		public int    objectType;
+		public ulong  objectHandle;
+		[MarshalAs(UnmanagedType.LPUTF8Str)] public string pObjectName;
+	}
+	delegate int VkSetDebugUtilsObjectNameEXT(IntPtr device, in VkDebugUtilsObjectNameInfoEXT nameInfo);
+	static        VkSetDebugUtilsObjectNameEXT vkSetDebugUtilsObjectNameEXT;
+
+	public bool Enabled { get; private set; }
+
+	public VulkanDebugNamesExt()
+	{
+		// Vulkan requests must happen before StereoKit initializes, so this
+		// IStepper needs to be added _before_ `SK.Initialize`.
+		if (SK.IsInitialized)
+			Log.Err("Vulkan extensions must be requested before StereoKit is initialized!");
+
+		// debug_utils is an _instance_ extension. A named request lets us query
+		// it later, and leaving `required` false means SK still starts up if
+		// the extension isn't available.
+		Backend.Vulkan.Request(new BackendVulkanRequest {
+			name               = "debug_utils",
+			required           = false,
+			instanceExtensions = new string[] { debugUtilsExt },
+		});
+	}
+
+	public bool Initialize()
+	{
+		// Confirm we're on Vulkan, the extension enabled, and our function
+		// bound. RequestEnabled("debug_utils") would also work here.
+		Enabled =
+			Backend.Graphics == BackendGraphics.Vulkan &&
+			Backend.Vulkan.ExtEnabled(debugUtilsExt)   &&
+			LoadBindings();
+
+		if (Enabled)
+		{
+			// Give the VkDevice a friendly name for debugging tools.
+			VkDebugUtilsObjectNameInfoEXT info = new VkDebugUtilsObjectNameInfoEXT {
+				sType        = 1000128000, // VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT
+				objectType   = 3,          // VK_OBJECT_TYPE_DEVICE
+				objectHandle = (ulong)Backend.Vulkan.Device,
+				pObjectName  = "StereoKit Device",
+			};
+			vkSetDebugUtilsObjectNameEXT(Backend.Vulkan.Device, info);
+		}
+		return Enabled;
+	}
+
+	private bool LoadBindings()
+	{
+		vkSetDebugUtilsObjectNameEXT = Backend.Vulkan.GetFunction<VkSetDebugUtilsObjectNameEXT>("vkSetDebugUtilsObjectNameEXT");
+		return vkSetDebugUtilsObjectNameEXT != null;
+	}
+
 	public void Shutdown() { }
 	public void Step() { }
 }

--- a/Examples/StereoKitTest/Program.cs
+++ b/Examples/StereoKitTest/Program.cs
@@ -59,6 +59,12 @@ class Program
 		WindowLog = SK.AddStepper<LogWindow>();
 		WindowLog.Enabled = false;
 
+		// Vulkan backend requests also need registered before SK.Initialize.
+		// This empty request enables vacuously, so TestBackendVulkan can verify
+		// the request round-trip after initialization.
+		if (Tests.IsTesting)
+			Backend.Vulkan.Request(new BackendVulkanRequest { name = "sk_test_request" });
+
 		// Initialize StereoKit
 		if (!SK.Initialize(settings))
 			Environment.Exit(1);

--- a/Examples/StereoKitTest/Tests/TestBackendVulkan.cs
+++ b/Examples/StereoKitTest/Tests/TestBackendVulkan.cs
@@ -1,0 +1,30 @@
+using StereoKit;
+using System;
+
+// Verifies the Backend.Vulkan extension/feature request surface: the request
+// registered before init (see Program.Main) enabled, extension/request queries
+// behave, and Vulkan function pointers resolve. Vulkan is StereoKit's only
+// graphics backend, so this runs on every supported platform.
+class TestBackendVulkan : ITest
+{
+	public void Initialize()
+	{
+		Tests.Test(() => Backend.Graphics == BackendGraphics.Vulkan);
+
+		// The empty request registered in Program.Main enables vacuously - no
+		// extensions or features to miss.
+		Tests.Test(() => Backend.Vulkan.RequestEnabled("sk_test_request") == true);
+		// An unregistered request name is simply not enabled.
+		Tests.Test(() => Backend.Vulkan.RequestEnabled("not_a_registered_request") == false);
+
+		// A made-up extension is never enabled.
+		Tests.Test(() => Backend.Vulkan.ExtEnabled("VK_KHR_not_a_real_extension") == false);
+
+		// Core Vulkan entry points always resolve, missing ones return zero.
+		Tests.Test(() => Backend.Vulkan.GetFunctionPtr("vkCreateBuffer")   != IntPtr.Zero);
+		Tests.Test(() => Backend.Vulkan.GetFunctionPtr("vkNotARealVkFunc") == IntPtr.Zero);
+	}
+
+	public void Shutdown() { }
+	public void Step()     { }
+}

--- a/StereoKit/Native/NativeAPI.Custom.cs
+++ b/StereoKit/Native/NativeAPI.Custom.cs
@@ -83,6 +83,12 @@ namespace StereoKit
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)]
 		public static extern void render_to(IntPtr to_rendertarget, int to_target_index, [In] Matrix[] in_arr_cameras, [In] Matrix[] in_arr_projections, int view_count, in RenderSettingsNative opt_settings);
 
+		// backend_vulkan_request takes arrays of extension strings and feature
+		// structs, so it's marshaled by hand in Backend.Vulkan.Request rather
+		// than through the generated binding.
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)]
+		public static extern void backend_vulkan_request(in BackendVulkanRequestT request);
+
 		// tex_create_mem with byte array
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)]
 		public static extern IntPtr tex_create_mem([In] byte[] data, UIntPtr data_size, [MarshalAs(UnmanagedType.Bool)] bool srgb_data, int priority);

--- a/StereoKit/Native/NativeAPI.cs
+++ b/StereoKit/Native/NativeAPI.cs
@@ -933,6 +933,11 @@ namespace StereoKit
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern uint         backend_vulkan_get_queue_family_index(BackendVulkanQueue queue);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         backend_vulkan_queue_lock(BackendVulkanQueue queue);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         backend_vulkan_queue_unlock(BackendVulkanQueue queue);
+		[return: MarshalAs(UnmanagedType.Bool)]
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern bool         backend_vulkan_request_enabled([MarshalAs(UnmanagedType.LPUTF8Str)] string name);
+		[return: MarshalAs(UnmanagedType.Bool)]
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern bool         backend_vulkan_ext_enabled([MarshalAs(UnmanagedType.LPUTF8Str)] string extension_name);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr       backend_vulkan_get_function([MarshalAs(UnmanagedType.LPUTF8Str)] string function_name);
 
 		///////////////////////////////////////////
 

--- a/StereoKit/Systems/Backend.cs
+++ b/StereoKit/Systems/Backend.cs
@@ -400,7 +400,184 @@ namespace StereoKit
 			/// frame has been submitted yet.</returns>
 			public static int GetFrameFenceFd()
 				=> NativeAPI.backend_vulkan_get_frame_fence_fd();
+
+			/// <summary>Registers a request for Vulkan instance/device
+			/// extensions and device features. This MUST be called before
+			/// SK.Initialize. A request enables atomically: only when all of
+			/// its extensions are present, and every requested feature bit is
+			/// supported. If <see cref="BackendVulkanRequest.required"/> is true
+			/// and the request can't be satisfied, SK.Initialize will fail!
+			/// After initialization, check the result with
+			/// <see cref="RequestEnabled"/> (by name) or <see cref="ExtEnabled"/>
+			/// (by extension name).</summary>
+			/// <param name="request">The extensions and features to request. Its
+			/// arrays and feature struct pointers only need to remain valid for
+			/// the duration of this call - StereoKit copies everything it needs.
+			/// </param>
+			public static void Request(BackendVulkanRequest request)
+			{
+				IntPtr nameStr = Marshal.StringToCoTaskMemUTF8(request.name);
+				IntPtr instArr = StrArrToNative(request.instanceExtensions, out int instCount);
+				IntPtr devArr  = StrArrToNative(request.deviceExtensions,   out int devCount);
+
+				int    featCount = request.features == null ? 0 : request.features.Length;
+				IntPtr featArr   = IntPtr.Zero;
+				if (featCount > 0)
+				{
+					int size = Marshal.SizeOf<BackendVulkanFeature>();
+					featArr  = Marshal.AllocHGlobal(size * featCount);
+					for (int i = 0; i < featCount; i++)
+						Marshal.StructureToPtr(request.features[i], featArr + i * size, false);
+				}
+
+				BackendVulkanRequestT native = new BackendVulkanRequestT {
+					name                   = nameStr,
+					required               = request.required,
+					instanceExtensions     = instArr,
+					instanceExtensionCount = instCount,
+					deviceExtensions       = devArr,
+					deviceExtensionCount   = devCount,
+					features               = featArr,
+					featureCount           = featCount,
+				};
+				NativeAPI.backend_vulkan_request(native);
+
+				// StereoKit copies the request, so temporaries can be freed now.
+				FreeStrArr(instArr, instCount);
+				FreeStrArr(devArr,  devCount);
+				if (featArr != IntPtr.Zero) Marshal.FreeHGlobal   (featArr);
+				Marshal.FreeCoTaskMem(nameStr);
+			}
+
+			/// <summary>Checks if a named request registered via
+			/// <see cref="Request"/> was successfully enabled. This MUST only be
+			/// called after SK.Initialize.</summary>
+			/// <param name="name">The name given to the BackendVulkanRequest.
+			/// </param>
+			/// <returns>If the request's extensions and features were all
+			/// enabled.</returns>
+			public static bool RequestEnabled(string name)
+				=> NativeAPI.backend_vulkan_request_enabled(name);
+
+			/// <summary>Checks if a Vulkan extension was enabled at init,
+			/// regardless of which request asked for it. This MUST only be
+			/// called after SK.Initialize.</summary>
+			/// <param name="extensionName">The extension name, for example
+			/// "VK_KHR_swapchain".</param>
+			/// <returns>If the extension is available to use.</returns>
+			public static bool ExtEnabled(string extensionName)
+				=> NativeAPI.backend_vulkan_ext_enabled(extensionName);
+
+			/// <summary>Resolves a Vulkan function pointer, using
+			/// `vkGetDeviceProcAddr` with a `vkGetInstanceProcAddr` fallback.
+			/// Use this to call into extensions you've enabled via
+			/// <see cref="Request"/>. You can use
+			/// `Marshal.GetDelegateForFunctionPointer` to turn the result into a
+			/// callable delegate.</summary>
+			/// <param name="functionName">The Vulkan function name, for example
+			/// "vkCmdBeginRenderingKHR".</param>
+			/// <returns>A function pointer, or IntPtr.Zero on failure.</returns>
+			public static IntPtr GetFunctionPtr(string functionName)
+				=> NativeAPI.backend_vulkan_get_function(functionName);
+
+			/// <summary>Resolves a Vulkan function pointer and wraps it as a
+			/// delegate, using `vkGetDeviceProcAddr` with a
+			/// `vkGetInstanceProcAddr` fallback. Use this to call into extensions
+			/// you've enabled via <see cref="Request"/>.</summary>
+			/// <param name="functionName">The Vulkan function name, for example
+			/// "vkCmdBeginRenderingKHR".</param>
+			/// <returns>A delegate, or null on failure.</returns>
+			public static TDelegate GetFunction<TDelegate>(string functionName)
+			{
+				IntPtr fn = NativeAPI.backend_vulkan_get_function(functionName);
+				if (fn == IntPtr.Zero) return default;
+				return Marshal.GetDelegateForFunctionPointer<TDelegate>(fn);
+			}
+
+			static IntPtr StrArrToNative(string[] strings, out int count)
+			{
+				count = strings == null ? 0 : strings.Length;
+				if (count == 0) return IntPtr.Zero;
+				IntPtr block = Marshal.AllocHGlobal(IntPtr.Size * count);
+				for (int i = 0; i < count; i++)
+					Marshal.WriteIntPtr(block, i * IntPtr.Size, Marshal.StringToCoTaskMemUTF8(strings[i]));
+				return block;
+			}
+
+			static void FreeStrArr(IntPtr block, int count)
+			{
+				if (block == IntPtr.Zero) return;
+				for (int i = 0; i < count; i++)
+					Marshal.FreeCoTaskMem(Marshal.ReadIntPtr(block, i * IntPtr.Size));
+				Marshal.FreeHGlobal(block);
+			}
 		}
-		
+
+	}
+
+	/// <summary>A single Vulkan feature struct to request as part of a
+	/// <see cref="BackendVulkanRequest"/>. See
+	/// <see cref="Backend.Vulkan.Request"/> for details.</summary>
+	public struct BackendVulkanFeature
+	{
+		/// <summary>A pointer to a pinned VkPhysicalDevice*Features struct with
+		/// its sType set, and the feature bits you want enabled set to VK_TRUE.
+		/// This must NOT be a VkPhysicalDeviceFeatures2. The pointer only needs
+		/// to remain valid for the duration of the Backend.Vulkan.Request call.
+		/// </summary>
+		public IntPtr vkStruct;
+		/// <summary>The size of the struct vkStruct points at, in bytes.
+		/// </summary>
+		public int    size;
+
+		/// <summary>Creates a feature request from a pointer to a pinned
+		/// VkPhysicalDevice*Features struct and its size in bytes.</summary>
+		/// <param name="vkStruct">A pointer to a pinned VkPhysicalDevice*Features
+		/// struct, with its sType and desired VK_TRUE bits set.</param>
+		/// <param name="size">The size of the struct vkStruct points at, in
+		/// bytes.</param>
+		public BackendVulkanFeature(IntPtr vkStruct, int size)
+		{
+			this.vkStruct = vkStruct;
+			this.size     = size;
+		}
+	}
+
+	/// <summary>A request for Vulkan instance/device extensions and device
+	/// features, registered via <see cref="Backend.Vulkan.Request"/> before
+	/// SK.Initialize.</summary>
+	public struct BackendVulkanRequest
+	{
+		/// <summary>An optional name used as a handle for
+		/// <see cref="Backend.Vulkan.RequestEnabled"/>. null makes the request
+		/// anonymous - it still contributes its extensions and features, but
+		/// can't be queried by name.</summary>
+		public string   name;
+		/// <summary>If true, SK.Initialize will fail should this request go
+		/// unsatisfied. If false, an unmet request is simply left disabled.
+		/// </summary>
+		public bool     required;
+		/// <summary>Vulkan instance extension names this request needs.</summary>
+		public string[] instanceExtensions;
+		/// <summary>Vulkan device extension names this request needs.</summary>
+		public string[] deviceExtensions;
+		/// <summary>Vulkan device features this request needs. Their bits are
+		/// queried for support before being enabled.</summary>
+		public BackendVulkanFeature[] features;
+	}
+
+	// Native ABI mirror of backend_vulkan_request_t, filled and freed by
+	// Backend.Vulkan.Request.
+	[StructLayout(LayoutKind.Sequential)]
+	internal struct BackendVulkanRequestT
+	{
+		public IntPtr name;
+		[MarshalAs(UnmanagedType.Bool)] public bool required;
+		public IntPtr instanceExtensions;
+		public int    instanceExtensionCount;
+		public IntPtr deviceExtensions;
+		public int    deviceExtensionCount;
+		public IntPtr features;
+		public int    featureCount;
 	}
 }

--- a/StereoKitC/backend.cpp
+++ b/StereoKitC/backend.cpp
@@ -215,4 +215,30 @@ void backend_vulkan_queue_unlock(backend_vulkan_queue_ queue) {
 	skr_vk_queue_unlock(backend_vulkan_get_queue_family_index(queue));
 }
 
+///////////////////////////////////////////
+
+void backend_vulkan_request(const backend_vulkan_request_t *request) {
+	if (sk_is_initialized()) {
+		log_err("backend_vulkan_request must be called BEFORE StereoKit initialization!");
+		return;
+	}
+	skr_vk_request_t r = {};
+	r.name                     = request->name;
+	r.required                 = request->required != 0;
+	r.instance_extensions      = request->instance_extensions;
+	r.instance_extension_count = request->instance_extension_count;
+	r.device_extensions        = request->device_extensions;
+	r.device_extension_count   = request->device_extension_count;
+	// backend_vulkan_feature_t is layout-identical to skr_vk_feature_t.
+	r.features                 = (const skr_vk_feature_t*)request->features;
+	r.feature_count            = request->feature_count;
+	skr_vk_request(&r);
+}
+
+///////////////////////////////////////////
+
+bool32_t backend_vulkan_request_enabled(const char *name)            { return skr_vk_request_enabled(name); }
+bool32_t backend_vulkan_ext_enabled    (const char *extension_name) { return skr_vk_ext_enabled(extension_name); }
+void    *backend_vulkan_get_function   (const char *function_name)  { return skr_vk_get_function(function_name); }
+
 }

--- a/StereoKitC/stereokit.h
+++ b/StereoKitC/stereokit.h
@@ -3641,6 +3641,41 @@ typedef enum backend_vulkan_queue_ {
 
 typedef uint64_t openxr_handle_t;
 
+/*A single Vulkan feature struct to request as part of a
+  backend_vulkan_request_t. See backend_vulkan_request for details.*/
+typedef struct backend_vulkan_feature_t {
+	/*A pointer to a VkPhysicalDevice*Features struct with its sType set, and
+	  the feature bits you want enabled set to VK_TRUE. This must NOT be a
+	  VkPhysicalDeviceFeatures2, the core features chain is handled separately.*/
+	const void* vk_struct;
+	/*The size of the struct vk_struct points at, in bytes.*/
+	int32_t     size;
+} backend_vulkan_feature_t;
+
+/*A request for Vulkan instance/device extensions and device features.
+  Register it with backend_vulkan_request before StereoKit initializes. A
+  request enables atomically: only when all of its extensions are present and
+  every requested feature bit is supported. See backend_vulkan_request.*/
+typedef struct backend_vulkan_request_t {
+	/*An optional name used as a handle for backend_vulkan_request_enabled.
+	  null makes the request anonymous, it still contributes its extensions and
+	  features, but can't be queried by name.*/
+	const char*                     name;
+	/*If true, StereoKit initialization will fail should this request go
+	  unsatisfied. If false, an unmet request is simply left disabled.*/
+	bool32_t                        required;
+	/*An array of Vulkan instance extension names this request needs.*/
+	const char**                    instance_extensions;
+	int32_t                         instance_extension_count;
+	/*An array of Vulkan device extension names this request needs.*/
+	const char**                    device_extensions;
+	int32_t                         device_extension_count;
+	/*An array of Vulkan device features this request needs. Their bits are
+	  queried for support before being enabled.*/
+	const backend_vulkan_feature_t* features;
+	int32_t                         feature_count;
+} backend_vulkan_request_t;
+
 SK_API backend_xr_type_  backend_xr_get_type                (void);
 SK_API openxr_handle_t   backend_openxr_get_instance        (void);
 SK_API openxr_handle_t   backend_openxr_get_session         (void);
@@ -3676,6 +3711,10 @@ SK_API void             *backend_vulkan_get_queue              (backend_vulkan_q
 SK_API uint32_t          backend_vulkan_get_queue_family_index (backend_vulkan_queue_ queue);
 SK_API void              backend_vulkan_queue_lock             (backend_vulkan_queue_ queue);
 SK_API void              backend_vulkan_queue_unlock           (backend_vulkan_queue_ queue);
+SK_API void              backend_vulkan_request                (const backend_vulkan_request_t *request);
+SK_API bool32_t          backend_vulkan_request_enabled        (const char *name);
+SK_API bool32_t          backend_vulkan_ext_enabled            (const char *extension_name);
+SK_API void             *backend_vulkan_get_function           (const char *function_name);
 
 ///////////////////////////////////////////
 

--- a/tools/StereoKitAPIGen/SKOverridesCSharp.txt
+++ b/tools/StereoKitAPIGen/SKOverridesCSharp.txt
@@ -78,6 +78,7 @@ color128 Color
 transparency_msaa MSAA
 
 sk_settings_t SKSettings
+backend_vulkan_request_t BackendVulkanRequest
 vind_t uint
 vert_t Vertex
 vert_component_t VertComponent
@@ -118,6 +119,8 @@ ui_scroll_ UIScroll
 # Complex structs in NativeTypes.cs with special handling
 @noimpl sk_settings_t rect_t
 @noimpl hand_sim_id_t id_hash_t
+# Request struct has string/feature arrays, hand-marshaled in Backend.Vulkan.Request
+@noimpl backend_vulkan_request_t
 
 # UI types with special handling
 # (none currently)
@@ -131,6 +134,8 @@ ui_scroll_ UIScroll
 # rather than the generator's IntPtr.
 @noimpl render_to render_list_draw_now
 @noimpl spherical_harmonics_t hand_t controller_t file_filter_t
+# Request takes arrays of strings/features, hand-marshaled in NativeAPI.Custom.cs
+@noimpl backend_vulkan_request
 
 # Enums with hand-written struct implementations
 @noimpl text_align_


### PR DESCRIPTION
This adds:
- `Backend.Vulkan.Request`
- `Backend.Vulkan.RequestEnabled`
- `Backend.Vulkan.ExtEnabled`
- `Backend.Vulkan.GetFunction`
- `Backend.Vulkan.GetFunctionPtr`

This allows for enabling Vulkan Device and Instance extensions along with their next-chained setup structs.

See [DocBackend.cs](https://github.com/StereoKit/StereoKit/blob/develop/Examples/StereoKitTest/Docs/DocBackend.cs#L98) for usage!