### PR TITLE
New text input API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -271,7 +271,7 @@ if (NOT SK_LOCAL_SK_APP)
   CPMAddPackage(
     NAME sk_app
     GITHUB_REPOSITORY StereoKit/sk_app
-    GIT_TAG v2026.8.12
+    GIT_TAG v2026.8.19
   )
 else()
   # For building directly with in-progress sk_app changes, point this to your

--- a/Examples/StereoKitTest/Demos/DemoTextInput.cs
+++ b/Examples/StereoKitTest/Demos/DemoTextInput.cs
@@ -64,54 +64,51 @@ class DemoTextInput : ITest
 		{
 			Platform.KeyboardSetLayout(TextContext.Text, new string[]
 			{
-				"q|w|e|r|t|y|u|i|o|p\n---1|a|s|d|f|g|h|j|k|l\nspr:sk/ui/shift---3-visit_1|z|x|c|v|b|n|m|spr:sk/ui/backspace-\\b--3\nspr:sk/ui/close----close|123---3-go_2|,| - --7|.|Return-\\n--4|",
-				"Q|W|E|R|T|Y|U|I|O|P\n---1|A|S|D|F|G|H|J|K|L\nspr:sk/ui/shift---3-go_0|Z|X|C|V|B|N|M|spr:sk/ui/backspace-\\b--3\nspr:sk/ui/close----close|123---3-go_2|!| - --7|?|Return-\\n--4|",
-				"1|2|3|4|5|6|7|8|9|0\n---1|\\-|/|:|;|(|)|$|&|@\nspr:sk/ui/shift---3-go_0|*|=|+|#|%|'|\"|spr:sk/ui/backspace-\\b--3\nspr:sk/ui/close----close|123---3-go_0|!| - --7|?|Return-\\n--4|"
+				"q|w|e|r|t|y|u|i|o|p\n---1|a|s|d|f|g|h|j|k|l\nspr:sk/ui/shift---3-visit_1|z|x|c|v|b|n|m|spr:sk/ui/backspace--8-3\nspr:sk/ui/close----close|123---3-go_2|,| - --7|.|Return-\\n--4|",
+				"Q|W|E|R|T|Y|U|I|O|P\n---1|A|S|D|F|G|H|J|K|L\nspr:sk/ui/shift---3-go_0|Z|X|C|V|B|N|M|spr:sk/ui/backspace--8-3\nspr:sk/ui/close----close|123---3-go_2|!| - --7|?|Return-\\n--4|",
+				"1|2|3|4|5|6|7|8|9|0\n---1|\\-|/|:|;|(|)|$|&|@\nspr:sk/ui/shift---3-go_0|*|=|+|#|%|'|\"|spr:sk/ui/backspace--8-3\nspr:sk/ui/close----close|123---3-go_0|!| - --7|?|Return-\\n--4|"
 			});
 		}
 
 		UI.WindowEnd();
 	}
 
-	/// :CodeSample: Input.TextReset Input.TextConsume
-	/// ### Raw Text Input
-	// If you need to read text input directly from a soft or hard keyboard,
-	// these functions give you direct access to the stream of Unicode
-	// characters produced! These characters are language and keyboard layout
-	// sensitive, making these functions the correct ones for working with text
-	// content vs. the `Input.Key` functions, which are not language specific.
+	/// :CodeSample: Input.KeyboardEventCount Input.KeyboardEventAt
+	/// ### Raw Keyboard Input
+	// If you need to read the keyboard directly from a soft or hard keyboard,
+	// this gives you the frame's events in the exact order the user made them.
+	// Text events are language and keyboard layout sensitive, which makes them
+	// the correct choice for text content, and key events carry the editing
+	// intent that text can't express, like backspace and enter.
 	//
-	// Every frame, `Input.TextConsume` will have a list of new characters that
-	// have been pressed or submitted to the app. Reading them will "consume"
-	// them, making them unavailable to anything that comes after. If you need
-	// to bypass some earlier element consuming them, you can reset the current
-	// frame's consume queue with `Input.TextReset`.
+	// `Input.KeyboardConsume` reads events destructively, so an element like
+	// UI.Input can hide input from whatever comes after it. Reading by index
+	// observes the frame's events without consuming anything, which is what a
+	// display like this window wants.
 	Pose         rawWinPose = new Pose(0.3f,0,0);
 	List<string> uniChars   = new List<string>(Enumerable.Repeat("", 10));
 	void ShowRawInputWindow()
 	{
-		UI.WindowBegin("Raw keyboard code points:", ref rawWinPose);
+		UI.WindowBegin("Raw keyboard events:", ref rawWinPose);
 
-		// Reset the text input back to the start of the list, since any
-		// UI.Input before this will consume the characters first and we
-		// always want to show input on this window.
-		Input.TextReset();
-
-		while (true)
+		// Read each of this frame's events, even the ones an earlier UI.Input
+		// may have consumed.
+		for (int evt = 0; evt < Input.KeyboardEventCount; evt++)
 		{
-			// Consume each new character, 0 marks the end of the list of new
-			// characters.
-			char c = Input.TextConsume();
-			if (c == 0) break;
+			KeyboardEvent e = Input.KeyboardEventAt(evt);
+			// Text events carry their character data in e.Text, which handles
+			// emoji and other codepoints too large for a single C# char.
+			string desc = e.type == KeyboardEventType.Text
+				? $"U+{char.ConvertToUtf32(e.Text, 0):X4} '{e.Text}'"
+				: $"{e.key} {(e.type == KeyboardEventType.KeyPress ? "down" : "up")}";
 
-			// Insert the codepoint at the start of the list, and bump off any
-			// more than 10 items.
-			uniChars.Insert(0, $"{(int)c}");
+			// Insert at the start of the list, and bump off any more than 10.
+			uniChars.Insert(0, desc);
 			if (uniChars.Count > 10)
 				uniChars.RemoveAt(uniChars.Count - 1);
 		}
 
-		// Show each character code as a label
+		// Show each event as a label
 		for (int i = 0; i < uniChars.Count; i++)
 			UI.Label(uniChars[i]);
 

--- a/Examples/StereoKitTest/Docs/DocInput.cs
+++ b/Examples/StereoKitTest/Docs/DocInput.cs
@@ -28,6 +28,43 @@ class DocInput : ITest
 		Input.FingerGlow = true;
 	}
 
+	/// :CodeSample: Input.KeyboardConsume KeyboardEvent
+	/// ### Reading the keyboard event queue
+	/// `Input.KeyboardConsume` reads this frame's key presses, releases, and
+	/// text in the exact order the user produced them, which is the right
+	/// foundation for custom text editing. Text events carry the layout and
+	/// language sensitive characters to insert, while key events carry the
+	/// editing intent that text can't express, and each auto-repeat of a held
+	/// key is its own press event.
+	///
+	/// Reading consumes, so a focused `UI.Input` earlier in the frame will
+	/// empty the queue. If observing is all you need, `Input.KeyboardEventAt`
+	/// reads by index without consuming anything.
+	static string typed = "";
+	static void ReadKeyboardEvents()
+	{
+		while (Input.KeyboardConsume(out KeyboardEvent e))
+		{
+			switch (e.type)
+			{
+				case KeyboardEventType.Text:
+					// Text may be two chars, for emoji and other codepoints
+					// too large for a single C# char.
+					typed += e.Text;
+					break;
+				case KeyboardEventType.KeyPress:
+					if (e.key == Key.Backspace && typed.Length > 0)
+					{
+						// Erase the whole codepoint, which may be two chars
+						int last = char.IsLowSurrogate(typed[typed.Length-1]) ? 2 : 1;
+						typed = typed.Remove(typed.Length - last);
+					}
+					break;
+			}
+		}
+	}
+	/// :End:
+
 	/// :CodeSample: Input.MouseMode MouseMode MouseMode.Relative
 	/// ### Mouse-look camera control
 	/// `MouseMode.Relative` hides the cursor and pins it in place, so the
