### PR TITLE
Hide mouse during mouse-look, this avoids a performance issue on Linux.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -326,7 +326,7 @@ if (NOT SK_LOCAL_SK_APP)
   CPMAddPackage(
     NAME sk_app
     GITHUB_REPOSITORY StereoKit/sk_app
-    GIT_TAG v2026.5.20
+    GIT_TAG v2026.7.28
   )
 else()
   # For building directly with in-progress sk_app changes, point this to your

--- a/Examples/StereoKitTest/Docs/DocInput.cs
+++ b/Examples/StereoKitTest/Docs/DocInput.cs
@@ -28,11 +28,33 @@ class DocInput : ITest
 		Input.FingerGlow = true;
 	}
 
+	/// :CodeSample: Input.MouseMode MouseMode MouseMode.Relative
+	/// ### Mouse-look camera control
+	/// `MouseMode.Relative` hides the cursor and pins it in place, so the
+	/// mouse can produce motion forever without ever reaching the edge of the
+	/// screen. `Mouse.pos` stops moving in this mode, and `Mouse.posChange` is
+	/// where all the motion shows up.
+	///
+	/// Note that the Simulator uses right click for its own flycam, so this is
+	/// best tried in the Window backend.
+	static Vec2 lookAngle;
+	static void MouseLook()
+	{
+		// Capture the mouse for as long as the right button is held
+		if      (Input.Key(Key.MouseRight).IsJustActive  ()) Input.MouseMode = MouseMode.Relative;
+		else if (Input.Key(Key.MouseRight).IsJustInactive()) Input.MouseMode = MouseMode.Normal;
+
+		if (Input.MouseMode == MouseMode.Relative)
+			lookAngle -= Input.Mouse.posChange * 0.1f;
+	}
+	/// :End:
+
 	public void Initialize() => Tests.RunForFrames(2);
 	public void Shutdown  () { }
 	public void Step      ()
 	{
 		FingerGlowWindow();
+		MouseLook();
 
 		Tests.Hand([new HandJoint(V.XYZ(-0.009f, -0.171f, -0.402f), new Quat(0.221f, -0.047f, -0.827f, 0.515f), 0.020f), new HandJoint(V.XYZ(-0.009f, -0.171f, -0.402f), new Quat(0.221f, -0.047f, -0.827f, 0.515f), 0.020f), new HandJoint(V.XYZ(0.005f, -0.166f, -0.432f), new Quat(0.245f, 0.010f, -0.766f, 0.594f), 0.013f), new HandJoint(V.XYZ(0.018f, -0.155f, -0.463f), new Quat(0.221f, -0.045f, -0.827f, 0.516f), 0.010f), new HandJoint(V.XYZ(0.030f, -0.151f, -0.485f), new Quat(0.221f, -0.045f, -0.827f, 0.516f), 0.009f), new HandJoint(V.XYZ(-0.016f, -0.164f, -0.394f), new Quat(0.488f, -0.042f, -0.077f, 0.868f), 0.022f), new HandJoint(V.XYZ(-0.001f, -0.112f, -0.421f), new Quat(0.422f, 0.007f, -0.091f, 0.902f), 0.011f), new HandJoint(V.XYZ(0.002f, -0.082f, -0.446f), new Quat(0.338f, 0.008f, -0.065f, 0.939f), 0.009f), new HandJoint(V.XYZ(0.003f, -0.066f, -0.466f), new Quat(0.308f, 0.029f, -0.040f, 0.950f), 0.008f), new HandJoint(V.XYZ(0.002f, -0.051f, -0.484f), new Quat(0.308f, 0.029f, -0.040f, 0.950f), 0.007f), new HandJoint(V.XYZ(-0.033f, -0.161f, -0.390f), new Quat(0.488f, -0.042f, -0.077f, 0.868f), 0.022f), new HandJoint(V.XYZ(-0.023f, -0.106f, -0.417f), new Quat(0.276f, 0.070f, 0.005f, 0.958f), 0.012f), new HandJoint(V.XYZ(-0.029f, -0.082f, -0.454f), new Quat(-0.219f, 0.054f, 0.050f, 0.973f), 0.008f), new HandJoint(V.XYZ(-0.031f, -0.094f, -0.479f), new Quat(-0.497f, 0.040f, 0.136f, 0.856f), 0.008f), new HandJoint(V.XYZ(-0.030f, -0.116f, -0.493f), new Quat(-0.497f, 0.040f, 0.136f, 0.856f), 0.007f), new HandJoint(V.XYZ(-0.049f, -0.157f, -0.387f), new Quat(0.488f, -0.042f, -0.077f, 0.868f), 0.020f), new HandJoint(V.XYZ(-0.044f, -0.110f, -0.416f), new Quat(0.308f, 0.064f, 0.052f, 0.948f), 0.010f), new HandJoint(V.XYZ(-0.050f, -0.087f, -0.449f), new Quat(-0.235f, -0.000f, 0.113f, 0.965f), 0.008f), new HandJoint(V.XYZ(-0.048f, -0.099f, -0.473f), new Quat(-0.560f, -0.064f, 0.133f, 0.815f), 0.007f), new HandJoint(V.XYZ(-0.042f, -0.122f, -0.484f), new Quat(-0.560f, -0.064f, 0.133f, 0.815f), 0.006f), new HandJoint(V.XYZ(-0.058f, -0.158f, -0.389f), new Quat(0.459f, -0.018f, 0.173f, 0.871f), 0.019f), new HandJoint(V.XYZ(-0.064f, -0.120f, -0.417f), new Quat(0.381f, 0.037f, 0.111f, 0.917f), 0.009f), new HandJoint(V.XYZ(-0.069f, -0.098f, -0.439f), new Quat(-0.135f, -0.038f, 0.192f, 0.971f), 0.007f), new HandJoint(V.XYZ(-0.066f, -0.104f, -0.459f), new Quat(-0.482f, -0.152f, 0.167f, 0.846f), 0.007f), new HandJoint(V.XYZ(-0.057f, -0.120f, -0.472f), new Quat(-0.482f, -0.152f, 0.167f, 0.846f), 0.006f), new HandJoint(V.XYZ(-0.028f, -0.133f, -0.403f), new Quat(-0.269f, 0.025f, -0.084f, 0.959f), 0.000f), new HandJoint(V.XYZ(-0.039f, -0.187f, -0.363f), new Quat(0.488f, -0.042f, -0.077f, 0.868f), 0.000f)]);
 		Tests.Screenshot("Docs/Input_FingerGlow.jpg", 1, 400, 400, 90, V.XYZ(0, -0.05f, -0.3f), V.XYZ(0, -0.05f, -0.5f));

--- a/StereoKit/Native/NativeAPI.cs
+++ b/StereoKit/Native/NativeAPI.cs
@@ -807,6 +807,8 @@ namespace StereoKit
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern Pose         input_eyes();
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern BtnState     input_eyes_tracked();
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern IntPtr       input_mouse();
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         input_mouse_mode_set(MouseMode mode);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern MouseMode    input_mouse_mode_get();
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         input_key_inject_press(Key key);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         input_key_inject_release(Key key);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern uint         input_text_consume();

--- a/StereoKit/Native/NativeEnums.cs
+++ b/StereoKit/Native/NativeEnums.cs
@@ -1615,6 +1615,24 @@ namespace StereoKit
 		Tip          = 4,
 	}
 
