### PR TITLE
Build fixes - multi-TFM dedup, clean, loader strip, glslang override

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -299,9 +299,9 @@ set(SKR_BUILD_EXAMPLES OFF CACHE PATH "Faster build" FORCE)
 # If we're only using the SVSL shader compiler, we can drop glslang from
 # skshaderc and save ourselves a lot of binary size and build time!
 if (SK_USE_SVSL)
-  set(SKSHADERC_ENABLE_GLSLANG OFF CACHE BOOL "Not needed with SVSL" FORCE)
+  set(SKSHADERC_ENABLE_GLSLANG OFF CACHE BOOL "Not needed with SVSL")
 else()
-  set(SKSHADERC_ENABLE_GLSLANG ON  CACHE BOOL "Required for HLSL shaders" FORCE)
+  set(SKSHADERC_ENABLE_GLSLANG ON  CACHE BOOL "Required for HLSL shaders")
 endif()
 if (NOT SK_LOCAL_SK_RENDERER)
   CPMAddPackage(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -700,11 +700,6 @@ if (NOT MSVC)
         COMMAND ${CMAKE_OBJCOPY} --add-gnu-debuglink=$<TARGET_FILE_DIR:StereoKitC>/$<TARGET_FILE_PREFIX:StereoKitC>$<TARGET_FILE_BASE_NAME:StereoKitC>${SK_BIN_DEBUG_EXT} $<TARGET_FILE:StereoKitC>
       )
     endif()
-    if (SK_DYNAMIC_OPENXR AND SK_STRIP_DEBUG_SYMBOLS)
-      add_custom_command(TARGET StereoKitC POST_BUILD
-        COMMAND ${CMAKE_STRIP} --strip-debug $<TARGET_FILE:openxr_loader>
-      )
-    endif()
   endif()
 else()
   set(SK_BIN_DEBUG_EXT ".pdb")
@@ -861,9 +856,15 @@ if(SK_DISTRIBUTE)
       COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE_DIR:StereoKitC>/$<TARGET_FILE_PREFIX:StereoKitC>$<TARGET_FILE_BASE_NAME:StereoKitC>${SK_BIN_DEBUG_EXT}" "${CMAKE_CURRENT_SOURCE_DIR}/${SK_DISTRIBUTE_FOLDER}/bin/${SK_BIN_OS}/${SK_ARCH}/$<CONFIG>/$<TARGET_FILE_PREFIX:StereoKitC>$<TARGET_FILE_BASE_NAME:StereoKitC>${SK_BIN_DEBUG_EXT}" )
   endif()
   if (SK_DYNAMIC_OPENXR)
+    set(SK_OPENXR_LOADER_DIST_SRC "$<TARGET_FILE:openxr_loader>")
+    if (SK_STRIP_DEBUG_SYMBOLS AND NOT MSVC AND NOT APPLE)
+      set(SK_OPENXR_LOADER_DIST_SRC "${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_FILE_NAME:openxr_loader>.stripped")
+      add_custom_command(TARGET StereoKitC POST_BUILD
+        COMMAND ${CMAKE_STRIP} --strip-debug -o "${SK_OPENXR_LOADER_DIST_SRC}" "$<TARGET_FILE:openxr_loader>" )
+    endif()
     add_custom_command(TARGET StereoKitC POST_BUILD
       COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_CURRENT_SOURCE_DIR}/${SK_DISTRIBUTE_FOLDER}/bin/${SK_BIN_OS}/${SK_ARCH}/$<CONFIG>/standard"
-      COMMAND ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:openxr_loader>" "${CMAKE_CURRENT_SOURCE_DIR}/${SK_DISTRIBUTE_FOLDER}/bin/${SK_BIN_OS}/${SK_ARCH}/$<CONFIG>/standard/$<TARGET_FILE_NAME:openxr_loader>" )
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different "${SK_OPENXR_LOADER_DIST_SRC}" "${CMAKE_CURRENT_SOURCE_DIR}/${SK_DISTRIBUTE_FOLDER}/bin/${SK_BIN_OS}/${SK_ARCH}/$<CONFIG>/standard/$<TARGET_FILE_NAME:openxr_loader>" )
   endif()
   # Copy sk_app.jar on Android (Java classes for file dialogs, activity results)
   if (ANDROID AND TARGET sk_app_jar)

