### PR TITLE
Migrate OpenXR extensions to <openxr/openxr_reflection.h>

### DIFF
--- a/StereoKitC/xr_backends/extensions/android_thread.cpp
+++ b/StereoKitC/xr_backends/extensions/android_thread.cpp
@@ -17,9 +17,7 @@
 
 #include <unistd.h> // gettid
 
-#define XR_EXT_FUNCTIONS( X ) \
-	X(xrSetAndroidApplicationThreadKHR)
-OPENXR_DEFINE_FN_STATIC(XR_EXT_FUNCTIONS);
+OPENXR_DEFINE_FN_REFLECT_STATIC(XR_LIST_FUNCTIONS_XR_KHR_android_thread_settings);
 
 ///////////////////////////////////////////
 
@@ -46,7 +44,7 @@ xr_system_ xr_ext_android_thread_initialize(void*) {
 	if (!backend_openxr_ext_enabled(XR_KHR_ANDROID_THREAD_SETTINGS_EXTENSION_NAME))
 		return xr_system_fail;
 
-	OPENXR_LOAD_FN_RETURN(XR_EXT_FUNCTIONS, xr_system_fail);
+	OPENXR_LOAD_FN_REFLECT_RETURN(XR_LIST_FUNCTIONS_XR_KHR_android_thread_settings, xr_system_fail);
 
 	return xr_system_succeed;
 }
