### PR TITLE
Pull in sk_app fixes for missing optional components

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -290,7 +290,7 @@ if (NOT SK_LOCAL_SK_APP)
   CPMAddPackage(
     NAME sk_app
     GITHUB_REPOSITORY StereoKit/sk_app
-    GIT_TAG v2026.8.11
+    GIT_TAG v2026.8.12
   )
 else()
   # For building directly with in-progress sk_app changes, point this to your


### PR DESCRIPTION
Fixes a crash when an optional Wayland component was missing, and surfaces a nice list of missing optional components in the logs.