--- a/StereoKit/BuildStereoKitNative.proj
+++ b/StereoKit/BuildStereoKitNative.proj
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+	<Target Name="StereoKit_BuildNative">
+		<Message Condition="!Exists('$(SKSDKCacheFile)')" Importance="high" Text="[StereoKit SDK] Configuring StereoKitC"/>
+		<Exec Condition="!Exists('$(SKSDKCacheFile)')" WorkingDirectory="$(SKSDKFolder)" Command="cmake --preset $(SKSDKPreset) -DSK_BUILD_TESTS=OFF" />
+		<Exec WorkingDirectory="$(SKSDKFolder)" Command="cmake --build --preset $(SKSDKPreset)" />
+	</Target>
+
+	<Target Name="StereoKit_CleanNative" Condition="Exists('$(SKSDKIntermediateDir)')">
+		<Message Importance="high" Text="[StereoKit SDK] Removing $(SKSDKIntermediateDir)"/>
+		<Exec Command="cmake -E rm -rf &quot;$(SKSDKIntermediateDir)&quot;" />
+	</Target>
+</Project>

--- a/StereoKit/BuildStereoKitSDK.targets
+++ b/StereoKit/BuildStereoKitSDK.targets
@@ -67,7 +67,7 @@
 	</ItemGroup>
 	<!-- This needs to be a Target instead of a PreBuildEvent, otherwise it won't
 	     run unless the consuming project has dirty code.-->
-	<Target Name="StereoKit_BuildNative" BeforeTargets="BeforeBuild;StereoKit_Properties">
+	<Target Name="StereoKit_BuildNative" BeforeTargets="BeforeBuild;StereoKit_Properties" Condition="'$(DesignTimeBuild)' != 'true'">
 		<PropertyGroup>
 			<SKSDKPresetFast Condition="'$(Configuration)'=='Debug'">_Fast</SKSDKPresetFast>
 			<!-- Overridable, so a cross-compile can pick a preset that doesn't follow the OS name, like MinGW. -->
@@ -75,14 +75,12 @@
 			<!-- Windows uses multi-config generator (MSVC), others use single-config (Ninja) -->
 			<SKSDKCacheFile Condition="'$(SKSDKBuildOS)'=='Win32'">$(SKSDKFolder)\bin\intermediate\$(SKSDKBuildOS)_$(SKSDKBuildModePreset)$(SKSDKPresetFast)\CMakeCache.txt</SKSDKCacheFile>
 			<SKSDKCacheFile Condition="'$(SKSDKCacheFile)'==''"   >$(SKSDKFolder)\bin\intermediate\$(SKSDKBuildOS)_$(SKSDKBuildModePreset)_$(Configuration)$(SKSDKPresetFast)\CMakeCache.txt</SKSDKCacheFile>
-
-			<SKBuildCommand                                         >cd "$(SKSDKFolder)"</SKBuildCommand>
-			<SKBuildCommand Condition="!Exists('$(SKSDKCacheFile)')">$(SKBuildCommand) &amp;&amp; cmake --preset $(SKSDKPreset) -DSK_BUILD_TESTS=OFF</SKBuildCommand>
-			<SKBuildCommand                                         >$(SKBuildCommand) &amp;&amp; cmake --build --preset $(SKSDKPreset)</SKBuildCommand>
 		</PropertyGroup>
 