+	/// <summary>How should the mouse cursor behave? This is only relevant on backends with a
+	/// real cursor to control, the Simulator and Window backends. Elsewhere, the
+	/// mode is remembered, but has nothing to act on.</summary>
+	public enum MouseMode {
+		/// <summary>The cursor is visible, and free to move anywhere, including outside the
+		/// window. This is the default.</summary>
+		Normal       = 0,
+		/// <summary>The cursor is invisible, but behaves exactly as it does in normal mode.
+		/// The mouse's position is still valid, and it can still leave the window.</summary>
+		Hidden,
+		/// <summary>The cursor is invisible and locked in place, which is what you want for
+		/// mouse-look style camera control. The mouse's position stops moving, and
+		/// its position change becomes the only source of motion - reported in
+		/// pixel-equivalent units, free of pointer acceleration, and never running
+		/// out of room at the edge of the screen.</summary>
+		Relative,
+	}
+
 	/// <summary>A collection of system key codes, representing keyboard
 	/// characters and mouse buttons. Based on VK codes.</summary>
 	public enum Key {

--- a/StereoKit/Native/NativeTypes.cs
+++ b/StereoKit/Native/NativeTypes.cs
@@ -99,8 +99,11 @@ namespace StereoKit
 		/// <summary>Position of the mouse relative to the window it's in! This is the number
 		/// of pixels from the top left corner of the screen.</summary>
 		public Vec2 pos;
-		/// <summary>How much has the mouse's position changed in the current frame? Measured
-		/// in pixels.</summary>
+		/// <summary>How much has the mouse moved during this frame? Measured in pixels. This
+		/// is all motion since the last frame, which is not always the same as the
+		/// difference between this frame's position and the last frame's! In relative
+		/// mouse mode, the position doesn't move at all, and this is the only place
+		/// mouse motion shows up.</summary>
 		public Vec2 posChange;
 		/// <summary>What's the current scroll value for the mouse's scroll wheel?</summary>
 		public float scroll;

--- a/StereoKit/Systems/Input.cs
+++ b/StereoKit/Systems/Input.cs
@@ -364,6 +364,18 @@ namespace StereoKit
 		/// </summary>
 		public static Mouse Mouse => Marshal.PtrToStructure<Mouse>(NativeAPI.input_mouse());
 
+		/// <summary>How should the mouse cursor behave? Use this to hide the
+		/// cursor, or to capture it for mouse-look style camera control. Only
+		/// the Simulator and Window backends have a cursor to act on, but the
+		/// mode is remembered everywhere. StereoKit restores the cursor
+		/// whenever the app loses focus, and this keeps reporting the mode you
+		/// asked for while that happens.</summary>
+		public static MouseMode MouseMode
+		{
+			set => NativeAPI.input_mouse_mode_set(value);
+			get => NativeAPI.input_mouse_mode_get();
+		}
+
 		/// <summary>This controls the visibility of StereoKit's finger glow
 		/// effect on the UI. When true, SK will fill out global shader
 		/// variable `sk_fingertip[2]` with the location of the pointer

--- a/StereoKitC/stereokit.h
+++ b/StereoKitC/stereokit.h
@@ -2868,14 +2868,35 @@ typedef struct mouse_t {
 	/*Position of the mouse relative to the window it's in! This is the number
 	of pixels from the top left corner of the screen.*/
 	vec2          pos;
-	/*How much has the mouse's position changed in the current frame? Measured
-	in pixels.*/
+	/*How much has the mouse moved during this frame? Measured in pixels. This
+	is all motion since the last frame, which is not always the same as the
+	difference between this frame's position and the last frame's! In relative
+	mouse mode, the position doesn't move at all, and this is the only place
+	mouse motion shows up.*/
 	vec2          pos_change;
 	/*What's the current scroll value for the mouse's scroll wheel?*/
 	float         scroll;
 	/*How much has the scroll wheel value changed during this frame?*/
 	float         scroll_change;
 } mouse_t;
+
+/*How should the mouse cursor behave? This is only relevant on backends with a
+  real cursor to control, the Simulator and Window backends. Elsewhere, the
+  mode is remembered, but has nothing to act on.*/
+typedef enum mouse_mode_ {
+	/*The cursor is visible, and free to move anywhere, including outside the
+	  window. This is the default.*/
+	mouse_mode_normal = 0,
+	/*The cursor is invisible, but behaves exactly as it does in normal mode.
+	  The mouse's position is still valid, and it can still leave the window.*/
+	mouse_mode_hidden,
+	/*The cursor is invisible and locked in place, which is what you want for
+	  mouse-look style camera control. The mouse's position stops moving, and
+	  its position change becomes the only source of motion - reported in
+	  pixel-equivalent units, free of pointer acceleration, and never running
+	  out of room at the edge of the screen.*/
+	mouse_mode_relative,
+} mouse_mode_;
 
 /*A collection of system key codes, representing keyboard
   characters and mouse buttons. Based on VK codes.*/
@@ -3344,6 +3365,8 @@ SK_API pose_t                input_head                      (void);
 SK_API pose_t                input_eyes                      (void);
 SK_API button_state_         input_eyes_tracked              (void);
 SK_API const mouse_t*        input_mouse                     (void);
+SK_API void                  input_mouse_mode_set            (mouse_mode_ mode);
+SK_API mouse_mode_           input_mouse_mode_get            (void);
 SK_API void                  input_key_inject_press          (key_ key);
 SK_API void                  input_key_inject_release        (key_ key);
 SK_API char32_t              input_text_consume              (void);

--- a/StereoKitC/systems/input.cpp
+++ b/StereoKitC/systems/input.cpp
@@ -56,6 +56,10 @@ struct evt_xy_t {
 
 struct input_state_t {
 	mouse_t               mouse_data;
+	mouse_mode_           mouse_mode;        // What the app asked for
+	mouse_mode_           mouse_mode_active; // What the cursor is actually doing
+	vec2                  mouse_lock_pos;    // Relative mode warps back here each frame
+	ska_window_t*         mouse_window;
 	controller_t          controllers[2];
 	bool                  controller_hand[2];
 	button_state_         controller_menubtn;
@@ -101,9 +105,11 @@ bool input_init() {
 	profiler_zone();
 
 	// Preserve values that may have been set before init, such as palm
-	// offsets from OpenXR interaction profile events.
-	pose_t palm_offset[2]     = { local.palm_offset[0],     local.palm_offset[1]     };
-	bool   controller_hand[2] = { local.controller_hand[0], local.controller_hand[1] };
+	// offsets from OpenXR interaction profile events, or the window the
+	// backend handed us - Platform initializes before Input.
+	pose_t        palm_offset[2]     = { local.palm_offset[0],     local.palm_offset[1]     };
+	bool          controller_hand[2] = { local.controller_hand[0], local.controller_hand[1] };
+	ska_window_t* mouse_window       = local.mouse_window;
 
 	local = {};
 	input_head_pose_local    = pose_identity;
@@ -112,6 +118,7 @@ bool input_init() {
 	local.palm_offset[1]     = palm_offset[1];
 	local.controller_hand[0] = controller_hand[0];
 	local.controller_hand[1] = controller_hand[1];
+	local.mouse_window       = mouse_window;
 
 	local.mtx_poses   = ft_mutex_create();
 	local.mtx_floats  = ft_mutex_create();
@@ -130,6 +137,9 @@ bool input_init() {
 ///////////////////////////////////////////
 
 void input_shutdown() {
+	if (local.mouse_mode_active != mouse_mode_normal)
+		ska_cursor_show(true);
+
 	ft_mutex_destroy(&local.mtx_poses);
 	ft_mutex_destroy(&local.mtx_floats);
 	ft_mutex_destroy(&local.mtx_buttons);
@@ -497,17 +507,56 @@ void input_mouse_update() {
 		local.mouse_data.scroll        = ska_scroll_accumulator;
 	}
 
+	// Losing focus always restores the cursor, so alt-tabbing out of a window
+	// that captured the mouse doesn't strand the user without one. Backends
+	// with no window of their own just remember the mode.
+	mouse_mode_ mode = local.mouse_data.available && local.mouse_window != nullptr
+		? local.mouse_mode
+		: mouse_mode_normal;
+	if (mode != local.mouse_mode_active) {
+		ska_cursor_show(mode == mouse_mode_normal);
+		local.mouse_lock_pos    = mouse_pos;
+		local.mouse_mode_active = mode;
+	}
+
 	// Mouse position and on-screen
 	if (local.mouse_data.available) {
-		local.mouse_data.pos_change = mouse_pos - local.mouse_data.pos;
-		local.mouse_data.pos        = mouse_pos;
+		if (local.mouse_mode_active == mouse_mode_relative) {
+			// The cursor is parked at mouse_lock_pos, so anything away from it is
+			// this frame's motion. Warping back means we never run out of screen,
+			// and the app sees a stationary pos.
+			local.mouse_data.pos_change = mouse_pos - local.mouse_lock_pos;
+			local.mouse_data.pos        = local.mouse_lock_pos;
+			if (mouse_pos.x != local.mouse_lock_pos.x || mouse_pos.y != local.mouse_lock_pos.y)
+				ska_mouse_warp(local.mouse_window, (int32_t)local.mouse_lock_pos.x, (int32_t)local.mouse_lock_pos.y);
+		} else {
+			local.mouse_data.pos_change = mouse_pos - local.mouse_data.pos;
+			local.mouse_data.pos        = mouse_pos;
+		}
 	}
 }
 
 ///////////////////////////////////////////
 
-void input_mouse_override_pos(vec2 override_pos) {
-	local.mouse_data.pos = { override_pos.x, override_pos.y };
+void input_mouse_set_window(ska_window_t* window) {
+	// Restore now, while the window that hid the cursor is still around.
+	if (window == nullptr && local.mouse_mode_active != mouse_mode_normal) {
+		ska_cursor_show(true);
+		local.mouse_mode_active = mouse_mode_normal;
+	}
+	local.mouse_window = window;
+}
+
+///////////////////////////////////////////
+
+void input_mouse_mode_set(mouse_mode_ mode) {
+	local.mouse_mode = mode;
+}
+
+///////////////////////////////////////////
+
+mouse_mode_ input_mouse_mode_get(void) {
+	return local.mouse_mode;
 }
 
 ///////////////////////////////////////////

--- a/StereoKitC/systems/input.h
+++ b/StereoKitC/systems/input.h
@@ -8,6 +8,8 @@
 
 #include "../stereokit.h"
 
+typedef struct ska_window_t ska_window_t;
+
 namespace sk {
 
 bool          input_init               ();
@@ -16,7 +18,7 @@ void          input_step               ();
 void          input_step_late          ();
 
 void          input_update_poses       ();
-void          input_mouse_override_pos (vec2 override_pos);
+void          input_mouse_set_window   (ska_window_t* window);
 controller_t* input_controller_ref     (handed_ handed);
 void          input_controller_menu_set(button_state_ state);
 bool          input_controller_key     (handed_ hand, controller_key_ key, float* out_amount);

--- a/StereoKitC/xr_backends/simulator.cpp
+++ b/StereoKitC/xr_backends/simulator.cpp
@@ -37,6 +37,8 @@ vec3           sim_head_rot;
 vec3           sim_head_pos;
 pose_t         sim_bounds_pose;
 bool           sim_mouse_look;
+bool           sim_mouse_look_prev; // Mouse-look state the mouse mode was last synced to
+mouse_mode_    sim_mouse_mode_prev; // App's mouse mode, restored when mouse-look ends
 
 ska_window_t*       ska_win;
 skr_surface_t       sim_skr_surface;
@@ -65,11 +67,13 @@ bool simulator_init() {
 	device_data.runtime           = string_copy("Simulator");
 	device_data.runtime_version   = 0;
 
-	sim_head_rot     = { -21, 0.0001f, 0 };
-	sim_head_pos     = { 0, 0.2f, 0.0f };
-	sim_mouse_look   = false;
-	ska_win          = nullptr;
-	sim_skr_surface  = {};
+	sim_head_rot        = { -21, 0.0001f, 0 };
+	sim_head_pos        = { 0, 0.2f, 0.0f };
+	sim_mouse_look      = false;
+	sim_mouse_look_prev = false;
+	sim_mouse_mode_prev = mouse_mode_normal;
+	ska_win             = nullptr;
+	sim_skr_surface     = {};
 
 	quat initial_rot = quat_from_angles(0, sim_head_rot.y, 0);
 	switch (sk_get_settings_ref()->origin) {
@@ -117,6 +121,7 @@ bool simulator_init() {
 		sim_surface_resize(sim_surface, sim_skr_surface.size.x, sim_skr_surface.size.y);
 
 	interactor_modes_set_default(default_interactors_mouse);
+	input_mouse_set_window(ska_win);
 	input_hand_visible(handed_max, false);
 	input_set_finger_glow(false);
 	anchors_init();
@@ -165,6 +170,7 @@ void simulator_shutdown() {
 	skr_surface_destroy(&sim_skr_surface);
 	sim_skr_surface = {};
 
+	input_mouse_set_window(nullptr);
 	ska_window_destroy(ska_win);
 	ska_win = nullptr;
 	anchors_shutdown(NULL);
@@ -232,12 +238,6 @@ void simulator_step_begin() {
 			sim_head_rot.x -= mouse->pos_change.y * sim_rot_speed.y * time_stepf_unscaled();
 			sim_head_rot.x = fmaxf(-89.9f, fminf(sim_head_rot.x, 89.9f));
 			orientation = quat_from_angles(sim_head_rot.x, sim_head_rot.y, sim_head_rot.z);
-
-			vec2 prev_pt = mouse->pos - mouse->pos_change;
-
-			ska_mouse_warp(ska_win, (int32_t)prev_pt.x, (int32_t)prev_pt.y);
-			input_mouse_override_pos(prev_pt);
-
 		} else {
 			orientation = quat_from_angles(sim_head_rot.x, sim_head_rot.y, sim_head_rot.z);
 		}
@@ -248,6 +248,14 @@ void simulator_step_begin() {
 	}
 	if (input_key(key_mouse_right) & button_state_just_inactive) {
 		sim_mouse_look = false;
+	}
+
+	// Mouse-look borrows relative mode for the length of the drag, and hands it
+	// back afterwards so an app that set its own mode still has it.
+	if (sim_mouse_look != sim_mouse_look_prev) {
+		if (sim_mouse_look) sim_mouse_mode_prev = input_mouse_mode_get();
+		input_mouse_mode_set(sim_mouse_look ? mouse_mode_relative : sim_mouse_mode_prev);
+		sim_mouse_look_prev = sim_mouse_look;
 	}
 
 	bool sim_tracked = (input_key(key_alt) & button_state_active) > 0 ? true : false;

--- a/StereoKitC/xr_backends/window.cpp
+++ b/StereoKitC/xr_backends/window.cpp
@@ -110,6 +110,7 @@ bool window_init() {
 		window_surface_resize(local->surface, local->skr_surface.size.x, local->skr_surface.size.y);
 
 	interactor_modes_set_default(default_interactors_mouse);
+	input_mouse_set_window(local->ska_win);
 	input_hand_visible(handed_max, false);
 	input_set_finger_glow(false);
 	return true;
@@ -158,6 +159,8 @@ void window_shutdown() {
 	}
 
 	render_pipeline_shutdown();
+
+	input_mouse_set_window(nullptr);
 
 	// Destroy the renderer surface before the window
 	skr_surface_destroy(&local->skr_surface);


### PR DESCRIPTION
This adds  `Input.MouseMode` for top level implementation of this mouse-look behavior in Window backends.

On Linux, previous mouse-look was implemented using a workaround for X11 behavior, hiding and showing the mouse every frame. This behavior caused performance issues and introduced lag during mouse look. The new behavior hides the mouse once at the start of the interaction, and shows it at the end. This does still spike on frames where show/hide happens, but unlocks smooth performance during the mouse-look interaction itself!