@@ -54,6 +91,7 @@ class DocInput : ITest
 	public void Step      ()
 	{
 		FingerGlowWindow();
+		ReadKeyboardEvents();
 		MouseLook();
 
 		Tests.Hand([new HandJoint(V.XYZ(-0.009f, -0.171f, -0.402f), new Quat(0.221f, -0.047f, -0.827f, 0.515f), 0.020f), new HandJoint(V.XYZ(-0.009f, -0.171f, -0.402f), new Quat(0.221f, -0.047f, -0.827f, 0.515f), 0.020f), new HandJoint(V.XYZ(0.005f, -0.166f, -0.432f), new Quat(0.245f, 0.010f, -0.766f, 0.594f), 0.013f), new HandJoint(V.XYZ(0.018f, -0.155f, -0.463f), new Quat(0.221f, -0.045f, -0.827f, 0.516f), 0.010f), new HandJoint(V.XYZ(0.030f, -0.151f, -0.485f), new Quat(0.221f, -0.045f, -0.827f, 0.516f), 0.009f), new HandJoint(V.XYZ(-0.016f, -0.164f, -0.394f), new Quat(0.488f, -0.042f, -0.077f, 0.868f), 0.022f), new HandJoint(V.XYZ(-0.001f, -0.112f, -0.421f), new Quat(0.422f, 0.007f, -0.091f, 0.902f), 0.011f), new HandJoint(V.XYZ(0.002f, -0.082f, -0.446f), new Quat(0.338f, 0.008f, -0.065f, 0.939f), 0.009f), new HandJoint(V.XYZ(0.003f, -0.066f, -0.466f), new Quat(0.308f, 0.029f, -0.040f, 0.950f), 0.008f), new HandJoint(V.XYZ(0.002f, -0.051f, -0.484f), new Quat(0.308f, 0.029f, -0.040f, 0.950f), 0.007f), new HandJoint(V.XYZ(-0.033f, -0.161f, -0.390f), new Quat(0.488f, -0.042f, -0.077f, 0.868f), 0.022f), new HandJoint(V.XYZ(-0.023f, -0.106f, -0.417f), new Quat(0.276f, 0.070f, 0.005f, 0.958f), 0.012f), new HandJoint(V.XYZ(-0.029f, -0.082f, -0.454f), new Quat(-0.219f, 0.054f, 0.050f, 0.973f), 0.008f), new HandJoint(V.XYZ(-0.031f, -0.094f, -0.479f), new Quat(-0.497f, 0.040f, 0.136f, 0.856f), 0.008f), new HandJoint(V.XYZ(-0.030f, -0.116f, -0.493f), new Quat(-0.497f, 0.040f, 0.136f, 0.856f), 0.007f), new HandJoint(V.XYZ(-0.049f, -0.157f, -0.387f), new Quat(0.488f, -0.042f, -0.077f, 0.868f), 0.020f), new HandJoint(V.XYZ(-0.044f, -0.110f, -0.416f), new Quat(0.308f, 0.064f, 0.052f, 0.948f), 0.010f), new HandJoint(V.XYZ(-0.050f, -0.087f, -0.449f), new Quat(-0.235f, -0.000f, 0.113f, 0.965f), 0.008f), new HandJoint(V.XYZ(-0.048f, -0.099f, -0.473f), new Quat(-0.560f, -0.064f, 0.133f, 0.815f), 0.007f), new HandJoint(V.XYZ(-0.042f, -0.122f, -0.484f), new Quat(-0.560f, -0.064f, 0.133f, 0.815f), 0.006f), new HandJoint(V.XYZ(-0.058f, -0.158f, -0.389f), new Quat(0.459f, -0.018f, 0.173f, 0.871f), 0.019f), new HandJoint(V.XYZ(-0.064f, -0.120f, -0.417f), new Quat(0.381f, 0.037f, 0.111f, 0.917f), 0.009f), new HandJoint(V.XYZ(-0.069f, -0.098f, -0.439f), new Quat(-0.135f, -0.038f, 0.192f, 0.971f), 0.007f), new HandJoint(V.XYZ(-0.066f, -0.104f, -0.459f), new Quat(-0.482f, -0.152f, 0.167f, 0.846f), 0.007f), new HandJoint(V.XYZ(-0.057f, -0.120f, -0.472f), new Quat(-0.482f, -0.152f, 0.167f, 0.846f), 0.006f), new HandJoint(V.XYZ(-0.028f, -0.133f, -0.403f), new Quat(-0.269f, 0.025f, -0.084f, 0.959f), 0.000f), new HandJoint(V.XYZ(-0.039f, -0.187f, -0.363f), new Quat(0.488f, -0.042f, -0.077f, 0.868f), 0.000f)]);

--- a/Examples/StereoKitTest/Tests/TestInputEvents.cs
+++ b/Examples/StereoKitTest/Tests/TestInputEvents.cs
@@ -1,0 +1,175 @@
+using StereoKit;
+using System.Collections.Generic;
+
+// Verifies the keyboard event queue itself, with no UI involved. Injections
+// made during one frame are published at the start of the next, so each check
+// runs one frame after the injections it describes.
+class TestInputEvents : ITest
+{
+	int frame = 0;
+
+	List<KeyboardEvent> ordered = new List<KeyboardEvent>();
+	List<KeyboardEvent> repeats = new List<KeyboardEvent>();
+	List<KeyboardEvent> mods    = new List<KeyboardEvent>();
+	BtnState            repeatPolled;
+	KeyboardEvent       astral;
+	int                 indexedCount;
+	KeyboardEvent       indexedFirst;
+	KeyboardEvent       outOfRange;
+	int                 afterIndexed;
+	List<KeyboardEvent> filtered     = new List<KeyboardEvent>();
+	List<uint>          legacyText   = new List<uint>();
+	List<uint>          legacyReread = new List<uint>();
+	uint                legacyAfterConsume;
+
+	public void Initialize() => Tests.RunForFrames(10);
+
+	public void Step()
+	{
+		switch (frame)
+		{
+			// Order: text and keys interleaved within a single frame must come
+			// back out in exactly the order they went in.
+			case 0:
+				Input.TextInject      ("a");
+				Input.KeyInjectPress  (Key.Backspace);
+				Input.TextInject      ("b");
+				Input.KeyInjectRelease(Key.Backspace);
+				break;
+			case 1:
+				Drain(ordered);
+				// Two presses with no release between them, as an auto-repeat
+				// arrives. Both must survive as separate events.
+				Input.KeyInjectPress(Key.Del);
+				Input.KeyInjectPress(Key.Del);
+				break;
+			case 2:
+				Drain(repeats);
+				repeatPolled = Input.Key(Key.Del);
+				Input.KeyInjectRelease(Key.Del);
+				break;
+			// Modifiers: each event carries the modifier state at the moment it
+			// was produced, which polled state can't reproduce mid-frame.
+			case 3:
+				Input.KeyInjectPress  (Key.Shift);
+				Input.TextInject      ("A");
+				Input.KeyInjectRelease(Key.Shift);
+				Input.TextInject      ("a");
+				break;
+			case 4:
+				Drain(mods);
+				Input.TextInject("\U0001F600");
+				break;
+			case 5:
+				Input.KeyboardConsume(out astral);
+				// Indexed reads see the whole frame, and consume nothing.
+				indexedCount = Input.KeyboardEventCount;
+				indexedFirst = Input.KeyboardEventAt(0);
+				outOfRange   = Input.KeyboardEventAt(99);
+				afterIndexed = Count(); // Consume had already emptied the queue
+				Input.TextInject      ("xy");
+				Input.KeyInjectPress  (Key.Home);
+				break;
+			// The deprecated cursor is independent: it sees only text events,
+			// and reading through it doesn't disturb the event cursor.
+			case 6:
+#pragma warning disable CS0618
+				for (char c = Input.TextConsume(); c != 0; c = Input.TextConsume())
+					legacyText.Add(c);
+				Input.TextReset();
+				for (char c = Input.TextConsume(); c != 0; c = Input.TextConsume())
+					legacyReread.Add(c);
+				legacyAfterConsume = (uint)Count(); // Event cursor untouched
+				// A lone surrogate half is not text, and must never reach a
+				// reader, where KeyboardEvent.Text would throw on it.
+				Input.TextInjectChar(0xD800);
+#pragma warning restore CS0618
+				// Carriage returns become newlines, and CRLF is a single one.
+				Input.TextInject("a\r\nb\rc");
+				Input.KeyInjectRelease(Key.Home);
+				break;
+			case 7:
+				Drain(filtered);
+				break;
+			case 8:
+				Tests.Test(OrderPreserved);
+				Tests.Test(RepeatsAreSeparateEvents);
+				Tests.Test(PolledKeyCollapsesRepeats);
+				Tests.Test(ModifiersStampedPerEvent);
+				Tests.Test(AstralCodepointSurvives);
+				Tests.Test(IndexedReadsDontConsume);
+				Tests.Test(CarriageReturnsBecomeNewlines);
+				Tests.Test(LegacyCursorIsTextOnly);
+				Tests.Test(LegacyCursorIsIndependent);
+				break;
+		}
+		frame++;
+	}
+
+	static void Drain(List<KeyboardEvent> into)
+	{
+		while (Input.KeyboardConsume(out KeyboardEvent e)) into.Add(e);
+	}
+
+	static int Count()
+	{
+		int count = 0;
+		while (Input.KeyboardConsume(out KeyboardEvent _)) count++;
+		return count;
+	}
+
+	bool OrderPreserved()
+		=>  ordered.Count == 4
+		&&  ordered[0].type == KeyboardEventType.Text       && ordered[0].Text == "a"
+		&&  ordered[1].type == KeyboardEventType.KeyPress   && ordered[1].key == Key.Backspace
+		&&  ordered[2].type == KeyboardEventType.Text       && ordered[2].Text == "b"
+		&&  ordered[3].type == KeyboardEventType.KeyRelease && ordered[3].key == Key.Backspace;
+
+	// Two presses in one frame are two events. This is the fidelity the old
+	// text-queue path had and polled keys never did.
+	bool RepeatsAreSeparateEvents()
+		=>  repeats.Count == 2
+		&&  repeats[0].type == KeyboardEventType.KeyPress && repeats[0].key == Key.Del
+		&&  repeats[1].type == KeyboardEventType.KeyPress && repeats[1].key == Key.Del;
+
+	// The same two presses collapse to one JustActive, which documents why
+	// editing keys read the queue rather than polling.
+	bool PolledKeyCollapsesRepeats() => repeatPolled.IsJustActive();
+
+	bool ModifiersStampedPerEvent()
+		=>  mods.Count == 4
+		// Shift's own press carries shift, its release does not.
+		&&  (mods[0].modifiers & KeyMod.Shift) != 0
+		&&  (mods[1].modifiers & KeyMod.Shift) != 0 && mods[1].Text == "A"
+		&& !((mods[2].modifiers & KeyMod.Shift) != 0)
+		&& !((mods[3].modifiers & KeyMod.Shift) != 0) && mods[3].Text == "a";
+
+	bool AstralCodepointSurvives()
+		=> astral.type == KeyboardEventType.Text && astral.Text == "\U0001F600";
+
+	bool IndexedReadsDontConsume()
+		=>  indexedCount == 1
+		&&  indexedFirst.type == KeyboardEventType.Text && indexedFirst.Text == "\U0001F600"
+		&&  outOfRange  .type == KeyboardEventType.None
+		&&  afterIndexed == 0;
+
+	// The surrogate injected alongside this text must not appear at all.
+	bool CarriageReturnsBecomeNewlines()
+	{
+		List<KeyboardEvent> text = filtered.FindAll(e => e.type == KeyboardEventType.Text);
+		return text.Count == 5
+			&& text[0].Text == "a" && text[1].Text == "\n"
+			&& text[2].Text == "b" && text[3].Text == "\n"
+			&& text[4].Text == "c";
+	}
+
+	// Text events only, in order, and 'x','y' are the only text that frame.
+	bool LegacyCursorIsTextOnly()
+		=> legacyText.Count == 2 && legacyText[0] == 'x' && legacyText[1] == 'y';
+
+	// TextReset re-reads the same text, and neither call moved the event cursor.
+	bool LegacyCursorIsIndependent()
+		=> legacyReread.Count == 2 && legacyReread[0] == 'x' && legacyAfterConsume == 3;
+
+	public void Shutdown() { }
+}

--- a/Examples/StereoKitTest/Tests/TestTextInput.cs
+++ b/Examples/StereoKitTest/Tests/TestTextInput.cs
@@ -1,0 +1,103 @@
+using StereoKit;
+
+// Verifies UI.Input's two input channels. Text arrives through the text queue,
+// and editing intent (backspace, delete, enter) arrives as key presses, which is
+// the only route a hardware keyboard has on Wayland, Web, and Android. Injected
+// keys and text land at the start of the following frame, so each scripted frame
+// asserts what the previous frame injected.
+class TestTextInput : ITest
+{
+	Pose windowPose = new Pose(0, 0, -0.5f, Quat.LookDir(0, 0, 1));
+
+	DefaultInteractors oldInteractors;
+	Interactor         ray;
+	Vec3               rayOrigin = V.XYZ(0.05f, -0.2f, -0.35f);
+	Vec3               target;
+	int                frame = 0;
+	string             text  = "";
+
+	string afterType, afterBackspace, afterDelete, afterInjectedControl;
+	bool   submitted;
+
+	public void Initialize()
+	{
+		oldInteractors = Interaction.DefaultInteractors;
+		if (!Tests.IsTesting) return; // leave the default interactors on to try by hand
+
+		Interaction.DefaultInteractors = DefaultInteractors.None;
+		ray    = Interactor.Create(InteractorType.Line, InteractorEvent.Pinch | InteractorEvent.Poke, InteractorActivation.State, InteractorSource.Unique, 0.01f, 0);
+		target = windowPose.position + V.XYZ(0, -0.04f, 0); // a guess at the field, refined once focused
+
+		Tests.RunForFrames(11);
+	}
+
+	public void Step()
+	{
+		bool scripted = Tests.IsTesting && frame < 11;
+		if (scripted)
+		{
+			// Frames 0-2 click the field to focus it: hover, press, release.
+			BtnState pinch = frame switch {
+				0 => BtnState.Inactive,
+				1 => BtnState.Active | BtnState.JustActive,
+				2 => BtnState.JustInactive,
+				_ => BtnState.Inactive };
+			Vec3 dir = (target - rayOrigin).Normalized;
+			ray.Update(rayOrigin, rayOrigin + dir * 100, new Pose(rayOrigin, Quat.LookDir(dir)), rayOrigin, Vec3.Zero, pinch, BtnState.Active);
+		}
+
+		UI.WindowBegin("Text Input", ref windowPose);
+		if (!Tests.IsTesting) UI.Text("Type, then try backspace, delete, and enter", Align.Center);
+		bool changed = UI.Input("field", ref text, new Vec2(0.2f, 0));
+		UI.WindowEnd();
+
+		if (scripted)
+		{
+			// Read what the previous frame's injection produced, then set up the
+			// next one.
+			switch (frame)
+			{
+				case 2: Input.TextInject("abc"); break;
+				case 3: afterType      = text; Input.KeyInjectPress  (Key.Backspace); break;
+				case 4: afterBackspace = text; Input.KeyInjectRelease(Key.Backspace); Input.KeyInjectPress(Key.Left); break;
+				case 5:                        Input.KeyInjectRelease(Key.Left);      Input.KeyInjectPress(Key.Del);  break;
+				case 6: afterDelete    = text; Input.KeyInjectRelease(Key.Del); break;
+				// A control code injected as text is not text, so it must not
+				// delete and must not land in the buffer.
+				case 7: Input.TextInject("\b"); break;
+				case 8: afterInjectedControl = text; Input.KeyInjectPress(Key.Return); break;
+				case 9: submitted = changed;   Input.KeyInjectRelease(Key.Return); break;
+			}
+			Log.Info($"frame {frame}: text=\"{text}\" changed={changed}");
+
+			if (frame < 2 && ray.TryGetFocusBounds(out Pose p, out Bounds b, out _))
+				target = p.ToMatrix().Transform(b.center);
+
+			if (frame == 10)
+			{
+				Tests.Test(TextInserts);
+				Tests.Test(BackspaceDeletesBack);
+				Tests.Test(DeleteDeletesForward);
+				Tests.Test(InjectedControlCodeIgnored);
+				Tests.Test(EnterSubmits);
+			}
+		}
+
+		frame++;
+	}
+
+	bool TextInserts()               => afterType      == "abc";
+	// Backspace at the end of the string removes the last character.
+	bool BackspaceDeletesBack()      => afterBackspace == "ab";
+	// Left moved the caret between 'a' and 'b', so Delete removes the 'b'.
+	bool DeleteDeletesForward()      => afterDelete    == "a";
+	bool InjectedControlCodeIgnored()=> afterInjectedControl == "a";
+	// Enter reports a change and closes the field out.
+	bool EnterSubmits()              => submitted;
+
+	public void Shutdown()
+	{
+		if (Tests.IsTesting) ray.Destroy();
+		Interaction.DefaultInteractors = oldInteractors;
+	}
+}

--- a/Examples/StereoKitTest/Tests/TestTextInputOrder.cs
+++ b/Examples/StereoKitTest/Tests/TestTextInputOrder.cs
@@ -1,0 +1,109 @@
+using StereoKit;
+
+// Verifies the three UI.Input behaviors that only appear when several events
+// land in the same frame, which is what a frame hitch produces. Each of these
+// fails under the older drain-text-then-poll-keys approach.
+class TestTextInputOrder : ITest
+{
+	Pose windowPose = new Pose(0, 0, -0.5f, Quat.LookDir(0, 0, 1));
+
+	DefaultInteractors oldInteractors;
+	Interactor         ray;
+	Vec3               rayOrigin = V.XYZ(0.05f, -0.2f, -0.35f);
+	Vec3               target;
+	int                frame = 0;
+	string             text  = "";
+
+	string afterSeed, afterInterleave, afterRepeat, afterShiftEnter;
+
+	public void Initialize()
+	{
+		oldInteractors = Interaction.DefaultInteractors;
+		if (!Tests.IsTesting) return;
+
+		Interaction.DefaultInteractors = DefaultInteractors.None;
+		ray    = Interactor.Create(InteractorType.Line, InteractorEvent.Pinch | InteractorEvent.Poke, InteractorActivation.State, InteractorSource.Unique, 0.01f, 0);
+		target = windowPose.position + V.XYZ(0, -0.04f, 0);
+
+		Tests.RunForFrames(10);
+	}
+
+	public void Step()
+	{
+		bool scripted = Tests.IsTesting && frame < 10;
+		if (scripted)
+		{
+			BtnState pinch = frame switch {
+				0 => BtnState.Inactive,
+				1 => BtnState.Active | BtnState.JustActive,
+				2 => BtnState.JustInactive,
+				_ => BtnState.Inactive };
+			Vec3 dir = (target - rayOrigin).Normalized;
+			ray.Update(rayOrigin, rayOrigin + dir * 100, new Pose(rayOrigin, Quat.LookDir(dir)), rayOrigin, Vec3.Zero, pinch, BtnState.Active);
+		}
+
+		UI.WindowBegin("Text Order", ref windowPose);
+		if (!Tests.IsTesting) UI.Text("Scripted same-frame input tests", Align.Center);
+		UI.Input("field", ref text, new Vec2(0.2f, 0));
+		UI.WindowEnd();
+
+		if (scripted)
+		{
+			switch (frame)
+			{
+				case 2: Input.TextInject("abc"); break;
+				// Type, delete, type, all inside one frame. Applied in order
+				// this is "abcy"; applied text-first it would be "abcx".
+				case 3:
+					afterSeed = text;
+					Input.TextInject      ("x");
+					Input.KeyInjectPress  (Key.Backspace);
+					Input.TextInject      ("y");
+					Input.KeyInjectRelease(Key.Backspace);
+					break;
+				// Two backspaces in one frame must delete two characters.
+				case 4:
+					afterInterleave = text;
+					Input.KeyInjectPress  (Key.Backspace);
+					Input.KeyInjectRelease(Key.Backspace);
+					Input.KeyInjectPress  (Key.Backspace);
+					Input.KeyInjectRelease(Key.Backspace);
+					break;
+				// Shift pressed and released around Return in one frame. Only
+				// the per-event modifier snapshot gets this right.
+				case 5:
+					afterRepeat = text;
+					Input.KeyInjectPress  (Key.Shift);
+					Input.KeyInjectPress  (Key.Return);
+					Input.KeyInjectRelease(Key.Return);
+					Input.KeyInjectRelease(Key.Shift);
+					break;
+				case 6: afterShiftEnter = text; break;
+				case 8:
+					Tests.Test(Seeded);
+					Tests.Test(InterleaveInOrder);
+					Tests.Test(SameFrameRepeatDeletesTwice);
+					Tests.Test(SameFrameShiftEnterAddsLine);
+					break;
+			}
+			Log.Info($"frame {frame}: text=\"{text.Replace("\n", "\\n")}\"");
+
+			if (frame < 2 && ray.TryGetFocusBounds(out Pose p, out Bounds b, out _))
+				target = p.ToMatrix().Transform(b.center);
+		}
+
+		frame++;
+	}
+
+	bool Seeded()                       => afterSeed       == "abc";
+	bool InterleaveInOrder()            => afterInterleave == "abcy";
+	bool SameFrameRepeatDeletesTwice()  => afterRepeat     == "ab";
+	// Shift+Enter adds a line rather than submitting, so the field stays open.
+	bool SameFrameShiftEnterAddsLine()  => afterShiftEnter == "ab\n";
+
+	public void Shutdown()
+	{
+		if (Tests.IsTesting) ray.Destroy();
+		Interaction.DefaultInteractors = oldInteractors;
+	}
+}

--- a/StereoKit/Native/NativeAPI.cs
+++ b/StereoKit/Native/NativeAPI.cs
@@ -842,9 +842,10 @@ namespace StereoKit
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern MouseMode    input_mouse_mode_get();
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         input_key_inject_press(Key key);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         input_key_inject_release(Key key);
-		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern uint         input_text_consume();
-		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         input_text_reset();
-		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         input_text_inject_char(uint character);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern KeyboardEvent input_keyboard_consume();
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern int          input_keyboard_event_count();
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern KeyboardEvent input_keyboard_event_at(int index);
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         input_text_inject([MarshalAs(UnmanagedType.LPUTF8Str)] string text_utf8);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         input_hand_visible(Handed hand, [MarshalAs(UnmanagedType.Bool)] bool visible);
 		[return: MarshalAs(UnmanagedType.Bool)]
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern bool         input_hand_get_visible(Handed hand);
@@ -867,6 +868,9 @@ namespace StereoKit
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern HandSimId    input_hand_sim_pose_add([In] Pose[] in_arr_palm_relative_hand_joints_25, ControllerKey button1, ControllerKey and_button2, Key or_hotkey1, Key and_hotkey2);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         input_hand_sim_pose_remove(HandSimId id);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         input_hand_sim_pose_clear();
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern uint         input_text_consume();
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         input_text_reset();
+		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         input_text_inject_char(uint character);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern int          input_pointer_count(InputSource filter);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern Pointer      input_pointer(int index, InputSource filter);
 		[DllImport(dll, CharSet = cSet, CallingConvention = call)] public static extern void         input_subscribe(InputSource source, BtnState input_event, [MarshalAs(UnmanagedType.FunctionPtr)] InputEventCallback input_event_callback);

--- a/StereoKit/Native/NativeEnums.cs
+++ b/StereoKit/Native/NativeEnums.cs
@@ -1943,6 +1943,36 @@ namespace StereoKit
 		MAX          = 0xFF,
 	}
 