-		<Message Condition="!Exists('$(SKSDKCacheFile)')" Importance="high" Text="[StereoKit SDK] Configuring StereoKitC"/>
-		<Exec Command="$(SKBuildCommand)" />
+		<MSBuild Projects="$(MSBuildThisFileDirectory)BuildStereoKitNative.proj"
+		         Targets="StereoKit_BuildNative"
+		         Properties="SKSDKFolder=$(SKSDKFolder);SKSDKPreset=$(SKSDKPreset);SKSDKCacheFile=$(SKSDKCacheFile)"
+		         RemoveProperties="TargetFramework;RuntimeIdentifier;Platform;Configuration;DesignTimeBuild" />
 	</Target>
 	
 	<!-- Attach the native library binaries. -->
@@ -120,9 +118,16 @@
 
 	<!-- Full rebuilds of this project should also be full rebuilds of StereoKit. -->
 	<Target Name="SKSDKRebuild" AfterTargets="Clean">
-		<!-- Windows uses multi-config generator (MSVC), others use single-config (Ninja) -->
-		<RemoveDir Condition="'$(SKSDKBuildOS)'=='Win32'" Directories="$(SKSDKFolder)\bin\intermediate\$(SKSDKBuildOS)_$(SKSDKBuildMode)" />
-		<RemoveDir Condition="'$(SKSDKBuildOS)'!='Win32'" Directories="$(SKSDKFolder)\bin\intermediate\$(SKSDKBuildOS)_$(SKSDKBuildMode)_$(Configuration)" />
+		<PropertyGroup>
+			<SKSDKPresetFast Condition="'$(Configuration)'=='Debug'">_Fast</SKSDKPresetFast>
+			<!-- Windows uses multi-config generator (MSVC), others use single-config (Ninja) -->
+			<SKSDKIntermediateDir Condition="'$(SKSDKBuildOS)'=='Win32'">$(SKSDKFolder)\bin\intermediate\$(SKSDKBuildOS)_$(SKSDKBuildModePreset)$(SKSDKPresetFast)</SKSDKIntermediateDir>
+			<SKSDKIntermediateDir Condition="'$(SKSDKIntermediateDir)'==''"  >$(SKSDKFolder)\bin\intermediate\$(SKSDKBuildOS)_$(SKSDKBuildModePreset)_$(Configuration)$(SKSDKPresetFast)</SKSDKIntermediateDir>
+		</PropertyGroup>
+		<MSBuild Projects="$(MSBuildThisFileDirectory)BuildStereoKitNative.proj"
+		         Targets="StereoKit_CleanNative"
+		         Properties="SKSDKIntermediateDir=$(SKSDKIntermediateDir)"
+		         RemoveProperties="TargetFramework;RuntimeIdentifier;Platform;Configuration;DesignTimeBuild" />
 	</Target>
 	
 	<!-- Error out if StereoKitC hasn't successfully built! -->


### PR DESCRIPTION
Some build fixes while consuming SK from source with multiple TFMs.

### 1. `fix: dedup native build/clean across multi-TFM builds via inner MSBuild project`
Multi-TFM builds and multi-project solutions each ran their own `cmake --build` of the same preset concurrently. The cmake configure/build and the clean's directory removal now route through a new `BuildStereoKitNative.proj` via the `<MSBuild>` task, so MSBuild collapses identical concurrent requests into a single execution (same mechanism that dedups `ProjectReference` builds). Also:

- Clean uses `cmake -E rm -rf`, which handles the read-only git objects under `_deps` that `RemoveDir` fails on (`MSB3231`).
- Design-time (IntelliSense) builds skip the native build entirely.

### 2. `fix: strip openxr_loader to a side file instead of in place`
The distribute step stripped the loader's build output on every StereoKitC post-build, removing debug symbols & rewriting the file each build. Now it strips to a `.stripped` file and points the distribute copy at it.

### 3. `fix: drop FORCE from SKSHADERC_ENABLE_GLSLANG so -D overrides work`
`FORCE` stomped the cache on every configure, making it impossible to opt in to glslang from the command line while `SK_USE_SVSL` is on (we need the glslang frontend for `.hlsl` shaders using `[[vk::combinedImageSampler]]`, which SVSL rejects). Defaults unchanged; an explicit `-DSKSHADERC_ENABLE_GLSLANG=ON` now wins.