### PR TITLE
Only update the root space if it matches our current space

### DIFF
--- a/StereoKitC/xr_backends/openxr.cpp
+++ b/StereoKitC/xr_backends/openxr.cpp
@@ -817,15 +817,19 @@ bool openxr_poll_events() {
 		case XR_TYPE_EVENT_DATA_REFERENCE_SPACE_CHANGE_PENDING: {
 			XrEventDataReferenceSpaceChangePending *pending   = (XrEventDataReferenceSpaceChangePending*)&event_buffer;
 
-			// Update the main app space. In particular, some fallback spaces
-			// may require recalculation.
-			XrSpace new_space = {};
-			if (openxr_try_get_app_space(xr_session, sk_get_settings_ref()->origin, pending->changeTime, &xr_app_space_type, &world_origin_offset, &new_space)) {
-				if (xr_app_space) xrDestroySpace(xr_app_space);
-				xr_app_space = new_space;
-			}
+			if (pending->referenceSpaceType == xr_app_space_type) {
+				// Update the main app space. In particular, some fallback spaces
+				// may require recalculation.
+				XrSpace new_space = {};
+				if (openxr_try_get_app_space(xr_session, sk_get_settings_ref()->origin, pending->changeTime, &xr_app_space_type, &world_origin_offset, &new_space)) {
+					if (xr_app_space) xrDestroySpace(xr_app_space);
+					xr_app_space = new_space;
+				}
 
-			xr_has_bounds = openxr_get_stage_bounds(&xr_bounds_size, &xr_bounds_pose_local, pending->changeTime);
+				xr_has_bounds = openxr_get_stage_bounds(&xr_bounds_size, &xr_bounds_pose_local, pending->changeTime);
+			} else if (pending->referenceSpaceType == XR_REFERENCE_SPACE_TYPE_STAGE) {
+				xr_has_bounds = openxr_get_stage_bounds(&xr_bounds_size, &xr_bounds_pose_local, pending->changeTime);
+			}
 		} break;
 		default: break;
 		}

--- a/StereoKitC/xr_backends/openxr.cpp
+++ b/StereoKitC/xr_backends/openxr.cpp
@@ -816,20 +816,23 @@ bool openxr_poll_events() {
 		case XR_TYPE_EVENT_DATA_INSTANCE_LOSS_PENDING         : sk_quit(quit_reason_session_lost); result = false; break;
 		case XR_TYPE_EVENT_DATA_REFERENCE_SPACE_CHANGE_PENDING: {
 			XrEventDataReferenceSpaceChangePending *pending   = (XrEventDataReferenceSpaceChangePending*)&event_buffer;
-
-			if (pending->referenceSpaceType == xr_app_space_type) {
-				// Update the main app space. In particular, some fallback spaces
-				// may require recalculation.
+			XrReferenceSpaceType moved         = pending->referenceSpaceType;
+			origin_mode_         origin        = sk_get_settings_ref()->origin;
+			bool                 recentered    = moved == XR_REFERENCE_SPACE_TYPE_LOCAL;
+			bool                 head_relative = origin == origin_mode_local || origin == origin_mode_floor;
+			// Head-relative modes sample the head into their offset, so a recenter must
+			// re-sample even when our base space didn't move. #715
+			bool resample_origin = moved == xr_app_space_type || (recentered && head_relative);
+			if (resample_origin) {
 				XrSpace new_space = {};
-				if (openxr_try_get_app_space(xr_session, sk_get_settings_ref()->origin, pending->changeTime, &xr_app_space_type, &world_origin_offset, &new_space)) {
+				if (openxr_try_get_app_space(xr_session, origin, pending->changeTime, &xr_app_space_type, &world_origin_offset, &new_space)) {
 					if (xr_app_space) xrDestroySpace(xr_app_space);
 					xr_app_space = new_space;
 				}
-
-				xr_has_bounds = openxr_get_stage_bounds(&xr_bounds_size, &xr_bounds_pose_local, pending->changeTime);
-			} else if (pending->referenceSpaceType == XR_REFERENCE_SPACE_TYPE_STAGE) {
-				xr_has_bounds = openxr_get_stage_bounds(&xr_bounds_size, &xr_bounds_pose_local, pending->changeTime);
 			}
+			// Bounds are reported in app space, so they shift with either one.
+			if (resample_origin || moved == XR_REFERENCE_SPACE_TYPE_STAGE)
+				xr_has_bounds = openxr_get_stage_bounds(&xr_bounds_size, &xr_bounds_pose_local, pending->changeTime);
 		} break;
 		default: break;
 		}


### PR DESCRIPTION
But do check if the stage has bounds if that's the space being updated.

I was finding that doing something like re-drawing my stage bounds was causing my local space to be fully regenerated. This matches my expectation more.