### PR TITLE
Miscellaneous fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -305,7 +305,7 @@ if (NOT SK_LOCAL_SK_RENDERER)
   CPMAddPackage(
     NAME sk_renderer
     GITHUB_REPOSITORY StereoKit/sk_renderer
-    GIT_TAG v2026.7.30
+    GIT_TAG v2026.8.3
   )
 else()
   # For building directly with in-progress sk_renderer changes, point this to your
@@ -324,7 +324,7 @@ if (NOT SK_LOCAL_SK_APP)
   CPMAddPackage(
     NAME sk_app
     GITHUB_REPOSITORY StereoKit/sk_app
-    GIT_TAG v2026.7.28
+    GIT_TAG v2026.8.3
   )
 else()
   # For building directly with in-progress sk_app changes, point this to your

--- a/StereoKitC/asset_types/assets.cpp
+++ b/StereoKitC/asset_types/assets.cpp
@@ -769,20 +769,20 @@ void assets_return_task(asset_task_t *task) {
 void assets_complete_task(asset_task_t* task) {
 	// Skip putting it back if it's complete :)
 
+	// Notify on_load, skipping assets removed by a load issue. Queued before
+	// the task count drops, so a blocking caller can't miss the event.
+	if (task->asset->state >= asset_state_loaded) {
+		ft_mutex_lock(assets_load_event_lock);
+		assets_load_events.add(task->asset);
+		ft_mutex_unlock(assets_load_event_lock);
+	}
+
 	ft_mutex_lock(asset_thread_task_mtx);
 	asset_active_tasks.remove(asset_active_tasks.index_of(task));
 	asset_tasks_finished   += 1;
 	asset_tasks_processing -= 1;
 	asset_tasks_priority    = assets_calculate_current_priority();
 	ft_mutex_unlock(asset_thread_task_mtx);
-
-	// If it was successfully loaded, we'll want to notify on_load, but we do
-	// want to skip this if it was removed because of an issue during load.
-	if (task->asset->state >= asset_state_loaded) {
-		ft_mutex_lock(assets_load_event_lock);
-		assets_load_events.add(task->asset);
-		ft_mutex_unlock(assets_load_event_lock);
-	}
 
 	if (task->free_data != nullptr) task->free_data(task->asset, task->load_data);
 	assets_releaseref_threadsafe(task->asset);
@@ -960,6 +960,10 @@ void assets_block_for_priority(int32_t priority) {
 		assets_step();
 		curr_priority = assets_current_task_priority();
 	}
+
+	// The last task queues its on_load event after the final step above, so
+	// without this, blocking returns with the callback still pending.
+	assets_step();
 }
 
 } // namespace sk

--- a/StereoKitC/asset_types/texture.cpp
+++ b/StereoKitC/asset_types/texture.cpp
@@ -89,8 +89,11 @@ skr_tex_flags_ tex_type_to_skr_flags(tex_type_ type) {
 		return (skr_tex_flags_)(skr_tex_flags_writeable | skr_tex_flags_input_attachment);
 	}
 
-	// Most textures are sampled
-	skr_tex_flags_ flags = skr_tex_flags_readable;
+	// Most textures are sampled, transient attachments never are. Both halves
+	// matter here, sk_renderer tests in_tile_msaa && !readable.
+	skr_tex_flags_ flags = (type & tex_type_transient_internal)
+		? skr_tex_flags_in_tile_msaa
+		: skr_tex_flags_readable;
 	if (type & tex_type_cubemap)      flags = (skr_tex_flags_)(flags | skr_tex_flags_cubemap);
 	if (type & tex_type_dynamic)      flags = (skr_tex_flags_)(flags | skr_tex_flags_dynamic);
 	if (type & tex_type_mips)         flags = (skr_tex_flags_)(flags | skr_tex_flags_gen_mips);