+	/// <summary>Describes what kind of keyboard input event this is.</summary>
+	public enum KeyboardEventType {
+		/// <summary>Not an event. Consuming returns this once no events remain in this
+		/// frame's queue, and reading by index returns it for an index outside the
+		/// queue.</summary>
+		None         = 0,
+		/// <summary>A key was pressed. Auto-repeats arrive as additional press events with no
+		/// release between them, one per repeat.</summary>
+		KeyPress,
+		/// <summary>A key was released.</summary>
+		KeyRelease,
+		/// <summary>A single codepoint of insertable text.</summary>
+		Text,
+	}
+
+	/// <summary>A bit flag describing which of the keyboard's modifier keys are held.</summary>
+	[Flags]
+	public enum KeyMod {
+		/// <summary>No modifier keys are held.</summary>
+		None         = 0,
+		/// <summary>Either shift key.</summary>
+		Shift        = 1 << 0,
+		/// <summary>Either ctrl key.</summary>
+		Ctrl         = 1 << 1,
+		/// <summary>Either alt key.</summary>
+		Alt          = 1 << 2,
+		/// <summary>Either Windows/Mac Command key.</summary>
+		Cmd          = 1 << 3,
+	}
+
 	/// <summary>Represents an input from an XR headset's controller!</summary>
 	public enum ControllerKey {
 		/// <summary>Doesn't represent a key, generally means this item has not been set to

--- a/StereoKit/Native/NativeTypes.Custom.cs
+++ b/StereoKit/Native/NativeTypes.Custom.cs
@@ -816,4 +816,34 @@ namespace StereoKit
 		}
 	}
 
+	/// <summary>A single keyboard input event, either a key press, a key
+	/// release, or one codepoint of insertable text. Events preserve the exact
+	/// order they were produced in, including how text and keys interleave.
+	/// </summary>
+	[StructLayout(LayoutKind.Sequential)]
+	public struct KeyboardEvent
+	{
+		/// <summary>What kind of event this is, and which of the fields below
+		/// apply.</summary>
+		public KeyboardEventType type;
+		/// <summary>The key for press and release events, and none for text
+		/// events. Mouse buttons arrive here too, as the mouse key values.
+		/// </summary>
+		public Key key;
+		/// <summary>The modifier keys held when this event was produced. A
+		/// modifier's own press event includes itself, its release event does
+		/// not.</summary>
+		public KeyMod modifiers;
+		// The raw UTF-32 codepoint stays private so readers go through Text,
+		// where a (char) cast can't truncate codepoints past the BMP.
+		private uint character;
+
+		/// <summary>This event's text, as a string. Emoji and other codepoints
+		/// outside the Basic Multilingual Plane don't fit in a single C# char,
+		/// so this is the safe way to read one. Empty for key events.</summary>
+		public string Text => type == KeyboardEventType.Text
+			? char.ConvertFromUtf32((int)character)
+			: "";
+	}
+
 }

