### PR TITLE
Bump skr, don't block unrecognized shader features

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -307,7 +307,7 @@ if (NOT SK_LOCAL_SK_RENDERER)
   CPMAddPackage(
     NAME sk_renderer
     GITHUB_REPOSITORY StereoKit/sk_renderer
-    GIT_TAG v2026.7.21
+    GIT_TAG v2026.7.24
   )
 else()
   # For building directly with in-progress sk_renderer changes, point this to your


### PR DESCRIPTION
sk_renderer was erroring out shaders that had unrecognized features. This may have been picking up some debug features from glslang, but would certainly block more advanced work that SVSL's inline spirv would enable.