--- a/StereoKitC/asset_types/texture.h
+++ b/StereoKitC/asset_types/texture.h
@@ -7,6 +7,10 @@
 
 namespace sk {
 
+// Internal only, an attachment resolved in-pass and never read. Drops every
+// usage bit but COLOR_ATTACHMENT, and reading one is a validation error.
+const tex_type_ tex_type_transient_internal = (tex_type_)(1 << 30);
+
 struct _tex_t {
 	asset_header_t   header;
 	tex_t            fallback;

--- a/StereoKitC/systems/lighting.cpp
+++ b/StereoKitC/systems/lighting.cpp
@@ -25,6 +25,7 @@ struct lighting_state_t {
 	material_t              sky_mat;
 	material_t              sky_mat_default;
 	bool32_t                sky_show;
+	bool32_t                sky_drawn; // Sky was added to this frame's list
 	tex_t                   sky_pending_tex;
 	vec4                    lighting[7];
 	spherical_harmonics_t   lighting_src;
@@ -70,9 +71,25 @@ bool lighting_init() {
 void lighting_step() {
 	render_check_pending_skytex();
 
-	if (local.sky_show && device_display_get_blend() == display_blend_opaque) {
-		render_add_mesh(local.sky_mesh, local.sky_mat, matrix_identity, {1,1,1,1}, render_layer_vfx);
+	bool32_t show = local.sky_show && device_display_get_blend() == display_blend_opaque;
+	if (show) {
+		render_add_mesh(local.sky_mesh, local.sky_mat, matrix_identity, {1,1,1,1}, render_sky_layer);
 	}
+
+	// The mesh is a clip space quad at z=1, so it covers every pixel, but only
+	// if the material is opaque and its depth test passes against that same 1.
+	depth_test_ depth   = material_get_depth_test(local.sky_mat);
+	bool32_t    covers  = depth == depth_test_less_or_eq
+	                   || depth == depth_test_greater_or_eq
+	                   || depth == depth_test_equal
+	                   || depth == depth_test_always;
+	local.sky_drawn = show && covers && material_get_transparency(local.sky_mat) == transparency_none;
+}
+
+///////////////////////////////////////////
+
+bool32_t render_sky_covers(render_layer_ filter) {
+	return local.sky_drawn && (filter & render_sky_layer) != 0;
 }
 
 ///////////////////////////////////////////

--- a/StereoKitC/systems/lighting.h
+++ b/StereoKitC/systems/lighting.h
@@ -9,7 +9,8 @@
 
 namespace sk {
 
-const int32_t render_skytex_register = 11;
+const int32_t       render_skytex_register = 11;
+const render_layer_ render_sky_layer       = render_layer_vfx;
 
 bool lighting_init    ();
 void lighting_step    ();

--- a/StereoKitC/systems/render.cpp
+++ b/StereoKitC/systems/render.cpp
@@ -1053,7 +1053,10 @@ void render_check_screenshots() {
 		// Create render targets for screenshot
 		// Depth matches the display's preferred (stencil-free) format, so
 		// depth-reading post-process effects work in screenshots too.
-		tex_t color_surface = tex_create_rendertarget(w, h, 8, local.screenshot_list[i].tex_format, tex_format_none);
+		// The MSAA surface only ever feeds resolve_tex, so it's transient. The
+		// readback below reads the resolve, never this.
+		tex_t color_surface = tex_create(tex_type_image_nomips | tex_type_rendertarget | tex_type_transient_internal, local.screenshot_list[i].tex_format);
+		tex_set_color_arr(color_surface, w, h, nullptr, 1, 8, nullptr);
 		tex_t depth_surface = tex_create_rendertarget(w, h, 8, tex_get_supported_depth_format(render_preferred_depth_fmt(), true, 8), tex_format_none);
 		tex_t resolve_tex   = tex_create_rendertarget(w, h, 1, local.screenshot_list[i].tex_format, tex_format_none);
 
@@ -1075,8 +1078,9 @@ void render_check_screenshots() {
 
 		// Determine clear flags
 		render_clear_ clear      = render_clear_resolve(local.screenshot_list[i].clear);
-		skr_clear_    clear_flags = skr_clear_none;
-		if (clear & render_clear_color) clear_flags = (skr_clear_)(clear_flags | skr_clear_color);
+		// The color surface is brand new every shot, so skipping the clear has
+		// nothing to preserve. Discard, or we'd load undefined contents.
+		skr_clear_    clear_flags = (clear & render_clear_color) ? skr_clear_color : skr_clear_color_discard;
 		if (clear & render_clear_depth) clear_flags = (skr_clear_)(clear_flags | skr_clear_depth | skr_clear_stencil);
 
 		// Render!

--- a/StereoKitC/systems/render.h
+++ b/StereoKitC/systems/render.h
@@ -45,6 +45,7 @@ void          render_pass_add_global_post_process(skr_pass_t* pass);
 bool32_t      render_material_is_post_process  (material_t material);
 void          render_check_screenshots    ();
 void          render_check_pending_skytex ();
+bool32_t      render_sky_covers           (render_layer_ filter);
 void          render_global_buffer_internal (int32_t register_slot, material_buffer_t buffer);
 void          render_global_texture_internal(int32_t register_slot, tex_t             texture);
 void          render_queue_compute          (compute_t compute, uint32_t group_count_x, uint32_t group_count_y, uint32_t group_count_z);

--- a/StereoKitC/systems/render_pipeline.cpp
+++ b/StereoKitC/systems/render_pipeline.cpp
@@ -20,6 +20,7 @@ struct pipeline_surface_t {
 	int32_t                     width;
 	int32_t                     height;
 	color128                    clear_color;
+	bool32_t                    clear_covered; // Draw fills every pixel, clear is skippable
 	tex_t                       tex;       // Null draws into resolve_target
 	tex_t                       depth_tex; // Used when tex is null
 	matrix*                     view_matrices;
@@ -66,8 +67,11 @@ void render_pipeline_draw() {
 
 		// Set up clear values and submit the pass - the pass system handles
 		// multi-view fallback automatically via the view_desc.
+		// A fully covered surface overwrites every pixel, so the clear is
+		// wasted work. Passthrough covers none, and there the clear _is_ the
+		// content.
 		skr_vec4_t clear_color = { s->clear_color.r, s->clear_color.g, s->clear_color.b, s->clear_color.a };
-		skr_clear_ clear_flags = (skr_clear_)(skr_clear_color | skr_clear_depth | skr_clear_stencil);
+		skr_clear_ clear_flags = (skr_clear_)((s->clear_covered ? skr_clear_color_discard : skr_clear_color) | skr_clear_depth | skr_clear_stencil);
 
 		render_draw_queue(list, s->view_matrices, s->proj_matrices, 0, s->array_count, s->layer, 0, width, height);
 
@@ -181,7 +185,9 @@ bool32_t render_pipeline_surface_resize(pipeline_surface_id surface_id, int32_t 
 
 		bool fresh = surface->tex == nullptr;
 		if (fresh) {
-			surface->tex = tex_create(tex_type_image_nomips | tex_type_rendertarget, surface->color);
+			// needs_tex is the "will be resolved" condition, so this tex is
+			// only ever an MSAA intermediate. Nothing samples or copies it.
+			surface->tex = tex_create(tex_type_image_nomips | tex_type_rendertarget | tex_type_transient_internal, surface->color);
 			snprintf(name, sizeof(name), "sk/render/pipeline_surface_%d", surface_id);
 			tex_set_id(surface->tex, name);
 		}
@@ -263,6 +269,13 @@ void render_pipeline_surface_present_swapchain(pipeline_surface_id surface_id, s
 void render_pipeline_surface_to_tex(pipeline_surface_id surface_id, tex_t destination, material_t mat) {
 	pipeline_surface_t* surface = &local.surfaces[surface_id];
 
+	// A multisampled surface renders into a transient MSAA intermediate that
+	// can't be sampled or copied, only the direct-render tex is readable.
+	if (surface->tex == nullptr || (surface->tex->type & tex_type_transient_internal)) {
+		log_err("render_pipeline_surface_to_tex: this surface has no readable texture, read its resolve target instead");
+		return;
+	}
+
 	if (mat) {
 		material_set_texture(mat, "source", surface->tex);
 		render_blit(destination, mat);
@@ -310,6 +323,14 @@ void render_pipeline_surface_set_tex(pipeline_surface_id surface_id, tex_t tex) 
 
 tex_t render_pipeline_surface_get_tex(pipeline_surface_id surface_id) {
 	pipeline_surface_t* surface = &local.surfaces[surface_id];
+
+	// A multisampled surface's tex is a transient that can't be sampled or
+	// copied, so handing it out is never useful. Same as _to_tex below.
+	if (surface->tex && (surface->tex->type & tex_type_transient_internal)) {
+		log_err("render_pipeline_surface_get_tex: this surface has no readable texture, read its resolve target instead");
+		return nullptr;
+	}
+
 	if (surface->tex) tex_addref(surface->tex);
 	return surface->tex;
 }
@@ -340,8 +361,9 @@ void render_pipeline_surface_set_viewport_scale(pipeline_surface_id surface, flo
 
 ///////////////////////////////////////////
 
-void render_pipeline_surface_set_clear(pipeline_surface_id surface, color128 color) {
-	local.surfaces[surface].clear_color = color;
+void render_pipeline_surface_set_clear(pipeline_surface_id surface, color128 color, bool32_t fully_covered) {
+	local.surfaces[surface].clear_color   = color;
+	local.surfaces[surface].clear_covered = fully_covered;
 }
 
 ///////////////////////////////////////////

--- a/StereoKitC/systems/render_pipeline.h
+++ b/StereoKitC/systems/render_pipeline.h
@@ -20,7 +20,7 @@ void                render_pipeline_surface_set_enabled       (pipeline_surface_
 bool32_t            render_pipeline_surface_get_enabled       (pipeline_surface_id surface);
 void                render_pipeline_surface_set_layer         (pipeline_surface_id surface, render_layer_ layer);
 void                render_pipeline_surface_set_viewport_scale(pipeline_surface_id surface, float viewport_rect_scale);
-void                render_pipeline_surface_set_clear         (pipeline_surface_id surface, color128 color);
+void                render_pipeline_surface_set_clear         (pipeline_surface_id surface, color128 color, bool32_t fully_covered);
 void                render_pipeline_surface_set_perspective   (pipeline_surface_id surface, matrix* view_matrices, matrix* proj_matrices, int32_t count);
 void                render_pipeline_surface_set_resolve_target(pipeline_surface_id surface, skr_tex_t* resolve_target);
 

--- a/StereoKitC/xr_backends/openxr_view.cpp
+++ b/StereoKitC/xr_backends/openxr_view.cpp
@@ -1091,7 +1091,7 @@ bool openxr_display_swapchain_acquire(device_display_t* display, color128 color,
 		render_pipeline_surface_set_resolve_target(display->render_surface, &display->swapchain_color.textures[color_id]->gpu_tex);
 	}
 	display->render_surface_tex = color_id;
-	render_pipeline_surface_set_clear(display->render_surface, color);
+	render_pipeline_surface_set_clear(display->render_surface, color, render_sky_covers(render_filter));
 	render_pipeline_surface_set_layer(display->render_surface, render_filter);
 
 	return true;

--- a/StereoKitC/xr_backends/simulator.cpp
+++ b/StereoKitC/xr_backends/simulator.cpp
@@ -286,7 +286,7 @@ void simulator_step_end() {
 
 	matrix view = matrix_invert(render_get_cam_final());
 	matrix proj = render_get_projection_matrix();
-	render_pipeline_surface_set_clear      (sim_surface, render_get_clear_color_ln());
+	render_pipeline_surface_set_clear      (sim_surface, render_get_clear_color_ln(), render_sky_covers(render_get_filter()));
 	render_pipeline_surface_set_layer      (sim_surface, render_get_filter());
 	render_pipeline_surface_set_perspective(sim_surface, &view, &proj, 1);
 

--- a/StereoKitC/xr_backends/window.cpp
+++ b/StereoKitC/xr_backends/window.cpp
@@ -218,7 +218,7 @@ void window_step_end() {
 
 	matrix view = matrix_invert(render_get_cam_final());
 	matrix proj = render_get_projection_matrix();
-	render_pipeline_surface_set_clear      (local->surface, render_get_clear_color_ln());
+	render_pipeline_surface_set_clear      (local->surface, render_get_clear_color_ln(), render_sky_covers(render_get_filter()));
 	render_pipeline_surface_set_layer      (local->surface, render_get_filter());
 	render_pipeline_surface_set_perspective(local->surface, &view, &proj, 1);
 


### PR DESCRIPTION
- Fix missing depth discard.
- Fix `Assets.Block__` functions not blocking _quite_ long enough, causing single frame delays on rare cases.
- Fix crash in surface destroy on shutdown for X11 on Wayland.
- Enable post processing effects to sample directly from MSAA depth surfaces without resolve.