--- a/StereoKit/Systems/Input.cs
+++ b/StereoKit/Systems/Input.cs
@@ -715,22 +715,73 @@ namespace StereoKit
 		/// event queue. It will be processed at the start of the next frame,
 		/// and will be indistinguishable from a physical key press. Remember
 		/// to release your key as well!
-		/// 
-		/// This will _not_ submit text to StereoKit's text queue, and will not
-		/// show up in places like UI.Input. For that, you must submit a
-		/// TextInjectChar call.</summary>
+		///
+		/// This will _not_ submit text to StereoKit's text queue, so to type a
+		/// character into something like UI.Input, you must submit a
+		/// TextInject call. Editing keys are the other way around: backspace,
+		/// delete, enter, and escape act on UI.Input through this call.</summary>
 		/// <param name="key">The key to press.</param>
 		public static void KeyInjectPress(Key key) => NativeAPI.input_key_inject_press(key);
 		/// <summary>This will inject a key release event into StereoKit's
 		/// input event queue. It will be processed at the start of the next
 		/// frame, and will be indistinguishable from a physical key release.
 		/// This should be preceded by a key press!
-		/// 
-		/// This will _not_ submit text to StereoKit's text queue, and will not
-		/// show up in places like UI.Input. For that, you must submit a
-		/// TextInjectChar call.</summary>
+		///
+		/// This will _not_ submit text to StereoKit's text queue, so to type a
+		/// character into something like UI.Input, you must submit a
+		/// TextInject call. Editing keys are the other way around: backspace,
+		/// delete, enter, and escape act on UI.Input through KeyInjectPress.</summary>
 		/// <param name="key">The key to release.</param>
 		public static void KeyInjectRelease(Key key) => NativeAPI.input_key_inject_release(key);
+
+		/// <summary>Reads the next keyboard event from this frame's queue, and
+		/// advances to the one after it. Key presses, key releases, and text
+		/// all arrive here in the exact order the user produced them, so a
+		/// text field can apply them without guessing at what came first.
+		///
+		/// Each auto-repeat of a held key is its own press event, which is why
+		/// this is the right way to drive editing keys. `Input.Key` reports
+		/// state for the whole frame instead, so it cannot tell one press from
+		/// several.
+		///
+		/// Events are consumed as they're read, and a focused `UI.Input` reads
+		/// the whole queue. To observe events without consuming them, read by
+		/// index with `Input.KeyboardEventCount` and `Input.KeyboardEventAt`
+		/// instead. Like the rest of the input API, the queue belongs to the
+		/// main thread, and is rebuilt at the start of each frame.</summary>
+		/// <param name="keyboardEvent">The next event in this frame's queue,
+		/// or an event of type `KeyboardEventType.None` if none remain.</param>
+		/// <returns>True if an event was read, false once the queue is empty.
+		/// </returns>
+		public static bool KeyboardConsume(out KeyboardEvent keyboardEvent)
+		{
+			keyboardEvent = NativeAPI.input_keyboard_consume();
+			return keyboardEvent.type != KeyboardEventType.None;
+		}
+		/// <summary>The number of keyboard events this frame, for reading by
+		/// index with `Input.KeyboardEventAt`. This is the whole frame's count,
+		/// unaffected by what `Input.KeyboardConsume` has consumed.</summary>
+		public static int KeyboardEventCount => NativeAPI.input_keyboard_event_count();
+		/// <summary>Reads a keyboard event by index, without consuming
+		/// anything. This suits code that wants to observe the frame's input
+		/// even after something else, like a focused `UI.Input`, has consumed
+		/// the queue.</summary>
+		/// <param name="index">Index of the event, from 0 up to
+		/// `Input.KeyboardEventCount`.</param>
+		/// <returns>The event at that index, or an event of type
+		/// `KeyboardEventType.None` if the index is out of range.</returns>
+		public static KeyboardEvent KeyboardEventAt(int index) => NativeAPI.input_keyboard_event_at(index);
+		/// <summary>Injects text into StereoKit's keyboard event queue, as if
+		/// the user had typed or pasted it. It will be available at the start
+		/// of the next frame, and is indistinguishable from normal text entry.
+		/// The whole string arrives as one uninterrupted run of events.
+		///
+		/// This is for text only. Carriage returns arrive as newlines, with
+		/// CRLF counting as a single one. Other control characters are ignored
+		/// here with a warning, since editing keys belong in
+		/// `Input.KeyInjectPress`.</summary>
+		/// <param name="text">The text to inject, as a normal string.</param>
+		public static void TextInject(string text) => NativeAPI.input_text_inject(text);
 
 		/// <summary>Returns the next text character from the list of
 		/// characters that have been entered this frame! Will return '\0' if
@@ -738,12 +789,18 @@ namespace StereoKit
 		/// system's text entry system, and so can be unicode, will repeat if
 		/// their 'key' is held down, and could arrive from something like a
 		/// copy/paste operation.
-		/// 
+		///
+		/// This is insertable text only. Editing keys such as backspace,
+		/// delete, enter, and escape never arrive here, so a text field must
+		/// read them with `Input.Key`, the same way it reads the arrow keys.
+		/// Newline and tab are text, and can arrive from a paste or an IME.
+		///
 		/// If you wish to reset this function to begin at the start of the
 		/// read list on the next call, you can call `Input.TextReset`.</summary>
 		/// <returns>The next character in this frame's list, or '\0' if none
 		/// remain.</returns>
-		public static char TextConsume() 
+		[Obsolete("Use Input.KeyboardConsume. It keeps text in order with the key events around it, and reports full UTF-32 codepoints instead of truncating to a char.")]
+		public static char TextConsume()
 			=> (char)NativeAPI.input_text_consume();
 		/// <summary>Resets the `Input.TextConsume` read list back to the
 		/// start.
@@ -754,6 +811,7 @@ namespace StereoKit
 		/// in the frame, you would read everything with `TextConsume`, and
 		/// then `TextReset` afterwards to reset the read list for the 
 		/// following `UI.Input`.</summary>
+		[Obsolete("Use Input.KeyboardEventCount and Input.KeyboardEventAt, which read events without consuming them at all.")]
 		public static void TextReset()
 			=> NativeAPI.input_text_reset();
 		/// <summary>This will inject a UTF32 Unicode text character into
@@ -762,9 +820,12 @@ namespace StereoKit
 		/// entry.
 		/// 
 		/// This will _not_ submit key press/release events to StereoKit's
-		/// input queue, use KeyInjectPress/Release for that.</summary>
+		/// input queue, use KeyInjectPress/Release for that. The text queue
+		/// carries insertable text only, so carriage returns become newlines,
+		/// and other control characters are ignored here with a warning.</summary>
 		/// <param name="unicodeCharUTF32">An unsigned integer representing a
 		/// single UTF32 character.</param>
+		[Obsolete("Use Input.TextInject.")]
 		public static void TextInjectChar(uint unicodeCharUTF32) => NativeAPI.input_text_inject_char(unicodeCharUTF32);
 		/// <summary>This will convert a C# string into a number of UTF32
 		/// Unicode text characters, and inject them into StereoKit's text
@@ -772,9 +833,12 @@ namespace StereoKit
 		/// and will be indistinguishable from normal text entry.
 		/// 
 		/// This will _not_ submit key press/release events to StereoKit's
-		/// input queue, use KeyInjectPress/Release for that.</summary>
+		/// input queue, use KeyInjectPress/Release for that. The text queue
+		/// carries insertable text only, so carriage returns become newlines,
+		/// and other control characters are ignored here with a warning.</summary>
 		/// <param name="chars">A collection of characters to submit as text
 		/// input.</param>