@@ -54,7 +52,7 @@ xr_system_ xr_ext_android_thread_initialize(void*) {
 ///////////////////////////////////////////
 
 void xr_ext_android_thread_shutdown(void*) {
-	OPENXR_CLEAR_FN(XR_EXT_FUNCTIONS);
+	OPENXR_CLEAR_FN_REFLECT(XR_LIST_FUNCTIONS_XR_KHR_android_thread_settings);
 }
 
 ///////////////////////////////////////////

--- a/StereoKitC/xr_backends/extensions/debug_utils.cpp
+++ b/StereoKitC/xr_backends/extensions/debug_utils.cpp
@@ -10,10 +10,7 @@
 #include "ext_management.h"
 #include "debug_utils.h"
 
-#define XR_EXT_FUNCTIONS( X )         \
-	X(xrCreateDebugUtilsMessengerEXT) \
-	X(xrDestroyDebugUtilsMessengerEXT)
-OPENXR_DEFINE_FN_STATIC(XR_EXT_FUNCTIONS);
+OPENXR_DEFINE_FN_REFLECT_STATIC(XR_LIST_FUNCTIONS_XR_EXT_debug_utils);
 
 typedef struct xr_debug_utils_state_t {
 	XrDebugUtilsMessengerEXT messenger;
@@ -78,7 +75,7 @@ xr_system_ xr_ext_debug_utils_pre_session(void*, XrBaseHeader*) {
 		return xr_system_fail;
 
 	// Load all extension functions
-	OPENXR_LOAD_FN_RETURN(XR_EXT_FUNCTIONS, xr_system_fail);
+	OPENXR_LOAD_FN_REFLECT_RETURN(XR_LIST_FUNCTIONS_XR_EXT_debug_utils, xr_system_fail);
 
 	// Set up a really verbose debug log! Great for dev, but turn this off or
 	// down for final builds. WMR doesn't produce much output here, but it
@@ -121,7 +118,7 @@ void xr_ext_debug_utils_shutdown(void*) {
 	if (local.messenger) xrDestroyDebugUtilsMessengerEXT(local.messenger);
 	local = {};
 
-	OPENXR_CLEAR_FN(XR_EXT_FUNCTIONS);
+	OPENXR_CLEAR_FN_REFLECT(XR_LIST_FUNCTIONS_XR_EXT_debug_utils);
 }
 
 } // namespace sk

--- a/StereoKitC/xr_backends/extensions/ext_interaction_render_model.cpp
+++ b/StereoKitC/xr_backends/extensions/ext_interaction_render_model.cpp
@@ -13,11 +13,7 @@
 
  ///////////////////////////////////////////
 
-#define XR_EXT_FUNCTIONS( X ) \
-	X(xrEnumerateInteractionRenderModelIdsEXT) \
-	X(xrEnumerateRenderModelSubactionPathsEXT) \
-	X(xrGetRenderModelPoseTopLevelUserPathEXT)
-OPENXR_DEFINE_FN_STATIC(XR_EXT_FUNCTIONS);
+OPENXR_DEFINE_FN_REFLECT_STATIC(XR_LIST_FUNCTIONS_XR_EXT_interaction_render_model);
 
 ///////////////////////////////////////////
 
@@ -58,7 +54,7 @@ xr_system_ xr_ext_interaction_render_model_initialize(void*) {
 	if (!backend_openxr_ext_enabled(XR_EXT_INTERACTION_RENDER_MODEL_EXTENSION_NAME))
 		return xr_system_fail;
 
-	OPENXR_LOAD_FN_RETURN(XR_EXT_FUNCTIONS, xr_system_fail);
+	OPENXR_LOAD_FN_REFLECT_RETURN(XR_LIST_FUNCTIONS_XR_EXT_interaction_render_model, xr_system_fail);
 
 	local.available = true;
 
@@ -68,7 +64,7 @@ xr_system_ xr_ext_interaction_render_model_initialize(void*) {
 ///////////////////////////////////////////
 
 void xr_ext_interaction_render_model_shutdown(void*) {
-	OPENXR_CLEAR_FN(XR_EXT_FUNCTIONS);
+	OPENXR_CLEAR_FN_REFLECT(XR_LIST_FUNCTIONS_XR_EXT_interaction_render_model);
 }
 
 ///////////////////////////////////////////

--- a/StereoKitC/xr_backends/extensions/ext_render_model.cpp
+++ b/StereoKitC/xr_backends/extensions/ext_render_model.cpp
@@ -14,17 +14,7 @@
 
  ///////////////////////////////////////////
 
-#define XR_EXT_FUNCTIONS( X )             \
-	X(xrCreateRenderModelAssetEXT)        \
-	X(xrCreateRenderModelEXT)             \
-	X(xrCreateRenderModelSpaceEXT)        \
-	X(xrDestroyRenderModelAssetEXT)       \
-	X(xrDestroyRenderModelEXT)            \
-	X(xrGetRenderModelAssetDataEXT)       \
-	X(xrGetRenderModelAssetPropertiesEXT) \
-	X(xrGetRenderModelPropertiesEXT)      \
-	X(xrGetRenderModelStateEXT)
-OPENXR_DEFINE_FN_STATIC(XR_EXT_FUNCTIONS);
+OPENXR_DEFINE_FN_REFLECT_STATIC(XR_LIST_FUNCTIONS_XR_EXT_render_model);
 
 ///////////////////////////////////////////
 
@@ -72,7 +62,7 @@ xr_system_ xr_ext_render_model_initialize(void*) {
 	if (!backend_openxr_ext_enabled(XR_EXT_RENDER_MODEL_EXTENSION_NAME))
 		return xr_system_fail;
 
-	OPENXR_LOAD_FN_RETURN(XR_EXT_FUNCTIONS, xr_system_fail);
+	OPENXR_LOAD_FN_REFLECT_RETURN(XR_LIST_FUNCTIONS_XR_EXT_render_model, xr_system_fail);
 
 	local.available = true;
 
@@ -87,7 +77,7 @@ void xr_ext_render_model_shutdown(void*) {
 	}
 	local.sources.free();
 
-	OPENXR_CLEAR_FN(XR_EXT_FUNCTIONS);
+	OPENXR_CLEAR_FN_REFLECT(XR_LIST_FUNCTIONS_XR_EXT_render_model);
 	local = {};
 }
 

--- a/StereoKitC/xr_backends/extensions/fb_colorspace.cpp
+++ b/StereoKitC/xr_backends/extensions/fb_colorspace.cpp
@@ -12,9 +12,7 @@
 
  ///////////////////////////////////////////
 
-#define XR_EXT_FUNCTIONS( X ) \
-	X(xrSetColorSpaceFB)
-OPENXR_DEFINE_FN_STATIC(XR_EXT_FUNCTIONS);
+OPENXR_DEFINE_FN_REFLECT_STATIC(XR_LIST_FUNCTIONS_XR_FB_color_space);
 
 ///////////////////////////////////////////
 
@@ -48,7 +46,7 @@ xr_system_ xr_ext_fb_colorspace_initialize(void*) {
 	if (!backend_openxr_ext_enabled(XR_FB_COLOR_SPACE_EXTENSION_NAME))
 		return xr_system_fail;
 
-	OPENXR_LOAD_FN_RETURN(XR_EXT_FUNCTIONS, xr_system_fail);
+	OPENXR_LOAD_FN_REFLECT_RETURN(XR_LIST_FUNCTIONS_XR_FB_color_space, xr_system_fail);
 
 	local.available = true;
 
@@ -58,7 +56,7 @@ xr_system_ xr_ext_fb_colorspace_initialize(void*) {
 ///////////////////////////////////////////
 
 void xr_ext_fb_colorspace_shutdown(void*) {
-	OPENXR_CLEAR_FN(XR_EXT_FUNCTIONS);
+	OPENXR_CLEAR_FN_REFLECT(XR_LIST_FUNCTIONS_XR_FB_color_space);
 }
 
 ///////////////////////////////////////////

--- a/StereoKitC/xr_backends/extensions/fb_haptic.cpp
+++ b/StereoKitC/xr_backends/extensions/fb_haptic.cpp
@@ -14,9 +14,7 @@
 
 ///////////////////////////////////////////
 
-#define XR_EXT_FUNCTIONS( X ) \
-	X(xrGetDeviceSampleRateFB)
-OPENXR_DEFINE_FN_STATIC(XR_EXT_FUNCTIONS);
+OPENXR_DEFINE_FN_REFLECT_STATIC(XR_LIST_FUNCTIONS_XR_FB_haptic_pcm);
 
 ///////////////////////////////////////////
 
@@ -56,7 +54,7 @@ xr_system_ xr_fb_haptic_initialize(void*) {
 		// xrGetDeviceSampleRateFB is the only new function from XR_FB_haptic_pcm.
 		// Both extensions chain into the existing core xrApplyHapticFeedback via
 		// XrHapticBaseHeader, so they don't add other entry points.
-		OPENXR_LOAD_FN_RETURN(XR_EXT_FUNCTIONS, xr_system_fail);
+		OPENXR_LOAD_FN_REFLECT_RETURN(XR_LIST_FUNCTIONS_XR_FB_haptic_pcm, xr_system_fail);
 	}
 
 	return (local.pcm_available || local.envelope_available)
@@ -67,7 +65,7 @@ xr_system_ xr_fb_haptic_initialize(void*) {
 ///////////////////////////////////////////
 
 void xr_fb_haptic_shutdown(void*) {
-	OPENXR_CLEAR_FN(XR_EXT_FUNCTIONS);
+	OPENXR_CLEAR_FN_REFLECT(XR_LIST_FUNCTIONS_XR_FB_haptic_pcm);
 	local = {};
 }
 

--- a/StereoKitC/xr_backends/extensions/fb_render_model.cpp
+++ b/StereoKitC/xr_backends/extensions/fb_render_model.cpp
@@ -15,11 +15,7 @@
 
 ///////////////////////////////////////////
 
-#define XR_EXT_FUNCTIONS( X )           \
-	X(xrEnumerateRenderModelPathsFB)    \
-	X(xrGetRenderModelPropertiesFB)     \
-	X(xrLoadRenderModelFB)
-OPENXR_DEFINE_FN_STATIC(XR_EXT_FUNCTIONS);
+OPENXR_DEFINE_FN_REFLECT_STATIC(XR_LIST_FUNCTIONS_XR_FB_render_model);
 
 ///////////////////////////////////////////
 
@@ -77,7 +73,7 @@ xr_system_ xr_fb_render_model_initialize(void*) {
 		backend_openxr_ext_enabled(XR_EXT_INTERACTION_RENDER_MODEL_EXTENSION_NAME))
 		return xr_system_fail;
 
-	OPENXR_LOAD_FN_RETURN(XR_EXT_FUNCTIONS, xr_system_fail);
+	OPENXR_LOAD_FN_REFLECT_RETURN(XR_LIST_FUNCTIONS_XR_FB_render_model, xr_system_fail);
 
 	// xrGetRenderModelPropertiesFB requires that xrEnumerateRenderModelPathsFB
 	// has been called first, so we do it once up front. The path set is static
@@ -115,7 +111,7 @@ void xr_fb_render_model_shutdown(void*) {
 		model_release(local.models[i].model);
 	}
 	local.models.free();
-	OPENXR_CLEAR_FN(XR_EXT_FUNCTIONS);
+	OPENXR_CLEAR_FN_REFLECT(XR_LIST_FUNCTIONS_XR_FB_render_model);
 	local = {};
 }
 

--- a/StereoKitC/xr_backends/extensions/hand_mesh.cpp
+++ b/StereoKitC/xr_backends/extensions/hand_mesh.cpp
@@ -15,10 +15,7 @@
 #include "../../systems/render.h"
 #include "../../hands/input_hand.h"
 
-#define XR_EXT_FUNCTIONS( X )    \
-	X(xrCreateHandMeshSpaceMSFT) \
-	X(xrUpdateHandMeshMSFT)
-OPENXR_DEFINE_FN_STATIC(XR_EXT_FUNCTIONS);
+OPENXR_DEFINE_FN_REFLECT_STATIC(XR_LIST_FUNCTIONS_XR_MSFT_hand_tracking_mesh);
 
 typedef struct xr_hand_mesh_state_t {
 	bool           available;
@@ -86,7 +83,7 @@ xr_system_ xr_ext_msft_hand_mesh_initialize(void*) {
 #endif
 
 	// Load all extension functions
-	OPENXR_LOAD_FN_RETURN(XR_EXT_FUNCTIONS, xr_system_fail);
+	OPENXR_LOAD_FN_REFLECT_RETURN(XR_LIST_FUNCTIONS_XR_MSFT_hand_tracking_mesh, xr_system_fail);
 
 	// Pre-allocate memory for the hand mesh structure and initialize hand
 	// mesh trackers.
@@ -132,7 +129,7 @@ void xr_ext_msft_hand_mesh_shutdown(void*) {
 	}
 	local = {};
 
-	OPENXR_CLEAR_FN(XR_EXT_FUNCTIONS);
+	OPENXR_CLEAR_FN_REFLECT(XR_LIST_FUNCTIONS_XR_MSFT_hand_tracking_mesh);
 }
 
 ///////////////////////////////////////////

--- a/StereoKitC/xr_backends/extensions/hand_tracking.cpp
+++ b/StereoKitC/xr_backends/extensions/hand_tracking.cpp
@@ -18,11 +18,7 @@
 #include "../../hands/input_hand.h"
 #include "../../libraries/stref.h"
 
-#define XR_EXT_FUNCTIONS( X )  \
-	X(xrCreateHandTrackerEXT)  \
-	X(xrDestroyHandTrackerEXT) \
-	X(xrLocateHandJointsEXT)
-OPENXR_DEFINE_FN_STATIC(XR_EXT_FUNCTIONS);
+OPENXR_DEFINE_FN_REFLECT_STATIC(XR_LIST_FUNCTIONS_XR_EXT_hand_tracking);
 
 typedef struct xr_hand_tracking_state_t {
 	bool             has_data_source;
@@ -137,7 +133,7 @@ xr_system_ xr_ext_hand_tracking_initialize(void*) {
 #endif
 
 	// Load all extension functions
-	OPENXR_LOAD_FN_RETURN(XR_EXT_FUNCTIONS, xr_system_fail);
+	OPENXR_LOAD_FN_REFLECT_RETURN(XR_LIST_FUNCTIONS_XR_EXT_hand_tracking, xr_system_fail);
 
 	for (int32_t h = 0; h < handed_max; h++) {
 		XrHandTrackerCreateInfoEXT info = { XR_TYPE_HAND_TRACKER_CREATE_INFO_EXT };
@@ -196,7 +192,7 @@ void xr_ext_hand_tracking_shutdown(void*) {
 	}
 	local = {};
 
-	OPENXR_CLEAR_FN(XR_EXT_FUNCTIONS);
+	OPENXR_CLEAR_FN_REFLECT(XR_LIST_FUNCTIONS_XR_EXT_hand_tracking);
 }
 
 ///////////////////////////////////////////

--- a/StereoKitC/xr_backends/extensions/meta_environment_depth.cpp
+++ b/StereoKitC/xr_backends/extensions/meta_environment_depth.cpp
@@ -16,18 +16,7 @@
 
 #include <stdint.h>
 
-#define XR_META_ENVIRONMENT_DEPTH_FUNCTIONS(X)             \
-	X(xrCreateEnvironmentDepthProviderMETA)                \
-	X(xrDestroyEnvironmentDepthProviderMETA)               \
-	X(xrStartEnvironmentDepthProviderMETA)                 \
-	X(xrStopEnvironmentDepthProviderMETA)                  \
-	X(xrAcquireEnvironmentDepthImageMETA)                  \
-	X(xrCreateEnvironmentDepthSwapchainMETA)               \
-	X(xrDestroyEnvironmentDepthSwapchainMETA)              \
-	X(xrEnumerateEnvironmentDepthSwapchainImagesMETA)      \
-	X(xrGetEnvironmentDepthSwapchainStateMETA)             \
-	X(xrSetEnvironmentDepthHandRemovalMETA)
-OPENXR_DEFINE_FN_STATIC(XR_META_ENVIRONMENT_DEPTH_FUNCTIONS);
+OPENXR_DEFINE_FN_REFLECT_STATIC(XR_LIST_FUNCTIONS_XR_META_environment_depth);
 
 namespace sk {
 
@@ -95,7 +84,7 @@ xr_system_ xr_ext_meta_environment_depth_initialize(void*) {
 	if (!backend_openxr_ext_enabled(XR_META_ENVIRONMENT_DEPTH_EXTENSION_NAME))
 		return xr_system_fail;
 
-	OPENXR_LOAD_FN_RETURN(XR_META_ENVIRONMENT_DEPTH_FUNCTIONS, xr_system_fail);
+	OPENXR_LOAD_FN_REFLECT_RETURN(XR_LIST_FUNCTIONS_XR_META_environment_depth, xr_system_fail);
 
 	XrSystemEnvironmentDepthPropertiesMETA properties_depth = { XR_TYPE_SYSTEM_ENVIRONMENT_DEPTH_PROPERTIES_META };
 	XrSystemProperties                     properties       = { XR_TYPE_SYSTEM_PROPERTIES };
@@ -153,7 +142,7 @@ void xr_ext_meta_environment_depth_destroy() {
 
 void xr_ext_meta_environment_depth_shutdown(void*) {
 	xr_ext_meta_environment_depth_destroy();
-	OPENXR_CLEAR_FN(XR_META_ENVIRONMENT_DEPTH_FUNCTIONS);
+	OPENXR_CLEAR_FN_REFLECT(XR_LIST_FUNCTIONS_XR_META_environment_depth);
 	local = {};
 }
 

--- a/StereoKitC/xr_backends/extensions/msft_anchors.cpp
+++ b/StereoKitC/xr_backends/extensions/msft_anchors.cpp
@@ -15,20 +15,8 @@
 #include "../../asset_types/anchor.h"
 #include "../../systems/input.h"
 
-#define XR_EXT_ANCHOR_FUNCTIONS( X )             \
-	X(xrCreateSpatialAnchorMSFT)                 \
-	X(xrCreateSpatialAnchorSpaceMSFT)            \
-	X(xrDestroySpatialAnchorMSFT)
-#define XR_EXT_PERSISTENCE_FUNCTIONS( X )        \
-	X(xrCreateSpatialAnchorStoreConnectionMSFT)  \
-	X(xrDestroySpatialAnchorStoreConnectionMSFT) \
-	X(xrEnumeratePersistedSpatialAnchorNamesMSFT)\
-	X(xrCreateSpatialAnchorFromPersistedNameMSFT)\
-	X(xrPersistSpatialAnchorMSFT)                \
-	X(xrUnpersistSpatialAnchorMSFT)              \
-	X(xrClearSpatialAnchorStoreMSFT)
-OPENXR_DEFINE_FN_STATIC(XR_EXT_ANCHOR_FUNCTIONS);
-OPENXR_DEFINE_FN_STATIC(XR_EXT_PERSISTENCE_FUNCTIONS);
+OPENXR_DEFINE_FN_REFLECT_STATIC(XR_LIST_FUNCTIONS_XR_MSFT_spatial_anchor);
+OPENXR_DEFINE_FN_REFLECT_STATIC(XR_LIST_FUNCTIONS_XR_MSFT_spatial_anchor_persistence);
 
 ///////////////////////////////////////////
 
@@ -78,11 +66,11 @@ xr_system_ xr_ext_msft_spatial_anchors_initialize(void*) {
 	local.persistence = backend_openxr_ext_enabled(XR_MSFT_SPATIAL_ANCHOR_PERSISTENCE_EXTENSION_NAME);
 
 	// Load all the main anchor extension functions
-	OPENXR_LOAD_FN_RETURN(XR_EXT_ANCHOR_FUNCTIONS, xr_system_fail);
+	OPENXR_LOAD_FN_REFLECT_RETURN(XR_LIST_FUNCTIONS_XR_MSFT_spatial_anchor, xr_system_fail);
 
 	if (local.persistence) {
 		// Load the persistence extension functions
-		OPENXR_LOAD_FN_RETURN(XR_EXT_PERSISTENCE_FUNCTIONS, xr_system_fail);
+		OPENXR_LOAD_FN_REFLECT_RETURN(XR_LIST_FUNCTIONS_XR_MSFT_spatial_anchor_persistence, xr_system_fail);
 
 		// Load all the persistent anchors from storage
 		if (xr_ext_msft_spatial_anchors_load_persistent_anchors() == false)
@@ -103,8 +91,8 @@ void xr_ext_msft_spatial_anchors_shutdown(void*) {
 	local.anchors.free();
 	local = {};
 
-	OPENXR_CLEAR_FN(XR_EXT_ANCHOR_FUNCTIONS);
-	OPENXR_CLEAR_FN(XR_EXT_PERSISTENCE_FUNCTIONS);
+	OPENXR_CLEAR_FN_REFLECT(XR_LIST_FUNCTIONS_XR_MSFT_spatial_anchor);
+	OPENXR_CLEAR_FN_REFLECT(XR_LIST_FUNCTIONS_XR_MSFT_spatial_anchor_persistence);
 }
 
 ///////////////////////////////////////////

--- a/StereoKitC/xr_backends/extensions/msft_scene_understanding.cpp
+++ b/StereoKitC/xr_backends/extensions/msft_scene_understanding.cpp
@@ -15,18 +15,7 @@
 #include "../../systems/vert_format.h"
 #include <float.h>
 
-#define XR_EXT_FUNCTIONS( X )              \
-	X(xrCreateSceneMSFT)                   \
-	X(xrCreateSceneObserverMSFT)           \
-	X(xrComputeNewSceneMSFT)               \
-	X(xrEnumerateSceneComputeFeaturesMSFT) \
-	X(xrGetSceneMeshBuffersMSFT)           \
-	X(xrGetSceneComputeStateMSFT)          \
-	X(xrGetSceneComponentsMSFT)            \
-	X(xrLocateSceneComponentsMSFT)         \
-	X(xrDestroySceneMSFT)                  \
-	X(xrDestroySceneObserverMSFT)
-OPENXR_DEFINE_FN_STATIC(XR_EXT_FUNCTIONS);
+OPENXR_DEFINE_FN_REFLECT_STATIC(XR_LIST_FUNCTIONS_XR_MSFT_scene_understanding);
 
 ///////////////////////////////////////////
 
@@ -106,7 +95,7 @@ xr_system_ xr_ext_msft_su_initialize(void*) {
 		return xr_system_fail;
 
 	// Load all extension functions
-	OPENXR_LOAD_FN_RETURN(XR_EXT_FUNCTIONS, xr_system_fail);
+	OPENXR_LOAD_FN_REFLECT_RETURN(XR_LIST_FUNCTIONS_XR_MSFT_scene_understanding, xr_system_fail);
 
 	// Check scene understanding features, these may be dependant on Session
 	// creation in the context of Holographic Remoting.
@@ -145,7 +134,7 @@ void xr_ext_msft_su_shutdown(void*) {
 	local.scene_visuals  .free();
 	local = {};
 
-	OPENXR_CLEAR_FN(XR_EXT_FUNCTIONS);
+	OPENXR_CLEAR_FN_REFLECT(XR_LIST_FUNCTIONS_XR_MSFT_scene_understanding);
 }
 
 ///////////////////////////////////////////

--- a/StereoKitC/xr_backends/extensions/oculus_audio.cpp
+++ b/StereoKitC/xr_backends/extensions/oculus_audio.cpp
@@ -41,11 +41,8 @@ xr_system_ xr_ext_oculus_audio_init(void*) {
 
 	// Load all extension functions, we can do this locally since it's such a
 	// simple extension!
-	#define XR_EXT_FUNCTIONS( X )           \
-		X(xrGetAudioOutputDeviceGuidOculus) \
-		X(xrGetAudioInputDeviceGuidOculus )
-	OPENXR_DEFINE_FN     (XR_EXT_FUNCTIONS);
-	OPENXR_LOAD_FN_RETURN(XR_EXT_FUNCTIONS, xr_system_fail);
+	OPENXR_DEFINE_FN_REFLECT     (XR_LIST_FUNCTIONS_XR_OCULUS_audio_device_guid);
+	OPENXR_LOAD_FN_REFLECT_RETURN(XR_LIST_FUNCTIONS_XR_OCULUS_audio_device_guid, xr_system_fail);
 
 	// All we really need to do here is just find out what audio devices the XR
 	// runtime recommends, and register that with our audio system!

--- a/StereoKitC/xr_backends/extensions/time.cpp
+++ b/StereoKitC/xr_backends/extensions/time.cpp
@@ -18,16 +18,12 @@
 #ifdef XR_USE_TIMESPEC
 	#include <time.h>
 	#define XR_TIME_EXTENSION XR_KHR_CONVERT_TIMESPEC_TIME_EXTENSION_NAME
-	#define XR_EXT_FUNCTIONS( X )         \
-		X(xrConvertTimespecTimeToTimeKHR) \
-		X(xrConvertTimeToTimespecTimeKHR)
+	#define XR_TIME_FUNCTIONS XR_LIST_FUNCTIONS_XR_KHR_convert_timespec_time
 #else
 	#define XR_TIME_EXTENSION XR_KHR_WIN32_CONVERT_PERFORMANCE_COUNTER_TIME_EXTENSION_NAME
-	#define XR_EXT_FUNCTIONS( X )                    \
-		X(xrConvertWin32PerformanceCounterToTimeKHR) \
-		X(xrConvertTimeToWin32PerformanceCounterKHR )
+	#define XR_TIME_FUNCTIONS XR_LIST_FUNCTIONS_XR_KHR_win32_convert_performance_counter_time
 #endif
-OPENXR_DEFINE_FN_STATIC(XR_EXT_FUNCTIONS);
+OPENXR_DEFINE_FN_REFLECT_STATIC(XR_TIME_FUNCTIONS);
 
 ///////////////////////////////////////////
 
@@ -58,7 +54,7 @@ xr_system_ xr_ext_time_init(void*) {
 		return xr_system_fail_critical;
 
 	// Load all extension functions
-	OPENXR_LOAD_FN_RETURN(XR_EXT_FUNCTIONS, xr_system_fail_critical);
+	OPENXR_LOAD_FN_REFLECT_RETURN(XR_TIME_FUNCTIONS, xr_system_fail_critical);
 
 	// A number of items use the xr_time, so lets get this ready as soon as we're
 	// able.
@@ -70,7 +66,7 @@ xr_system_ xr_ext_time_init(void*) {
 ///////////////////////////////////////////
 
 void xr_ext_time_shutdown(void*) {
-	OPENXR_CLEAR_FN(XR_EXT_FUNCTIONS);
+	OPENXR_CLEAR_FN_REFLECT(XR_TIME_FUNCTIONS);
 }
 
 ///////////////////////////////////////////

--- a/StereoKitC/xr_backends/extensions/vulkan_enable.cpp
+++ b/StereoKitC/xr_backends/extensions/vulkan_enable.cpp
@@ -21,19 +21,8 @@
 // Function pointers
 ///////////////////////////////////////////
 
-#define XR_VULKAN_ENABLE_FN(X)              \
-	X(xrGetVulkanInstanceExtensionsKHR)     \
-	X(xrGetVulkanDeviceExtensionsKHR)       \
-	X(xrGetVulkanGraphicsDeviceKHR)         \
-	X(xrGetVulkanGraphicsRequirementsKHR)
-OPENXR_DEFINE_FN_STATIC(XR_VULKAN_ENABLE_FN);
-
-#define XR_VULKAN_ENABLE2_FN(X)             \
-	X(xrCreateVulkanInstanceKHR)            \
-	X(xrCreateVulkanDeviceKHR)              \
-	X(xrGetVulkanGraphicsDevice2KHR)        \
-	X(xrGetVulkanGraphicsRequirements2KHR)
-OPENXR_DEFINE_FN_STATIC(XR_VULKAN_ENABLE2_FN);
+OPENXR_DEFINE_FN_REFLECT_STATIC(XR_LIST_FUNCTIONS_XR_KHR_vulkan_enable);
+OPENXR_DEFINE_FN_REFLECT_STATIC(XR_LIST_FUNCTIONS_XR_KHR_vulkan_enable2);
 
 ///////////////////////////////////////////
 // State
@@ -163,7 +152,7 @@ static void log_vulkan_requirements(const XrGraphicsRequirementsVulkanKHR* requi
 ///////////////////////////////////////////
 
 static bool xr_vulkan_enable_init() {
-	OPENXR_LOAD_FN_RETURN(XR_VULKAN_ENABLE_FN, false);
+	OPENXR_LOAD_FN_REFLECT_RETURN(XR_LIST_FUNCTIONS_XR_KHR_vulkan_enable, false);
 
 	XrGraphicsRequirementsVulkanKHR vulkan_requirements = { XR_TYPE_GRAPHICS_REQUIREMENTS_VULKAN_KHR };
 	xr_check(xrGetVulkanGraphicsRequirementsKHR(xr_instance, xr_system_id, &vulkan_requirements),
@@ -226,7 +215,7 @@ static skr_device_request_t xr_vulkan_enable_device_init(void* vk_instance, void
 ///////////////////////////////////////////
 
 static bool xr_vulkan_enable2_init() {
-	OPENXR_LOAD_FN_RETURN(XR_VULKAN_ENABLE2_FN, false);
+	OPENXR_LOAD_FN_REFLECT_RETURN(XR_LIST_FUNCTIONS_XR_KHR_vulkan_enable2, false);
 
 	XrGraphicsRequirementsVulkanKHR vulkan_requirements = { XR_TYPE_GRAPHICS_REQUIREMENTS_VULKAN_KHR };
 	xr_check(xrGetVulkanGraphicsRequirements2KHR(xr_instance, xr_system_id, &vulkan_requirements),
@@ -338,8 +327,8 @@ static void xr_ext_vulkan_enable_shutdown(void*) {
 	local.device_extensions.free();
 	local = {};
 
-	OPENXR_CLEAR_FN(XR_VULKAN_ENABLE_FN);
-	OPENXR_CLEAR_FN(XR_VULKAN_ENABLE2_FN);
+	OPENXR_CLEAR_FN_REFLECT(XR_LIST_FUNCTIONS_XR_KHR_vulkan_enable);
+	OPENXR_CLEAR_FN_REFLECT(XR_LIST_FUNCTIONS_XR_KHR_vulkan_enable2);
 }
 
 ///////////////////////////////////////////

--- a/StereoKitC/xr_backends/openxr.h
+++ b/StereoKitC/xr_backends/openxr.h
@@ -12,6 +12,7 @@
 #include "../stereokit.h"
 #include "openxr_input.h"
 #include <openxr/openxr.h>
+#include <openxr/openxr_reflection.h>
 #include <stdint.h>
 
 typedef struct XR_MAY_ALIAS XrBaseHeader {
@@ -34,6 +35,16 @@ inline void xr_insert_next(XrBaseHeader *xr_base, XrBaseHeader *xr_next) { xr_ne
 #define OPENXR_DEFINE_FN_STATIC(list) list(_OPENXR_DEFINE_FN_STATIC)
 #define _OPENXR_LOAD_FN_RESULT(name) if (xrGetInstanceProcAddr(xr_instance, #name, (PFN_xrVoidFunction*)((PFN_##name*)(&name)))<0) { result = result && false; }
 #define OPENXR_LOAD_FN_RETURN(list, failure_result) do { bool result = true; list(_OPENXR_LOAD_FN_RESULT); if (!result) return failure_result; } while(0);
+
+// Adapters for openxr_reflection.h XR_LIST_FUNCTIONS_* macros, which pass (FunctionNameWithoutXr, ExtensionNameWithoutXR_)
+#define _OPENXR_DEFINE_FN_REFLECT(name, ext)        _OPENXR_DEFINE_FN(xr##name)
+#define OPENXR_DEFINE_FN_REFLECT(list)              list(_OPENXR_DEFINE_FN_REFLECT)
+#define _OPENXR_CLEAR_FN_REFLECT(name, ext)         _OPENXR_CLEAR_FN(xr##name)
+#define OPENXR_CLEAR_FN_REFLECT(list)               list(_OPENXR_CLEAR_FN_REFLECT)
+#define _OPENXR_DEFINE_FN_REFLECT_STATIC(name, ext) _OPENXR_DEFINE_FN_STATIC(xr##name)
+#define OPENXR_DEFINE_FN_REFLECT_STATIC(list)       list(_OPENXR_DEFINE_FN_REFLECT_STATIC)
+#define _OPENXR_LOAD_FN_REFLECT_RESULT(name, ext)   _OPENXR_LOAD_FN_RESULT(xr##name)
+#define OPENXR_LOAD_FN_REFLECT_RETURN(list, failure_result) do { bool result = true; list(_OPENXR_LOAD_FN_REFLECT_RESULT); if (!result) return failure_result; } while(0);
 
 namespace sk {
 


### PR DESCRIPTION
Replace manually maintained function lists across OpenXR extensions with standard reflection macros provided by Khronos \<openxr/openxr_reflection.h>\:

- Added reflection macros in openxr.h that prepend xr and delegate to existing macros.
- Migrated 15 extension files to Khronos XR_LIST_FUNCTIONS_* macros:
  - android_thread
  - debug_utils
  - ext_interaction_render_model
  - ext_render_model
  - fb_colorspace
  - fb_haptic
  - fb_render_model
  - hand_mesh
  - hand_tracking
  - meta_environment_depth
  - msft_anchors
  - msft_scene_understanding
  - oculus_audio
  - time
  - vulkan_enable