+		[Obsolete("Use Input.TextInject.")]
 		public static void TextInjectChar(string chars) {
 			byte[] bytes = Encoding.Convert(Encoding.Unicode, Encoding.UTF32, Encoding.Unicode.GetBytes(chars));
 			for (int i = 0; i+4 <= bytes.Length; i += 4)
@@ -786,12 +850,15 @@ namespace StereoKit
 		/// frame, and will be indistinguishable from normal text entry.
 		/// 
 		/// This will _not_ submit key press/release events to StereoKit's
-		/// input queue, use KeyInjectPress/Release for that.</summary>
+		/// input queue, use KeyInjectPress/Release for that. The text queue
+		/// carries insertable text only, so carriage returns become newlines,
+		/// and other control characters are ignored here with a warning.</summary>
 		/// <param name="chars">A byte array representing a string in some
 		/// encoded format.</param>
 		/// <param name="charEncoding">The encoding format of the byte array.
 		/// Note that an encoding of UTF32 will skip converting bytes to UTF32.
 		/// </param>
+		[Obsolete("Use Input.TextInject.")]
 		public static void TextInjectChar(byte[] chars, Encoding charEncoding)
 		{
 			byte[] bytes = charEncoding == Encoding.UTF32 && chars.Length % 4 == 0

--- a/StereoKit/Systems/UI.cs
+++ b/StereoKit/Systems/UI.cs
@@ -231,6 +231,13 @@ namespace StereoKit
 		public static bool IsInteracting(Handed hand)
 			=> NativeAPI.interactor_is_interacting(HandToSource(hand));
 
+		/// <summary>Is a `UI.Input` currently focused and taking keyboard
+		/// input? A focused Input reads the whole keyboard event queue, so
+		/// this is how you tell whether your own keyboard handling should
+		/// stand down for the frame.</summary>
+		public static bool HasKeyboardFocus
+			=> NativeAPI.ui_has_keyboard_focus();
+
 		/// <summary>This allows you to explicitly set a theme color, for finer
 		/// grained control over the UI appearance. Each theme type is still
 		/// used by many different UI elements. This will automatically
@@ -1059,7 +1066,8 @@ namespace StereoKit
 		/// <summary>This is an input field where users can input text to the
 		/// app! Selecting it will spawn a virtual keyboard, or act as the
 		/// keyboard focus. Hitting escape or enter, or focusing another UI
-		/// element will remove focus from this Input.</summary>
+		/// element will remove focus from this Input. Shift+Enter adds a
+		/// newline instead, and tab adds a tab.</summary>
 		/// <param name="id">An id for tracking element state. MUST be unique
 		/// within current hierarchy.</param>
 		/// <param name="value">The string that will store the Input's 
@@ -1087,7 +1095,8 @@ namespace StereoKit
 		/// <summary>This is an input field where users can input text to the
 		/// app! Selecting it will spawn a virtual keyboard, or act as the
 		/// keyboard focus. Hitting escape or enter, or focusing another UI
-		/// element will remove focus from this Input.</summary>
+		/// element will remove focus from this Input. Shift+Enter adds a
+		/// newline instead, and tab adds a tab.</summary>
 		/// <param name="id">An id for tracking element state. MUST be unique
 		/// within current hierarchy.</param>
 		/// <param name="value">The string that will store the Input's

--- a/StereoKitC/stereokit.h
+++ b/StereoKitC/stereokit.h
@@ -3314,6 +3314,52 @@ typedef enum key_ {
 	key_MAX = 0xFF,
 } key_;
 
+/*Describes what kind of keyboard input event this is.*/
+typedef enum keyboard_event_type_ {
+	/*Not an event. Consuming returns this once no events remain in this
+	  frame's queue, and reading by index returns it for an index outside the
+	  queue.*/
+	keyboard_event_type_none = 0,
+	/*A key was pressed. Auto-repeats arrive as additional press events with no
+	  release between them, one per repeat.*/
+	keyboard_event_type_key_press,
+	/*A key was released.*/
+	keyboard_event_type_key_release,
+	/*A single codepoint of insertable text.*/
+	keyboard_event_type_text,
+} keyboard_event_type_;
+
+/*A bit flag describing which of the keyboard's modifier keys are held.*/
+typedef enum key_mod_ {
+	/*No modifier keys are held.*/
+	key_mod_none = 0,
+	/*Either shift key.*/
+	key_mod_shift = 1 << 0,
+	/*Either ctrl key.*/
+	key_mod_ctrl = 1 << 1,
+	/*Either alt key.*/
+	key_mod_alt = 1 << 2,
+	/*Either Windows/Mac Command key.*/
+	key_mod_cmd = 1 << 3,
+} key_mod_;
+SK_MakeFlag(key_mod_);
+
+/*A single keyboard input event, either a key press, a key release, or one
+  codepoint of insertable text. Events preserve the exact order they were
+  produced in, including how text and keys interleave.*/
+typedef struct keyboard_event_t {
+	/*What kind of event this is, and which of the fields below apply.*/
+	keyboard_event_type_ type;
+	/*The key for press and release events, and none for text events. Mouse
+	  buttons arrive here too, as the mouse key values.*/
+	key_                 key;
+	/*The modifier keys held when this event was produced. A modifier's own
+	  press event includes itself, its release event does not.*/
+	key_mod_             modifiers;
+	/*The UTF-32 codepoint for text events, 0 for key events.*/
+	char32_t             character;
+} keyboard_event_t;
+
 /*Represents an input from an XR headset's controller!*/
 typedef enum controller_key_ {
 	/*Doesn't represent a key, generally means this item has not been set to
@@ -3566,9 +3612,10 @@ SK_API void                  input_mouse_mode_set            (mouse_mode_ mode);
 SK_API mouse_mode_           input_mouse_mode_get            (void);
 SK_API void                  input_key_inject_press          (key_ key);
 SK_API void                  input_key_inject_release        (key_ key);
-SK_API char32_t              input_text_consume              (void);
-SK_API void                  input_text_reset                (void);
-SK_API void                  input_text_inject_char          (char32_t character);
+SK_API keyboard_event_t      input_keyboard_consume          (void);
+SK_API int32_t               input_keyboard_event_count      (void);
+SK_API keyboard_event_t      input_keyboard_event_at         (int32_t index);
+SK_API void                  input_text_inject               (const char* text_utf8);
 SK_API void                  input_hand_visible              (handed_ hand, bool32_t visible);
 SK_API bool32_t              input_hand_get_visible          (handed_ hand);
 SK_API void                  input_hand_material             (handed_ hand, material_t material);
@@ -3593,6 +3640,9 @@ SK_API hand_sim_id_t         input_hand_sim_pose_add         (const pose_t* in_a
 SK_API void                  input_hand_sim_pose_remove      (hand_sim_id_t id);
 SK_API void                  input_hand_sim_pose_clear       (void);
 
+SK_API SK_DEPRECATED char32_t input_text_consume             (void);
+SK_API SK_DEPRECATED void    input_text_reset                (void);
+SK_API SK_DEPRECATED void    input_text_inject_char          (char32_t character);
 SK_API SK_DEPRECATED int32_t input_pointer_count             (input_source_ filter sk_default(input_source_any));
 SK_API SK_DEPRECATED pointer_t input_pointer                 (int32_t index, input_source_ filter sk_default(input_source_any));
 SK_API SK_DEPRECATED void    input_subscribe                 (input_source_ source, button_state_ input_event, void (*input_event_callback)(input_source_ source, button_state_ input_event, const sk_ref(pointer_t) in_pointer));

--- a/StereoKitC/systems/input_keyboard.cpp
+++ b/StereoKitC/systems/input_keyboard.cpp
@@ -3,51 +3,105 @@
 #include "../platforms/platform.h"
 #include "../libraries/array.h"
 #include "../libraries/ferr_thread.h"
+#include "../libraries/unicode.h"
 
 namespace sk {
 
 ///////////////////////////////////////////
 
-struct keyboard_event_t {
-	key_    key;
-	int16_t down;
-};
-
 struct keyboard_t {
 	uint8_t                   keys[key_MAX];
-	array_t<keyboard_event_t> events;
-	array_t<char32_t>         characters;
-	int32_t                   queue_counter;
+	array_t<keyboard_event_t> events;       // This frame's events, in order
+	int32_t                   event_cursor; // input_keyboard_consume
+	int32_t                   text_cursor;  // Deprecated input_text_consume
 };
 
 ///////////////////////////////////////////
 
 struct input_keyboard_state_t {
 	keyboard_t                key_data;
-	array_t<keyboard_event_t> key_pending;
-	array_t<char32_t>         chars_pending;
-	ft_mutex_t                key_pending_mtx;
+	array_t<keyboard_event_t> pending;             // Guarded by pending_mtx
+	key_mod_                  pending_mods;        // Guarded by pending_mtx
+	ft_mutex_t                pending_mtx;
 	bool                      key_suspended;
+	uint64_t                  warned_char_mask;    // Guarded by pending_mtx
 	float                     last_physical_keypress;
 };
 static input_keyboard_state_t local = {};
 
 ///////////////////////////////////////////
 
+static key_mod_ input_key_to_mod(key_ key) {
+	switch (key) {
+	case key_shift: return key_mod_shift;
+	case key_ctrl:  return key_mod_ctrl;
+	case key_alt:   return key_mod_alt;
+	case key_lcmd:
+	case key_rcmd:  return key_mod_cmd;
+	default:        return key_mod_none;
+	}
+}
+
+///////////////////////////////////////////
+
+// Stamps the event with the modifiers held right now, so a consumer walking
+// the queue sees the state at each event. Callers must hold pending_mtx.
+static void input_pending_add(keyboard_event_type_ type, key_ key, char32_t character) {
+	keyboard_event_t evt = {};
+	evt.type      = type;
+	evt.key       = key;
+	evt.modifiers = local.pending_mods;
+	evt.character = character;
+	local.pending.add(evt);
+}
+
+///////////////////////////////////////////
+
+// The text channel carries insertable text only. Newline and tab qualify, the
+// rest of the control codes are editing keys. Surrogates and codepoints past
+// the Unicode range are not text at all.
+bool input_text_insertable(char32_t character) {
+	if (character >= 0xD800 && character <= 0xDFFF) return false;
+	if (character >  0x10FFFF)                      return false;
+	return (character >= 0x20 && character != 0x7f) ||
+	        character == '\n' || character == '\t';
+}
+
+///////////////////////////////////////////
+
+// One warning per distinct character, so a held key's repeats don't spam the
+// log. Callers must hold pending_mtx.
+static bool input_text_warn_once(char32_t character) {
+	uint64_t bit = 1ULL << (character & 63);
+	if (local.warned_char_mask & bit) return false;
+	local.warned_char_mask |= bit;
+	return true;
+}
+
+///////////////////////////////////////////
+
+static void input_text_warn_skipped(char32_t character) {
+	if (character < 0x20 || character == 0x7f)
+		log_warnf("Ignored control character U+%04X injected as text. Editing "
+		          "keys go through input_key_inject_press instead.", (uint32_t)character);
+	else
+		log_warnf("Ignored invalid codepoint U+%X injected as text.", (uint32_t)character);
+}
+
+///////////////////////////////////////////
+
 void input_keyboard_initialize() {
 	local = {};
 	local.last_physical_keypress = -1000;
-	local.key_pending_mtx        = ft_mutex_create();
+	local.pending_mtx            = ft_mutex_create();
 }
 
 ///////////////////////////////////////////
 
 void input_keyboard_shutdown() {
-	ft_mutex_destroy(&local.key_pending_mtx);
-	local.key_pending        .free();
-	local.chars_pending      .free();
-	local.key_data.events    .free();
-	local.key_data.characters.free();
+	ft_mutex_destroy(&local.pending_mtx);
+	local.pending         .free();
+	local.key_data.events .free();
 	local = {};
 }
 
@@ -55,39 +109,42 @@ void input_keyboard_shutdown() {
 
 void input_keyboard_suspend(bool suspend) {
 	local.key_suspended = suspend;
+
+	// Modifier releases can get lost around a suspend, and a stale modifier
+	// would mis-stamp every event after. Fresh presses will set them again.
+	if (suspend) {
+		ft_mutex_lock(local.pending_mtx);
+		local.pending_mods = key_mod_none;
+		ft_mutex_unlock(local.pending_mtx);
+	}
 }
 
 ///////////////////////////////////////////
 
 void input_keyboard_update() {
-	input_text_reset();
+	local.key_data.event_cursor = 0;
+	local.key_data.text_cursor  = 0;
 
 	// Clear any just_in/active flags that were set on the last frame
 	array_t<keyboard_event_t> &evts = local.key_data.events;
 	for (int32_t i = 0; i < evts.count; i++) {
-		if (evts[i].down)
-			local.key_data.keys[evts[i].key] &= ~button_state_just_active;
-		else
-			local.key_data.keys[evts[i].key] &= ~button_state_just_inactive;
+		if      (evts[i].type == keyboard_event_type_key_press  ) local.key_data.keys[evts[i].key] &= ~button_state_just_active;
+		else if (evts[i].type == keyboard_event_type_key_release) local.key_data.keys[evts[i].key] &= ~button_state_just_inactive;
 	}
 
-	// Thread safe copy new key events into the main thread
-	local.key_data.events    .clear();
-	local.key_data.characters.clear();
-	ft_mutex_lock(local.key_pending_mtx);
-	local.key_data.events    .add_range(local.key_pending  .data, local.key_pending  .count);
-	local.key_data.characters.add_range(local.chars_pending.data, local.chars_pending.count);
-	local.key_pending  .clear();
-	local.chars_pending.clear();
-	ft_mutex_unlock(local.key_pending_mtx);
+	// Thread safe copy new events into the main thread
+	evts.clear();
+	ft_mutex_lock(local.pending_mtx);
+	evts.add_range(local.pending.data, local.pending.count);
+	local.pending.clear();
+	ft_mutex_unlock(local.pending_mtx);
 
 	// Set key activity flags based on the new event queue
-	evts = local.key_data.events;
 	for (int32_t i = 0; i < evts.count; i++) {
 		keyboard_event_t &evt = evts.get(i);
-		if (evt.down) {
+		if (evt.type == keyboard_event_type_key_press) {
 			local.key_data.keys[evt.key] |= button_state_just_active | button_state_active;
-		} else {
+		} else if (evt.type == keyboard_event_type_key_release) {
 			local.key_data.keys[evt.key] &= ~button_state_active;
 			local.key_data.keys[evt.key] |=  button_state_just_inactive;
 		}
@@ -98,40 +155,71 @@ void input_keyboard_update() {
 
 void input_key_inject_press(key_ key) {
 	// Don't inject keys if input is suspended
-	if (local.key_suspended) return;
+	if (local.key_suspended || (uint32_t)key >= key_MAX) return;
 
-	ft_mutex_lock(local.key_pending_mtx);
+	ft_mutex_lock(local.pending_mtx);
 
-	keyboard_event_t evt;
-	evt.key  = key;
-	evt.down = 1;
-	local.key_pending.add(evt);
+	// A modifier's own press carries itself, its release does not
+	local.pending_mods |= input_key_to_mod(key);
+	input_pending_add(keyboard_event_type_key_press, key, 0);
 
-	ft_mutex_unlock(local.key_pending_mtx);
+	ft_mutex_unlock(local.pending_mtx);
 }
 
 ///////////////////////////////////////////
 
 void input_key_inject_release(key_ key) {
+	if ((uint32_t)key >= key_MAX) return;
+
 	// Don't inject keys if input is suspended, unless the key was pressed
 	// before input was suspended.
 	if (local.key_suspended && (input_keyboard_get(key) & button_state_inactive))
 		return;
 
-	ft_mutex_lock(local.key_pending_mtx);
+	ft_mutex_lock(local.pending_mtx);
 
-	keyboard_event_t evt;
-	evt.key  = key;
-	evt.down = 0;
-	local.key_pending.add(evt);
+	local.pending_mods &= ~input_key_to_mod(key);
+	input_pending_add(keyboard_event_type_key_release, key, 0);
 
-	ft_mutex_unlock(local.key_pending_mtx);
+	ft_mutex_unlock(local.pending_mtx);
 }
 
 ///////////////////////////////////////////
 
 button_state_ input_keyboard_get(key_ key) {
+	if ((uint32_t)key >= key_MAX) return button_state_inactive;
 	return (button_state_)local.key_data.keys[key];
+}
+
+///////////////////////////////////////////
+
+void input_text_inject(const char* text_utf8) {
+	// Don't inject characters if input is suspended
+	if (local.key_suspended || text_utf8 == nullptr) return;
+
+	char32_t warn_char = 0;
+	char32_t curr      = 0;
+
+	// One lock for the whole string, so a paste arrives as a single block
+	ft_mutex_lock(local.pending_mtx);
+
+	while (utf8_decode_fast_b(text_utf8, &text_utf8, &curr)) {
+		// Carriage returns are line breaks, and CRLF is a single one
+		if (curr == '\r') {
+			if (*text_utf8 == '\n') text_utf8++;
+			curr = '\n';
+		}
+		if (input_text_insertable(curr)) {
+			input_pending_add(keyboard_event_type_text, key_none, curr);
+		} else if (warn_char == 0 && input_text_warn_once(curr)) {
+			warn_char = curr;
+		}
+	}
+
+	ft_mutex_unlock(local.pending_mtx);
+
+	if (warn_char != 0)
+		input_text_warn_skipped(warn_char);
 }
 
 ///////////////////////////////////////////
@@ -140,30 +228,69 @@ void input_text_inject_char(char32_t character) {
 	// Don't inject characters if input is suspended
 	if (local.key_suspended) return;
 
-	ft_mutex_lock(local.key_pending_mtx);
+	if (character == '\r') character = '\n'; // Carriage return is a line break
 
-	local.chars_pending.add(character);
+	bool insertable = input_text_insertable(character);
+	bool warn       = false;
 
-	ft_mutex_unlock(local.key_pending_mtx);
+	ft_mutex_lock(local.pending_mtx);
+
+	if (insertable) input_pending_add(keyboard_event_type_text, key_none, character);
+	else            warn = input_text_warn_once(character);
+
+	ft_mutex_unlock(local.pending_mtx);
+
+	if (warn)
+		input_text_warn_skipped(character);
 }
 
 ///////////////////////////////////////////
 
-char32_t input_text_consume() {
-	// Return false if queue is empty
-	if (local.key_data.queue_counter >= local.key_data.characters.count) return 0;
+// The event queue and its cursors are unguarded main thread state, same as
+// the rest of the polled input API.
+keyboard_event_t input_keyboard_consume() {
+	keyboard_event_t result = {};
+	if (local.key_data.event_cursor >= local.key_data.events.count) return result;
 
 	// Next item in queue for the next consume call
-	char32_t result = local.key_data.characters[local.key_data.queue_counter];
-	local.key_data.queue_counter++;
+	result = local.key_data.events[local.key_data.event_cursor];
+	local.key_data.event_cursor++;
 
 	return result;
 }
 
 ///////////////////////////////////////////
 
+int32_t input_keyboard_event_count() {
+	return local.key_data.events.count;
+}
+
+///////////////////////////////////////////
+
+keyboard_event_t input_keyboard_event_at(int32_t index) {
+	keyboard_event_t result = {};
+	if (index < 0 || index >= local.key_data.events.count) return result;
+	return local.key_data.events[index];
+}
+
+///////////////////////////////////////////
+
+char32_t input_text_consume() {
+	// This cursor is independent of the event cursor, so a consumer of the
+	// deprecated API sees every text event regardless of who else has read.
+	array_t<keyboard_event_t> &evts = local.key_data.events;
+	while (local.key_data.text_cursor < evts.count) {
+		keyboard_event_t &evt = evts.get(local.key_data.text_cursor);
+		local.key_data.text_cursor++;
+		if (evt.type == keyboard_event_type_text) return evt.character;
+	}
+	return 0;
+}
+
+///////////////////////////////////////////
+
 void input_text_reset() {
-	local.key_data.queue_counter = 0;
+	local.key_data.text_cursor = 0;
 }
 
 ///////////////////////////////////////////

--- a/StereoKitC/systems/input_keyboard.h
+++ b/StereoKitC/systems/input_keyboard.h
@@ -4,17 +4,12 @@
 
 namespace sk {
 
-struct key_event_t {
-	key_          key;
-	button_state_ state;
-	char32_t      character;
-};
-
 void          input_keyboard_initialize();
 void          input_keyboard_shutdown  ();
 void          input_keyboard_suspend   (bool suspend);
 void          input_keyboard_update    ();
 button_state_ input_keyboard_get       (key_ key);
+bool          input_text_insertable    (char32_t character);
 
 float         input_get_last_physical_keypress_time();
 void          input_set_last_physical_keypress_time(float time);

--- a/StereoKitC/tools/virtual_keyboard.cpp
+++ b/StereoKitC/tools/virtual_keyboard.cpp
@@ -9,7 +9,6 @@
 #include "../stereokit_ui.h"
 #include "../sk_math.h"
 #include "../libraries/array.h"
-#include "../libraries/unicode.h"
 #include "../libraries/stref.h"
 #include "../platforms/platform.h"
 
@@ -81,15 +80,15 @@ void virtualkeyboard_initialize() {
 
 	////// Text keyboard //////
 	layouts[0] =
-R"(`-`-192|1-1-49|2-2-50|3-3-51|4-4-52|5-5-53|6-6-54|7-7-55|8-8-56|9-9-57|0-0-48|\--\--189|=-=-187|spr:sk/ui/backspace-\b-8-3|spr:sk/ui/close----close
-Tab-\t-9-3|q-q-81|w-w-87|e-e-69|r-r-82|t-t-84|y-y-89|u-u-85|i-i-73|o-o-79|p-p-80|[-[-219|]-]-221|\\-\\-220
-Enter-\n-13-4|a-a-65|s-s-83|d-d-68|f-f-70|g-g-71|h-h-72|j-j-74|k-k-75|l-l-76|;-;-186|'-'-222|Enter-\r-13-3
+R"(`-`-192|1-1-49|2-2-50|3-3-51|4-4-52|5-5-53|6-6-54|7-7-55|8-8-56|9-9-57|0-0-48|\--\--189|=-=-187|spr:sk/ui/backspace--8-3|spr:sk/ui/close----close
+Tab--9-3|q-q-81|w-w-87|e-e-69|r-r-82|t-t-84|y-y-89|u-u-85|i-i-73|o-o-79|p-p-80|[-[-219|]-]-221|\\-\\-220
+Enter-\n--4|a-a-65|s-s-83|d-d-68|f-f-70|g-g-71|h-h-72|j-j-74|k-k-75|l-l-76|;-;-186|'-'-222|Enter--13-3
 spr:sk/ui/shift--16-5-visit_1|z-z-90|x-x-88|c-c-67|v-v-86|b-b-66|n-n-78|m-m-77|,-,-188|.-.-190|/-/-191|spr:sk/ui/shift--16-2-visit_1|spr:sk/ui/arrow_up--38
 Ctrl--17-4-mod|Cmd--91-3|Alt--18-3-mod| - -32-9|Alt--18-3-mod|Ctrl--17-3-mod|spr:sk/ui/arrow_left--37|spr:sk/ui/arrow_down--40|spr:sk/ui/arrow_right--39|)";
 	layouts[1] =
-R"(~-~-192|!-!-49|@-@-50|#-#-51|$-$-52|%-%-53|^-^-54|&-&-55|*-*-56|(-(-57|)-)-48|_-_-189|+-+-187|spr:sk/ui/backspace-\b-8-3|spr:sk/ui/close----close
-Tab-\t-9-3|Q-Q-81|W-W-87|E-E-69|R-R-82|T-T-84|Y-Y-89|U-U-85|I-I-73|O-O-79|P-P-80|{-{-219|}-}-221|\|-\|-220
-Enter-\n-13-4|A-A-65|S-S-83|D-D-68|F-F-70|G-G-71|H-H-72|J-J-74|K-K-75|L-L-76|:-:-186|"-"-222|Enter-\r-13-3
+R"(~-~-192|!-!-49|@-@-50|#-#-51|$-$-52|%-%-53|^-^-54|&-&-55|*-*-56|(-(-57|)-)-48|_-_-189|+-+-187|spr:sk/ui/backspace--8-3|spr:sk/ui/close----close
+Tab--9-3|Q-Q-81|W-W-87|E-E-69|R-R-82|T-T-84|Y-Y-89|U-U-85|I-I-73|O-O-79|P-P-80|{-{-219|}-}-221|\|-\|-220
+Enter-\n--4|A-A-65|S-S-83|D-D-68|F-F-70|G-G-71|H-H-72|J-J-74|K-K-75|L-L-76|:-:-186|"-"-222|Enter--13-3
 spr:sk/ui/shift--16-5-go_0|Z-Z-90|X-X-88|C-C-67|V-V-86|B-B-66|N-N-78|M-M-77|<-<-188|>->-190|?-?-191|spr:sk/ui/shift--16-2-go_0|spr:sk/ui/arrow_up--38
 Ctrl--17-4-mod|Cmd--91-3|Alt--18-3-mod| - -32-9|Alt--18-3-mod|Ctrl--17-3-mod|spr:sk/ui/arrow_left--37|spr:sk/ui/arrow_down--40|spr:sk/ui/arrow_right--39|)";
 	platform_keyboard_set_layout(text_context_text,     layouts, 2);
@@ -97,25 +96,25 @@ Ctrl--17-4-mod|Cmd--91-3|Alt--18-3-mod| - -32-9|Alt--18-3-mod|Ctrl--17-3-mod|spr
 
 	////// URI keyboard //////
 	layouts[0] =
-R"(`-`-192|1-1-49|2-2-50|3-3-51|4-4-52|5-5-53|6-6-54|7-7-55|8-8-56|9-9-57|0-0-48|\--\--189|=-=-187|spr:sk/ui/backspace-\b-8-3|---2|spr:sk/ui/close----close
-Tab-\t-9-3|q-q-81|w-w-87|e-e-69|r-r-82|t-t-84|y-y-89|u-u-85|i-i-73|o-o-79|p-p-80|[-[-219|]-]-221|\\-\\-220|.com-.com--4
-Enter-\n-13-4|a-a-65|s-s-83|d-d-68|f-f-70|g-g-71|h-h-72|j-j-74|k-k-75|l-l-76|;-;-186|'-'-222|Enter-\r-13-3|.net-.net--4
+R"(`-`-192|1-1-49|2-2-50|3-3-51|4-4-52|5-5-53|6-6-54|7-7-55|8-8-56|9-9-57|0-0-48|\--\--189|=-=-187|spr:sk/ui/backspace--8-3|---2|spr:sk/ui/close----close
+Tab--9-3|q-q-81|w-w-87|e-e-69|r-r-82|t-t-84|y-y-89|u-u-85|i-i-73|o-o-79|p-p-80|[-[-219|]-]-221|\\-\\-220|.com-.com--4
+Enter-\n--4|a-a-65|s-s-83|d-d-68|f-f-70|g-g-71|h-h-72|j-j-74|k-k-75|l-l-76|;-;-186|'-'-222|Enter--13-3|.net-.net--4
 spr:sk/ui/shift--16-5-visit_1|z-z-90|x-x-88|c-c-67|v-v-86|b-b-66|n-n-78|m-m-77|,-,-188|.-.-190|/-/-191|spr:sk/ui/shift--16-2-visit_1|spr:sk/ui/arrow_up--38|https://-https://--4
 Ctrl--17-4-mod|Cmd--91-3|Alt--18-3-mod| - -32-9|Alt--18-3-mod|Ctrl--17-3-mod|spr:sk/ui/arrow_left--37|spr:sk/ui/arrow_down--40|spr:sk/ui/arrow_right--39|)";
 	layouts[1] =
-R"(~-~-192|!-!-49|@-@-50|#-#-51|$-$-52|%-%-53|^-^-54|&-&-55|*-*-56|(-(-57|)-)-48|_-_-189|+-+-187|spr:sk/ui/backspace-\b-8-3|---2|spr:sk/ui/close----close
-Tab-\t-9-3|Q-Q-81|W-W-87|E-E-69|R-R-82|T-T-84|Y-Y-89|U-U-85|I-I-73|O-O-79|P-P-80|{-{-219|}-}-221|\|-\|-220|.com-.com--4
-Enter-\n-13-4|A-A-65|S-S-83|D-D-68|F-F-70|G-G-71|H-H-72|J-J-74|K-K-75|L-L-76|:-:-186|"-"-222|Enter-\r-13-3|.net-.net--4
+R"(~-~-192|!-!-49|@-@-50|#-#-51|$-$-52|%-%-53|^-^-54|&-&-55|*-*-56|(-(-57|)-)-48|_-_-189|+-+-187|spr:sk/ui/backspace--8-3|---2|spr:sk/ui/close----close
+Tab--9-3|Q-Q-81|W-W-87|E-E-69|R-R-82|T-T-84|Y-Y-89|U-U-85|I-I-73|O-O-79|P-P-80|{-{-219|}-}-221|\|-\|-220|.com-.com--4
+Enter-\n--4|A-A-65|S-S-83|D-D-68|F-F-70|G-G-71|H-H-72|J-J-74|K-K-75|L-L-76|:-:-186|"-"-222|Enter--13-3|.net-.net--4
 spr:sk/ui/shift--16-5-go_0|Z-Z-90|X-X-88|C-C-67|V-V-86|B-B-66|N-N-78|M-M-77|<-<-188|>->-190|?-?-191|spr:sk/ui/shift--16-2-go_0|spr:sk/ui/arrow_up--38|https://-https://--4
 Ctrl--17-4-mod|Cmd--91-3|Alt--18-3-mod| - -32-9|Alt--18-3-mod|Ctrl--17-3-mod|spr:sk/ui/arrow_left--37|spr:sk/ui/arrow_down--40|spr:sk/ui/arrow_right--39|)";
 	platform_keyboard_set_layout(text_context_uri, layouts, 2);
 
 	////// Numeric keyboard //////
 	layouts[0] =
-R"(7|8|9|spr:sk/ui/backspace-\b
+R"(7|8|9|spr:sk/ui/backspace--8
 4|5|6|\-
 1|2|3
-0|.|Return-\r--4-close|)";
+0|.|Return--13-4-close|)";
 	layouts[1] = nullptr;
 	platform_keyboard_set_layout(text_context_number, layouts, 1);
 
@@ -124,20 +123,20 @@ R"(7|8|9|spr:sk/ui/backspace-\b
 	/*layout =
 R"(q|w|e|r|t|y|u|i|o|p
 ---1|a|s|d|f|g|h|j|k|l
-spr:sk/ui/shift---3-go_1|z|x|c|v|b|n|m|spr:sk/ui/backspace-\b--3
-spr:sk/ui/close----close|123---3-go_2|,| - --7|.|Return-\r--4|)";
+spr:sk/ui/shift---3-go_1|z|x|c|v|b|n|m|spr:sk/ui/backspace--8-3
+spr:sk/ui/close----close|123---3-go_2|,| - --7|.|Return--13-4|)";
 	if (virtualkeyboard_parse_layout(layout, strlen(layout), &layer)) keyboard_ctx_root_text = keyboard_layers.add(layer);
 	layout =
 R"(Q|W|E|R|T|Y|U|I|O|P
 ---1|A|S|D|F|G|H|J|K|L
-spr:sk/ui/shift---3-go_0|Z|X|C|V|B|N|M|spr:sk/ui/backspace-\b--3
-spr:sk/ui/close----close|123---3-go_2|!| - --7|?|Return-\r--4|)";
+spr:sk/ui/shift---3-go_0|Z|X|C|V|B|N|M|spr:sk/ui/backspace--8-3
+spr:sk/ui/close----close|123---3-go_2|!| - --7|?|Return--13-4|)";
 	if (virtualkeyboard_parse_layout(layout, strlen(layout), &layer)) keyboard_layers.add(layer);
 	layout =
 R"(1|2|3|4|5|6|7|8|9|0
 ---1|\-|/|:|;|(|)|$|&|@
-spr:sk/ui/shift---3-go_0|*|=|+|#|%|'|"|spr:sk/ui/backspace-\b--3
-spr:sk/ui/close----close|123---3-go_0|!| - --7|?|Return-\r--4|)";
+spr:sk/ui/shift---3-go_0|*|=|+|#|%|'|"|spr:sk/ui/backspace--8-3
+spr:sk/ui/close----close|123---3-go_0|!| - --7|?|Return--13-4|)";
 	if (virtualkeyboard_parse_layout(layout, strlen(layout), &layer)) keyboard_layers.add(layer);*/
 }
 
@@ -246,24 +245,13 @@ void virtualkeyboard_release_keys() {
 
 ///////////////////////////////////////////
 
-void submit_chars(const char *utf8) {
-	if (utf8 == nullptr) return;
-
-	char32_t c = 0;
-	while (utf8_decode_fast_b(utf8, &utf8, &c)) {
-		input_text_inject_char(c);
-	}
-}
-
-///////////////////////////////////////////
-
 void virtualkeyboard_keypress(keylayout_key_t key) {
 	if (key.key_event_type != key_none) {
 		local.pressed_keys.add((key_)key.key_event_type);
 		input_key_inject_press((key_)key.key_event_type);
 	}
 	if (local.modifier_keys.count == 0)
-		submit_chars(key.clicked_text);
+		input_text_inject(key.clicked_text);
 	virtualkeyboard_reset_modifiers();
 
 	if (local.visit_return_idx != -1) {
@@ -288,7 +276,7 @@ void virtualkeyboard_keymodifier(keylayout_key_t key, bool32_t modifier_state) {
 		if (modifier_state) input_key_inject_press  ((key_)key.key_event_type);
 		else                input_key_inject_release((key_)key.key_event_type);
 	}
-	if (modifier_state) submit_chars(key.clicked_text);
+	if (modifier_state) input_text_inject(key.clicked_text);
 }
 
 ///////////////////////////////////////////
@@ -410,6 +398,26 @@ bool next_separator(const char* start, int32_t start_len, const char **out_next,
 
 ///////////////////////////////////////////
 
+// Layouts from before the unified event queue put editing keys in the text
+// field, like "\b" for backspace. Text is insertable-only now, so translate
+// those to the key events they meant.
+static void virtualkeyboard_legacy_key(keylayout_key_t* key) {
+	if (key->clicked_text == nullptr || key->clicked_text[0] == '\0' || key->clicked_text[1] != '\0') return;
+
+	char c = key->clicked_text[0];
+	if (c == '\b' || c == '\r' || c == '\t') {
+		if (key->key_event_type == key_none)
+			key->key_event_type = (uint8_t)(c == '\b' ? key_backspace : c == '\r' ? key_return : key_tab);
+		if (key->clicked_text != key->display_text) sk_free(key->clicked_text);
+		key->clicked_text = nullptr;
+	} else if (c == '\n' && key->key_event_type == key_return) {
+		// The old UI ignored the key and inserted the newline, so text wins
+		key->key_event_type = key_none;
+	}
+}
+
+///////////////////////////////////////////
+
 bool virtualkeyboard_parse_layout(const char* text_start, int32_t text_length, keylayout_info_t *out_layout) {
 	// File format is:
 	// '|' separates keys on a row
@@ -418,11 +426,16 @@ bool virtualkeyboard_parse_layout(const char* text_start, int32_t text_length, k
 	// KeyDisplay-KeySend-KeyPress-Width-Behavior
 	// KeyDisplay - The text displayed on the button, or parentheses for indicating
 	//              a sprite, eg: '(ui/sprite_close)'
-	// KeySend    - The text injected when the key is pressed. If not present, this
-	//              will be the same as the KeyDisplay, and if empty, this will not
-	//              submit any text
-	// KeyPress   - The key code to inject into the input system. This is none by
-	//              default.
+	// KeySend    - Insertable text injected when the key is pressed, and can be
+	//              more than one character, like '.com'. If not present, this
+	//              will be the same as the KeyDisplay, and if empty, this will
+	//              not submit any text. Editing keys like backspace and enter
+	//              belong in KeyPress instead, though a lone legacy control
+	//              character here is translated to its key code for
+	//              compatibility.
+	// KeyPress   - The key code to inject into the input system, which is how
+	//              editing keys like backspace (8) or enter (13) act on a text
+	//              field. This is none by default.
 	// Width      - The width of the key, in keyboard cells. 1 is half a cell, 2 is
 	//              a whole cell. This defaults to 2 if not specified.
 	// Behavior   - Special behavior for the key. 'close' will close the keyboard,
@@ -436,8 +449,8 @@ bool virtualkeyboard_parse_layout(const char* text_start, int32_t text_length, k
 	// 
 	// q|w|e|r|t|y|u|i|o|p
 	// ---1|a|s|d|f|g|h|j|k|l
-	// Shift---3-go_1|z|x|c|v|b|n|m|<\--\b--3
-	// X----close|123----go_2|,|- --7|.|Return-\n--4
+	// Shift---3-go_1|z|x|c|v|b|n|m|<\---8-3
+	// X----close|123----go_2|,|- --7|.|Return--13-4
 
 	// Fix escape characters, and transform our syntax characters into chars that
 	// won't get into our way. Count how many keys while we're at it :)
@@ -518,6 +531,7 @@ bool virtualkeyboard_parse_layout(const char* text_start, int32_t text_length, k
 				}
 				arg_idx++;
 			}
+			virtualkeyboard_legacy_key(&result[key_idx]);
 			key_idx += 1;
 		}
 		result[key_idx].special_key = skey_nextline;

--- a/StereoKitC/ui/stereokit_ui.cpp
+++ b/StereoKitC/ui/stereokit_ui.cpp
@@ -12,6 +12,7 @@
 #include "../sk_math.h"
 #include "../sk_memory.h"
 #include "../hierarchy.h"
+#include "../systems/input_keyboard.h"
 #include "../libraries/array.h"
 #include "../libraries/unicode.h"
 #include "../libraries/stref.h"
@@ -505,6 +506,34 @@ void ui_model(model_t model, vec2 ui_size, float model_scale) {
 inline vec2 text_char_at_o(const char*     text, text_style_t style, int32_t char_index, vec2* opt_size, text_fit_ fit, pivot_ position, align_ align) { return text_char_at   (text, style, char_index, opt_size, fit, position, align); }
 inline vec2 text_char_at_o(const char16_t* text, text_style_t style, int32_t char_index, vec2* opt_size, text_fit_ fit, pivot_ position, align_ align) { return text_char_at_16(text, style, char_index, opt_size, fit, position, align); }
 
+// Removes the selected range, and returns true if there was one to remove.
+template<typename C>
+bool ui_input_delete_selection_g(C* buffer) {
+	if (skui_input_caret == skui_input_caret_end) return false;
+
+	int32_t start = mini(skui_input_caret, skui_input_caret_end);
+	int32_t count = maxi(skui_input_caret, skui_input_caret_end) - start;
+	utf_remove_chars(utf_advance_chars(buffer, start), count);
+	skui_input_caret_end = skui_input_caret = start;
+	return true;
+}
+
+///////////////////////////////////////////
+
+// Inserts at the caret, replacing any selection. Returns true if the buffer
+// changed, which a full buffer's failed insert doesn't undo.
+template<typename C>
+bool ui_input_insert_g(C* buffer, int32_t buffer_size, char32_t add) {
+	bool changed = ui_input_delete_selection_g(buffer);
+	if (utf_insert_char(buffer, buffer_size, utf_advance_chars(buffer, skui_input_caret), add)) {
+		skui_input_caret_end = skui_input_caret = skui_input_caret + 1;
+		changed = true;
+	}
+	return changed;
+}
+
+///////////////////////////////////////////
+
 template<typename C>
 bool32_t ui_input_at_g(const C* id, C* buffer, int32_t buffer_size, vec3 window_relative_pos, vec2 size, text_context_ type) {
 	id_hash_t id_hash  = ui_stack_hash(id);
@@ -532,67 +561,69 @@ bool32_t ui_input_at_g(const C* id, C* buffer, int32_t buffer_size, vec3 window_
 
 	// If focused, acquire any input in the keyboard's queue
 	if (skui_input_target == id_hash) {
-		uint32_t curr = input_text_consume();
-		while (curr != 0) {
-			uint32_t add = '\0';
+		// Walking the event queue keeps text and editing in the order the user
+		// produced them, and gives every auto-repeat its own action.
+		keyboard_event_t evt = input_keyboard_consume();
+		while (evt.type != keyboard_event_type_none) {
+			bool shift = (evt.modifiers & key_mod_shift) != key_mod_none;
 
-			if (curr == key_backspace) {
-				if (skui_input_caret != skui_input_caret_end) {
-					int32_t start = mini(skui_input_caret, skui_input_caret_end);
-					int32_t count = maxi(skui_input_caret, skui_input_caret_end) - start;
-					utf_remove_chars(utf_advance_chars(buffer, start), count);
-					skui_input_caret_end = skui_input_caret = start;
+			if (evt.type == keyboard_event_type_text) {
+				// The queue is insertable text by contract, this is a guard
+				if (input_text_insertable(evt.character) && ui_input_insert_g(buffer, buffer_size, evt.character))
 					result = true;
-				} else if (skui_input_caret > 0) {
-					skui_input_caret_end = skui_input_caret = skui_input_caret - 1;
-					utf_remove_chars(utf_advance_chars(buffer, skui_input_caret), 1);
-					result = true;
+			} else if (evt.type == keyboard_event_type_key_press) {
+				switch (evt.key) {
+				case key_backspace: {
+					if (ui_input_delete_selection_g(buffer)) {
+						result = true;
+					} else if (skui_input_caret > 0) {
+						skui_input_caret_end = skui_input_caret = skui_input_caret - 1;
+						utf_remove_chars(utf_advance_chars(buffer, skui_input_caret), 1);
+						result = true;
+					}
+				} break;
+				case key_del: {
+					if (ui_input_delete_selection_g(buffer) ||
+					    utf_remove_chars(utf_advance_chars(buffer, skui_input_caret), 1))
+						result = true;
+				} break;
+				case key_tab: {
+					if (ui_input_insert_g(buffer, buffer_size, '\t')) result = true;
+				} break;
+				case key_return: {
+					if (shift) { if (ui_input_insert_g(buffer, buffer_size, '\n')) result = true; }
+					else       { skui_input_target = 0; platform_keyboard_show(false, type); result = true; }
+				} break;
+				case key_esc: {
+					skui_input_target = 0;
+					platform_keyboard_show(false, type);
+				} break;
+				case key_left: {
+					skui_input_blink = time_totalf_unscaled();
+					if (shift) skui_input_caret = maxi(0, skui_input_caret - 1);
+					else {
+						if (skui_input_caret_end == skui_input_caret) skui_input_caret = maxi(0, skui_input_caret - 1);
+						skui_input_caret_end = skui_input_caret;
+					}
+				} break;
+				case key_right: {
+					skui_input_blink = time_totalf_unscaled();
+					if (shift) skui_input_caret = mini((int32_t)utf_charlen(buffer), skui_input_caret + 1);
+					else {
+						if (skui_input_caret_end == skui_input_caret) skui_input_caret = mini((int32_t)utf_charlen(buffer), skui_input_caret + 1);
+						skui_input_caret_end = skui_input_caret;
+					}
+				} break;
+				default: break;
 				}
-			} else if (curr == 0x7f) {
-				if (skui_input_caret != skui_input_caret_end) {
-					int32_t start = mini(skui_input_caret, skui_input_caret_end);
-					int32_t count = maxi(skui_input_caret, skui_input_caret_end) - start;
-					utf_remove_chars(utf_advance_chars(buffer, start), count);
-					skui_input_caret_end = skui_input_caret = start;
-					result = true;
-				} else if (skui_input_caret >= 0) {
-					utf_remove_chars(utf_advance_chars(buffer, skui_input_caret), 1);
-					result = true;
-				}
-			} else if (curr == 0x0D) { // Enter, carriage return
-				skui_input_target = 0;
-				platform_keyboard_show(false, type);
-				result = true;
-			} else if (curr == 0x0A) { // Shift+Enter, linefeed 
-				add = '\n';
-			} else if (curr == 0x1B) { // Escape
-				skui_input_target = 0;
-				platform_keyboard_show(false, type);
-			} else {
-				add = curr;
 			}
 
-			if (add != '\0') {
-				// Remove any selected
-				if (skui_input_caret != skui_input_caret_end) {
-					int32_t start = mini(skui_input_caret, skui_input_caret_end);
-					int32_t count = maxi(skui_input_caret, skui_input_caret_end) - start;
-					utf_remove_chars(utf_advance_chars(buffer, start), count);
-					skui_input_caret_end = skui_input_caret = start;
-				}
-				if (utf_insert_char(buffer, buffer_size, utf_advance_chars(buffer, skui_input_caret), add)) {
-					skui_input_caret += 1;
-					skui_input_caret_end = skui_input_caret;
-					result = true;
-				}
-			}
+			// Submit or escape closed the field, so leave the rest of the
+			// frame's events for whoever reads next.
+			if (skui_input_target != id_hash) break;
 
-			curr = input_text_consume();
+			evt = input_keyboard_consume();
 		}
-		if      (input_key(key_shift) & button_state_active && input_key(key_left ) & button_state_just_active) { skui_input_blink = time_totalf_unscaled(); skui_input_caret = maxi(0, skui_input_caret - 1); }
-		else if (input_key(key_left ) & button_state_just_active)                                               { skui_input_blink = time_totalf_unscaled(); if (skui_input_caret_end == skui_input_caret) skui_input_caret = maxi(0, skui_input_caret - 1); skui_input_caret_end = skui_input_caret; }
-		if      (input_key(key_shift) & button_state_active && input_key(key_right) & button_state_just_active) { skui_input_blink = time_totalf_unscaled(); skui_input_caret = mini((int32_t)utf_charlen(buffer), skui_input_caret + 1); }
-		else if (input_key(key_right) & button_state_just_active)                                               { skui_input_blink = time_totalf_unscaled(); if (skui_input_caret_end == skui_input_caret) skui_input_caret = mini((int32_t)utf_charlen(buffer), skui_input_caret + 1); skui_input_caret_end = skui_input_caret; }
 	}
 
 	// Render the input UI

--- a/StereoKitC/xr_backends/ska_input.h
+++ b/StereoKitC/xr_backends/ska_input.h
@@ -120,32 +120,6 @@ inline key_ ska_mouse_button_to_key(ska_mouse_button_ button) {
 	}
 }
 
-// Decode UTF-8 text to UTF-32 codepoints and inject into input system
-inline void ska_inject_text_input(const char* text) {
-	while (*text) {
-		uint32_t codepoint = 0;
-		if ((*text & 0x80) == 0) {
-			codepoint = *text++;
-		} else if ((*text & 0xE0) == 0xC0) {
-			codepoint = (*text++ & 0x1F) << 6;
-			if (*text) codepoint |= (*text++ & 0x3F);
-		} else if ((*text & 0xF0) == 0xE0) {
-			codepoint = (*text++ & 0x0F) << 12;
-			if (*text) codepoint |= (*text++ & 0x3F) << 6;
-			if (*text) codepoint |= (*text++ & 0x3F);
-		} else if ((*text & 0xF8) == 0xF0) {
-			codepoint = (*text++ & 0x07) << 18;
-			if (*text) codepoint |= (*text++ & 0x3F) << 12;
-			if (*text) codepoint |= (*text++ & 0x3F) << 6;
-			if (*text) codepoint |= (*text++ & 0x3F);
-		} else {
-			text++;
-			continue;
-		}
-		input_text_inject_char((char32_t)codepoint);
-	}
-}
-
 ///////////////////////////////////////////
 // Common event handler for events that backends don't handle themselves
 // Backends poll ska_event_poll() and handle backend-specific events, then
@@ -170,7 +144,7 @@ inline void ska_handle_event(ska_event_t* evt) {
 			input_key_inject_release(key);
 	} break;
 	case ska_event_text_input:
-		ska_inject_text_input(evt->text.text);
+		input_text_inject(evt->text.text);
 		break;
 	case ska_event_mouse_button_down: {
 		if (sk_app_focus() == app_focus_active) {

--- a/tools/StereoKitAPIGen/SKOverridesCSharp.txt
+++ b/tools/StereoKitAPIGen/SKOverridesCSharp.txt
@@ -124,6 +124,8 @@ audio_env_t AudioEnvironment
 @noimpl hand_sim_id_t id_hash_t
 # Request struct has string/feature arrays, hand-marshaled in Backend.Vulkan.Request
 @noimpl backend_vulkan_request_t
+# Keeps the raw codepoint private so readers use Text, which can't truncate
+@noimpl keyboard_event_t
 
 # UI types with special handling
 # (none currently)


### PR DESCRIPTION
This merges text and keyboard events into the same queue. It also fixes events like del / backspace / modifiers from falling out-of-order on lagging frames. The sk_app update unifies text entry backends, so all OSes behave the same, a few differences had crept in previously.

Added C#:
- `Input.KeyboardConsume`
- `Input.KeyboardEventCount`
- `Input.KeyboardEventAt`
- `Input.TextInject`
- `UI.HasKeyboardFocus`

Deprecated C#:
- `Input.TextConsume`
- `Input.TextReset`
- `Input.TextInjectChar`

Added C:
- `input_keyboard_consume`
- `input_keyboard_event_count`
- `input_keyboard_event_at`
- `input_text_inject`

Deprecated C:
- `input_text_consume`
- `input_text_reset`
- `input_text_inject_char`